### PR TITLE
Add Transifex project url for contributors to find easier

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ If you would like to improve the docs, simply:
 > [Transifex][tfx], a third-party cloud platform. Do **NOT** manually edit the
 > `.po` and `.mo` localization files, as any such changes will be overwritten
 > in the compilation process.
+> 
+> If you want to help on translation, you can find the [find the Transifex project here][tfxtranslate]. 
+> You can also request to translate new languages. 💪
 
 Thanks! ❤ ❤ ❤  
 The Zammad Team
@@ -96,3 +99,4 @@ $ make -e SPHINXOPTS="-D language='en'" html
 [badge]: https://readthedocs.org/projects/zammad-user-documentation/badge/?version=latest
 [docs]: https://zammad-user-documentation.readthedocs.io/en/latest/
 [tfx]: https://www.transifex.com/
+[tfxtranslate]: https://www.transifex.com/zammad/zammad-user-documentation/

--- a/README.md
+++ b/README.md
@@ -12,13 +12,9 @@ If you would like to improve the docs, simply:
 2. edit the appropriate `.rst` files (see [Markup Format](#markup-format) below), and
 3. submit a pull request.
 
-> **🌍 Note on localization:** Translations are prepared and stored on
-> [Transifex][tfx], a third-party cloud platform. Do **NOT** manually edit the
-> `.po` and `.mo` localization files, as any such changes will be overwritten
-> in the compilation process.
-> 
-> If you want to help on translation, you can find the [find the Transifex project here][tfxtranslate]. 
-> You can also request to translate new languages. 💪
+> 🌍 **Wanna help translate?** Submit your contributions
+> (or request additional languages) [here][tfxtranslate].
+> Do **NOT** submit a PR with changes to the contents of the `locale/` directory.
 
 Thanks! ❤ ❤ ❤  
 The Zammad Team
@@ -98,5 +94,4 @@ $ make -e SPHINXOPTS="-D language='en'" html
 
 [badge]: https://readthedocs.org/projects/zammad-user-documentation/badge/?version=latest
 [docs]: https://zammad-user-documentation.readthedocs.io/en/latest/
-[tfx]: https://www.transifex.com/
 [tfxtranslate]: https://www.transifex.com/zammad/zammad-user-documentation/


### PR DESCRIPTION
In order to help contributors to find the user documentations translation project easier, this commit adds a new paragraph that points to that project.