### PR TITLE
Add note about limit of macros in overview page

### DIFF
--- a/advanced/macros.rst
+++ b/advanced/macros.rst
@@ -69,3 +69,7 @@ To apply a macro to many tickets at the same time:
    
    When running it from the overviews page, Zammad will always stay on the
    overviews page.
+
+   ⚠️ **Macro limit:** In the overview page, the macros that shows up have limit
+   depending on the screen size, however, as much as 20 macros could show no
+   matter the screen size.


### PR DESCRIPTION
This PR adds a note about the limit of the number of macros shown on the overview page for batch action.