### PR TITLE
Translations update from Zammad-Translations

### DIFF
--- a/locale/cs/LC_MESSAGES/user-docs.po
+++ b/locale/cs/LC_MESSAGES/user-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-09 13:15+0100\n"
+"POT-Creation-Date: 2023-12-04 12:38+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -1271,7 +1271,7 @@ msgid ""
 msgstr ""
 
 #: ../snippets/ticket-state-type-circles.rst:4
-#: ../snippets/ticket-state-type-circles.rst:6 ../extras/knowledge-base.rst:221
+#: ../snippets/ticket-state-type-circles.rst:6 ../extras/knowledge-base.rst:227
 msgid "|grn|"
 msgstr ""
 
@@ -2035,9 +2035,9 @@ msgstr ""
 
 #: ../basics/service-ticket/create.rst:58
 msgid ""
-"📞 For phone calls, record the details of your conversation. These notes will "
-"not be sent to the customer (though he may be able to see them if he has a "
-"Zammad account)."
+"📞 For phone calls, record the details of your conversation. These notes "
+"will not be sent to the customer (though he may be able to see them if he "
+"has a Zammad account)."
 msgstr ""
 
 #: ../basics/service-ticket/create.rst:62
@@ -2046,8 +2046,8 @@ msgstr ""
 
 #: ../snippets/ui-protip-message-editor-features.rst:3
 msgid ""
-"The message editor supports 📋 copying-and-pasting (or dragging-and-dropping) "
-"of **🔤 rich text**, **🌄 images** and **📎 file attachments**."
+"The message editor supports 📋 copying-and-pasting (or dragging-and-"
+"dropping) of **🔤 rich text**, **🌄 images** and **📎 file attachments**."
 msgstr ""
 
 #: ../snippets/ui-protip-message-editor-features.rst:6
@@ -2242,8 +2242,9 @@ msgstr ""
 msgid ""
 "What about the **deletion of articles**? In Zammad, you can only delete "
 "articles that you have created yourself and which are not older than 10 "
-"minutes. To see the \"delete\" button in articles of the type \"communication"
-"\" (emails, calls), their visibility has to be switched to internal first."
+"minutes. To see the \"delete\" button in articles of the type "
+"\"communication\" (emails, calls), their visibility has to be switched to "
+"internal first."
 msgstr ""
 
 #: ../basics/service-ticket/follow-up.rst:107
@@ -2464,7 +2465,8 @@ msgid ""
 "problematic *per se,* but it does lead to a lot of unnecessary clutter in "
 "the :doc:`overviews menu </basics/find-ticket>`. (It can be much worse when, "
 "for example, a customer service rep sees tickets meant for your HR "
-"department, and finds out how much their colleagues in sales are making! 💸💸💸)"
+"department, and finds out how much their colleagues in sales are making! 💸💸"
+"💸)"
 msgstr ""
 
 #: ../basics/service-ticket/settings/group.rst:25
@@ -4173,8 +4175,8 @@ msgstr ""
 
 #: ../extras/chat.rst:51
 msgid ""
-"📝 Chats can be **renamed** or **tagged**, and record technical details about "
-"the customer’s connection."
+"📝 Chats can be **renamed** or **tagged**, and record technical details "
+"about the customer’s connection."
 msgstr ""
 
 #: ../extras/chat.rst:0
@@ -4856,42 +4858,48 @@ msgid ""
 "permissions"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:0
-msgid "Permissions of a parent category are inherited!"
+#: ../extras/knowledge-base.rst:162
+msgid ""
+"In general, permissions of a parent category are inherited! If you want to "
+"grant edit permissions for a sub-category for a specific role for example, "
+"set the upper level to \"reader\" and the desired sub-category to "
+"\"editor\". The other way round is not possible (permissions can only be "
+"widened, not restricted). If you can't select permissions in the table, this "
+"could be the reason."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:0
-msgid "Public answers are always available!"
+#: ../extras/knowledge-base.rst:169
+msgid "Be aware that public answers are always available!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:165
+#: ../extras/knowledge-base.rst:171
 msgid "**⚙️ Roles require knowledge base reader permission**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:167
+#: ../extras/knowledge-base.rst:173
 msgid ""
 "Your administrator has to provide the relevant groups with reader "
 "permissions for the knowledge base."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:170
+#: ../extras/knowledge-base.rst:176
 msgid "**🥵 Beware of visibility levels**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:172
+#: ../extras/knowledge-base.rst:178
 msgid ""
 "Knowledge base reader permission means that affected users can see "
 "**internal answers**. This is a potential issue if you're not dividing "
 "carefully!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:176
+#: ../extras/knowledge-base.rst:182
 msgid ""
 "If you're unsure, please ask your administrator to configure the :admin-docs:"
 "`role permissions </manage/roles/agent-permissions.html>` accordingly."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:181
+#: ../extras/knowledge-base.rst:187
 msgid "Editing Answers"
 msgstr ""
 
@@ -4899,7 +4907,7 @@ msgstr ""
 msgid "Edit answer"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:187
+#: ../extras/knowledge-base.rst:193
 msgid ""
 "The knowledge base editor comes equipped with the same **rich text editing "
 "capabilities** available in the Zammad ticket composer. That means you can "
@@ -4908,19 +4916,19 @@ msgid ""
 "attachments and links!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:193
+#: ../extras/knowledge-base.rst:199
 msgid "🤷 **Why are there four kinds of links?**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:196
+#: ../extras/knowledge-base.rst:202
 msgid "🔗 **Weblink**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:196
+#: ../extras/knowledge-base.rst:202
 msgid "URLs pointing to other websites."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:200
+#: ../extras/knowledge-base.rst:206
 msgid "💡 **Link Answer**"
 msgstr ""
 
@@ -4932,7 +4940,7 @@ msgstr ""
 msgid "(Will not break if destination URL changes.)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:204
+#: ../extras/knowledge-base.rst:210
 msgid "📋 **Linked Tickets**"
 msgstr ""
 
@@ -4944,7 +4952,7 @@ msgstr ""
 msgid "(Visible only in Preview and Edit Modes.)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:211
+#: ../extras/knowledge-base.rst:217
 msgid "🏷️ **Tags**"
 msgstr ""
 
@@ -4962,38 +4970,38 @@ msgstr ""
 msgid "Screencast showing tags on answers"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:216
+#: ../extras/knowledge-base.rst:222
 msgid ""
 "🙈 Set the **visibility** of an answer to control who can see an article, or "
 "schedule it to be published at a later date. Articles are **color-coded** "
 "according to their visibility:"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:221
+#: ../extras/knowledge-base.rst:227
 msgid "**Public** (visible to everyone)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:223
+#: ../extras/knowledge-base.rst:229
 msgid "|blu|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:223
+#: ../extras/knowledge-base.rst:229
 msgid "**Internal** (visible to agents & editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:225
+#: ../extras/knowledge-base.rst:231
 msgid "|gry|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:225
+#: ../extras/knowledge-base.rst:231
 msgid "**Draft/Scheduled/Archived** (visible to editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:241
+#: ../extras/knowledge-base.rst:247
 msgid "Using answers in ticket articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:243
+#: ../extras/knowledge-base.rst:249
 msgid ""
 "As soon as the knowledge base contains one or more answers, you can use "
 "these just like text modules. Instead of ``::`` just use ``??`` to open the "
@@ -5001,22 +5009,22 @@ msgid ""
 "all languages available."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:248
+#: ../extras/knowledge-base.rst:254
 msgid ""
 "If you've found what you've been looking for, simply hit your ENTER-Key to "
 "load the answer into the ticket article. This way you don't have to throw "
 "URLs at your customer and provide the answer right away."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:252
+#: ../extras/knowledge-base.rst:258
 msgid "Loading answers into articles *does not* replace article content."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:258
+#: ../extras/knowledge-base.rst:264
 msgid "Screencast showing how to insert KB answers into articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:258
+#: ../extras/knowledge-base.rst:264
 msgid "Use ``??`` to find and load knowledge base answers into ticket articles"
 msgstr ""
 
@@ -6138,8 +6146,8 @@ msgstr ""
 
 #: ../extras/shared-drafts.rst:50
 msgid ""
-"If you're in a new ticket dialogue *after selecting the ticket group*, the 📝 "
-"button will indicate the shared drafts function to be available."
+"If you're in a new ticket dialogue *after selecting the ticket group*, the "
+"📝 button will indicate the shared drafts function to be available."
 msgstr ""
 
 #: ../extras/shared-drafts.rst:55

--- a/locale/da/LC_MESSAGES/user-docs.po
+++ b/locale/da/LC_MESSAGES/user-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-09 13:15+0100\n"
+"POT-Creation-Date: 2023-12-04 12:38+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -1271,7 +1271,7 @@ msgid ""
 msgstr ""
 
 #: ../snippets/ticket-state-type-circles.rst:4
-#: ../snippets/ticket-state-type-circles.rst:6 ../extras/knowledge-base.rst:221
+#: ../snippets/ticket-state-type-circles.rst:6 ../extras/knowledge-base.rst:227
 msgid "|grn|"
 msgstr ""
 
@@ -2035,9 +2035,9 @@ msgstr ""
 
 #: ../basics/service-ticket/create.rst:58
 msgid ""
-"📞 For phone calls, record the details of your conversation. These notes will "
-"not be sent to the customer (though he may be able to see them if he has a "
-"Zammad account)."
+"📞 For phone calls, record the details of your conversation. These notes "
+"will not be sent to the customer (though he may be able to see them if he "
+"has a Zammad account)."
 msgstr ""
 
 #: ../basics/service-ticket/create.rst:62
@@ -2046,8 +2046,8 @@ msgstr ""
 
 #: ../snippets/ui-protip-message-editor-features.rst:3
 msgid ""
-"The message editor supports 📋 copying-and-pasting (or dragging-and-dropping) "
-"of **🔤 rich text**, **🌄 images** and **📎 file attachments**."
+"The message editor supports 📋 copying-and-pasting (or dragging-and-"
+"dropping) of **🔤 rich text**, **🌄 images** and **📎 file attachments**."
 msgstr ""
 
 #: ../snippets/ui-protip-message-editor-features.rst:6
@@ -2242,8 +2242,9 @@ msgstr ""
 msgid ""
 "What about the **deletion of articles**? In Zammad, you can only delete "
 "articles that you have created yourself and which are not older than 10 "
-"minutes. To see the \"delete\" button in articles of the type \"communication"
-"\" (emails, calls), their visibility has to be switched to internal first."
+"minutes. To see the \"delete\" button in articles of the type "
+"\"communication\" (emails, calls), their visibility has to be switched to "
+"internal first."
 msgstr ""
 
 #: ../basics/service-ticket/follow-up.rst:107
@@ -2464,7 +2465,8 @@ msgid ""
 "problematic *per se,* but it does lead to a lot of unnecessary clutter in "
 "the :doc:`overviews menu </basics/find-ticket>`. (It can be much worse when, "
 "for example, a customer service rep sees tickets meant for your HR "
-"department, and finds out how much their colleagues in sales are making! 💸💸💸)"
+"department, and finds out how much their colleagues in sales are making! 💸💸"
+"💸)"
 msgstr ""
 
 #: ../basics/service-ticket/settings/group.rst:25
@@ -4173,8 +4175,8 @@ msgstr ""
 
 #: ../extras/chat.rst:51
 msgid ""
-"📝 Chats can be **renamed** or **tagged**, and record technical details about "
-"the customer’s connection."
+"📝 Chats can be **renamed** or **tagged**, and record technical details "
+"about the customer’s connection."
 msgstr ""
 
 #: ../extras/chat.rst:0
@@ -4856,42 +4858,48 @@ msgid ""
 "permissions"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:0
-msgid "Permissions of a parent category are inherited!"
+#: ../extras/knowledge-base.rst:162
+msgid ""
+"In general, permissions of a parent category are inherited! If you want to "
+"grant edit permissions for a sub-category for a specific role for example, "
+"set the upper level to \"reader\" and the desired sub-category to "
+"\"editor\". The other way round is not possible (permissions can only be "
+"widened, not restricted). If you can't select permissions in the table, this "
+"could be the reason."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:0
-msgid "Public answers are always available!"
+#: ../extras/knowledge-base.rst:169
+msgid "Be aware that public answers are always available!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:165
+#: ../extras/knowledge-base.rst:171
 msgid "**⚙️ Roles require knowledge base reader permission**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:167
+#: ../extras/knowledge-base.rst:173
 msgid ""
 "Your administrator has to provide the relevant groups with reader "
 "permissions for the knowledge base."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:170
+#: ../extras/knowledge-base.rst:176
 msgid "**🥵 Beware of visibility levels**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:172
+#: ../extras/knowledge-base.rst:178
 msgid ""
 "Knowledge base reader permission means that affected users can see "
 "**internal answers**. This is a potential issue if you're not dividing "
 "carefully!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:176
+#: ../extras/knowledge-base.rst:182
 msgid ""
 "If you're unsure, please ask your administrator to configure the :admin-docs:"
 "`role permissions </manage/roles/agent-permissions.html>` accordingly."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:181
+#: ../extras/knowledge-base.rst:187
 msgid "Editing Answers"
 msgstr ""
 
@@ -4899,7 +4907,7 @@ msgstr ""
 msgid "Edit answer"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:187
+#: ../extras/knowledge-base.rst:193
 msgid ""
 "The knowledge base editor comes equipped with the same **rich text editing "
 "capabilities** available in the Zammad ticket composer. That means you can "
@@ -4908,19 +4916,19 @@ msgid ""
 "attachments and links!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:193
+#: ../extras/knowledge-base.rst:199
 msgid "🤷 **Why are there four kinds of links?**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:196
+#: ../extras/knowledge-base.rst:202
 msgid "🔗 **Weblink**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:196
+#: ../extras/knowledge-base.rst:202
 msgid "URLs pointing to other websites."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:200
+#: ../extras/knowledge-base.rst:206
 msgid "💡 **Link Answer**"
 msgstr ""
 
@@ -4932,7 +4940,7 @@ msgstr ""
 msgid "(Will not break if destination URL changes.)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:204
+#: ../extras/knowledge-base.rst:210
 msgid "📋 **Linked Tickets**"
 msgstr ""
 
@@ -4944,7 +4952,7 @@ msgstr ""
 msgid "(Visible only in Preview and Edit Modes.)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:211
+#: ../extras/knowledge-base.rst:217
 msgid "🏷️ **Tags**"
 msgstr ""
 
@@ -4962,38 +4970,38 @@ msgstr ""
 msgid "Screencast showing tags on answers"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:216
+#: ../extras/knowledge-base.rst:222
 msgid ""
 "🙈 Set the **visibility** of an answer to control who can see an article, or "
 "schedule it to be published at a later date. Articles are **color-coded** "
 "according to their visibility:"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:221
+#: ../extras/knowledge-base.rst:227
 msgid "**Public** (visible to everyone)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:223
+#: ../extras/knowledge-base.rst:229
 msgid "|blu|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:223
+#: ../extras/knowledge-base.rst:229
 msgid "**Internal** (visible to agents & editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:225
+#: ../extras/knowledge-base.rst:231
 msgid "|gry|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:225
+#: ../extras/knowledge-base.rst:231
 msgid "**Draft/Scheduled/Archived** (visible to editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:241
+#: ../extras/knowledge-base.rst:247
 msgid "Using answers in ticket articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:243
+#: ../extras/knowledge-base.rst:249
 msgid ""
 "As soon as the knowledge base contains one or more answers, you can use "
 "these just like text modules. Instead of ``::`` just use ``??`` to open the "
@@ -5001,22 +5009,22 @@ msgid ""
 "all languages available."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:248
+#: ../extras/knowledge-base.rst:254
 msgid ""
 "If you've found what you've been looking for, simply hit your ENTER-Key to "
 "load the answer into the ticket article. This way you don't have to throw "
 "URLs at your customer and provide the answer right away."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:252
+#: ../extras/knowledge-base.rst:258
 msgid "Loading answers into articles *does not* replace article content."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:258
+#: ../extras/knowledge-base.rst:264
 msgid "Screencast showing how to insert KB answers into articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:258
+#: ../extras/knowledge-base.rst:264
 msgid "Use ``??`` to find and load knowledge base answers into ticket articles"
 msgstr ""
 
@@ -6138,8 +6146,8 @@ msgstr ""
 
 #: ../extras/shared-drafts.rst:50
 msgid ""
-"If you're in a new ticket dialogue *after selecting the ticket group*, the 📝 "
-"button will indicate the shared drafts function to be available."
+"If you're in a new ticket dialogue *after selecting the ticket group*, the "
+"📝 button will indicate the shared drafts function to be available."
 msgstr ""
 
 #: ../extras/shared-drafts.rst:55

--- a/locale/de/LC_MESSAGES/user-docs.po
+++ b/locale/de/LC_MESSAGES/user-docs.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-09 13:15+0100\n"
-"PO-Revision-Date: 2023-11-23 13:00+0000\n"
+"POT-Creation-Date: 2023-12-04 12:38+0100\n"
+"PO-Revision-Date: 2023-12-08 08:00+0000\n"
 "Last-Translator: Ralf Schmid <rsc@zammad.com>\n"
 "Language-Team: German <https://translations.zammad.org/projects/"
 "documentations/user-documentation-pre-release/de/>\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 5.0.2\n"
+"X-Generator: Weblate 5.2.1\n"
 
 #: ../advanced/keyboard-shortcuts.rst:4
 msgid "Keyboard Shortcuts"
@@ -1452,7 +1452,7 @@ msgstr ""
 "**Farbcodes:**"
 
 #: ../snippets/ticket-state-type-circles.rst:4
-#: ../snippets/ticket-state-type-circles.rst:6 ../extras/knowledge-base.rst:221
+#: ../snippets/ticket-state-type-circles.rst:6 ../extras/knowledge-base.rst:227
 msgid "|grn|"
 msgstr "|grn|"
 
@@ -6034,19 +6034,32 @@ msgstr ""
 "Bildschirmaufzeichnung zeigt die Sichtbarkeitseinstellungen für Kategorien "
 "für differenzierte Kategorieberechtigungen"
 
-#: ../extras/knowledge-base.rst:0
-msgid "Permissions of a parent category are inherited!"
-msgstr "Zugriffsrechte für Eltern-Kategorien werden vererbt!"
+#: ../extras/knowledge-base.rst:162
+msgid ""
+"In general, permissions of a parent category are inherited! If you want to "
+"grant edit permissions for a sub-category for a specific role for example, "
+"set the upper level to \"reader\" and the desired sub-category to "
+"\"editor\". The other way round is not possible (permissions can only be "
+"widened, not restricted). If you can't select permissions in the table, this "
+"could be the reason."
+msgstr ""
+"Im Allgemeinen werden die Rechte einer übergeordneten Kategorie vererbt! "
+"Wenn Sie z.B. einer bestimmten Rolle Bearbeitungsrechte für eine "
+"Unterkategorie erteilen wollen, setzen Sie die übergeordnete Ebene auf "
+"\"Reader\" und die gewünschte Unterkategorie auf \"Editor\". Der umgekehrte "
+"Weg ist nicht möglich (Berechtigungen können nur erweitert, nicht "
+"eingeschränkt werden). Wenn Sie in der Tabelle keine Berechtigungen "
+"auswählen können, könnte dies der Grund dafür sein."
 
-#: ../extras/knowledge-base.rst:0
-msgid "Public answers are always available!"
-msgstr "Öffentliche Antworten sind immer verfügbar!"
+#: ../extras/knowledge-base.rst:169
+msgid "Be aware that public answers are always available!"
+msgstr "Beachten Sie, dass öffentliche Antworten immer verfügbar sind!"
 
-#: ../extras/knowledge-base.rst:165
+#: ../extras/knowledge-base.rst:171
 msgid "**⚙️ Roles require knowledge base reader permission**"
 msgstr "**⚙️ Rollen erfordern Wissensdatenbank-Reader-Rechte**"
 
-#: ../extras/knowledge-base.rst:167
+#: ../extras/knowledge-base.rst:173
 msgid ""
 "Your administrator has to provide the relevant groups with reader "
 "permissions for the knowledge base."
@@ -6054,11 +6067,11 @@ msgstr ""
 "Ihr Administrator muss die relevanten Gruppen mit Reader-Rechten für die "
 "Wissensdatenbank versehen."
 
-#: ../extras/knowledge-base.rst:170
+#: ../extras/knowledge-base.rst:176
 msgid "**🥵 Beware of visibility levels**"
 msgstr "**🥵 Beachten Sie Sichtbarkeitsebenen**"
 
-#: ../extras/knowledge-base.rst:172
+#: ../extras/knowledge-base.rst:178
 msgid ""
 "Knowledge base reader permission means that affected users can see "
 "**internal answers**. This is a potential issue if you're not dividing "
@@ -6068,7 +6081,7 @@ msgstr ""
 "Antworten**. Das ist ein mögliches Risiko falls Sie nicht umsichtig "
 "aufteilen!"
 
-#: ../extras/knowledge-base.rst:176
+#: ../extras/knowledge-base.rst:182
 msgid ""
 "If you're unsure, please ask your administrator to configure the :admin-docs:"
 "`role permissions </manage/roles/agent-permissions.html>` accordingly."
@@ -6077,7 +6090,7 @@ msgstr ""
 "`Rollenberechtigungen </manage/roles/agent-permissions.html>` entsprechend "
 "zu konfigurieren."
 
-#: ../extras/knowledge-base.rst:181
+#: ../extras/knowledge-base.rst:187
 msgid "Editing Answers"
 msgstr "Antworten bearbeiten"
 
@@ -6085,7 +6098,7 @@ msgstr "Antworten bearbeiten"
 msgid "Edit answer"
 msgstr "Antwort editieren"
 
-#: ../extras/knowledge-base.rst:187
+#: ../extras/knowledge-base.rst:193
 msgid ""
 "The knowledge base editor comes equipped with the same **rich text editing "
 "capabilities** available in the Zammad ticket composer. That means you can "
@@ -6100,19 +6113,19 @@ msgstr ""
 "Text-Formatierungen, Aufzählungszeichen und mehr einzubinden. Es können "
 "sogar Dateianhänge und Links hinzugefügt werden!"
 
-#: ../extras/knowledge-base.rst:193
+#: ../extras/knowledge-base.rst:199
 msgid "🤷 **Why are there four kinds of links?**"
 msgstr "🤷 **Warum gibt es vier Arten von Links?**"
 
-#: ../extras/knowledge-base.rst:196
+#: ../extras/knowledge-base.rst:202
 msgid "🔗 **Weblink**"
 msgstr "🔗 **Weblink**"
 
-#: ../extras/knowledge-base.rst:196
+#: ../extras/knowledge-base.rst:202
 msgid "URLs pointing to other websites."
 msgstr "URLs, die auf andere Websites verweisen."
 
-#: ../extras/knowledge-base.rst:200
+#: ../extras/knowledge-base.rst:206
 msgid "💡 **Link Answer**"
 msgstr "💡 **Link zu einer Antwort**"
 
@@ -6124,7 +6137,7 @@ msgstr "Interne Verweise auf andere Antworten der Wissensdatenbank."
 msgid "(Will not break if destination URL changes.)"
 msgstr "(Wird nicht ungültig, wenn sich die Ziel-URL ändert.)"
 
-#: ../extras/knowledge-base.rst:204
+#: ../extras/knowledge-base.rst:210
 msgid "📋 **Linked Tickets**"
 msgstr "📋 **Verlinkte Tickets**"
 
@@ -6136,7 +6149,7 @@ msgstr "Interne Verweise auf Zammad-Tickets."
 msgid "(Visible only in Preview and Edit Modes.)"
 msgstr "(Nur im Vorschau- und Bearbeitungsmodus sichtbar.)"
 
-#: ../extras/knowledge-base.rst:211
+#: ../extras/knowledge-base.rst:217
 msgid "🏷️ **Tags**"
 msgstr "🏷️ **Schlagworte**"
 
@@ -6158,7 +6171,7 @@ msgstr ""
 msgid "Screencast showing tags on answers"
 msgstr "Screencast zeigt Tags an Antworten"
 
-#: ../extras/knowledge-base.rst:216
+#: ../extras/knowledge-base.rst:222
 msgid ""
 "🙈 Set the **visibility** of an answer to control who can see an article, or "
 "schedule it to be published at a later date. Articles are **color-coded** "
@@ -6169,31 +6182,31 @@ msgstr ""
 "späteren Zeitpunkt. Artikel werden entsprechend ihrer Sichtbarkeit "
 "**farblich gekennzeichnet**:"
 
-#: ../extras/knowledge-base.rst:221
+#: ../extras/knowledge-base.rst:227
 msgid "**Public** (visible to everyone)"
 msgstr "**Öffentlich** (für jeden sichtbar)"
 
-#: ../extras/knowledge-base.rst:223
+#: ../extras/knowledge-base.rst:229
 msgid "|blu|"
 msgstr "|blu|"
 
-#: ../extras/knowledge-base.rst:223
+#: ../extras/knowledge-base.rst:229
 msgid "**Internal** (visible to agents & editors only)"
 msgstr "**Intern** (nur sichtbar für Agenten und Bearbeiter)"
 
-#: ../extras/knowledge-base.rst:225
+#: ../extras/knowledge-base.rst:231
 msgid "|gry|"
 msgstr "|gry|"
 
-#: ../extras/knowledge-base.rst:225
+#: ../extras/knowledge-base.rst:231
 msgid "**Draft/Scheduled/Archived** (visible to editors only)"
 msgstr "**Entwurf / geplant / archiviert** (sichtbar nur für Bearbeiter)"
 
-#: ../extras/knowledge-base.rst:241
+#: ../extras/knowledge-base.rst:247
 msgid "Using answers in ticket articles"
 msgstr "Antworten in Ticket-Artikeln benutzen"
 
-#: ../extras/knowledge-base.rst:243
+#: ../extras/knowledge-base.rst:249
 msgid ""
 "As soon as the knowledge base contains one or more answers, you can use "
 "these just like text modules. Instead of ``::`` just use ``??`` to open the "
@@ -6205,7 +6218,7 @@ msgstr ""
 "``??`` um den Suchdialog zu öffnen. Die Suche sucht Volltext in dem Body und "
 "Titel aller verfügbaren Sprachen der Antwort."
 
-#: ../extras/knowledge-base.rst:248
+#: ../extras/knowledge-base.rst:254
 msgid ""
 "If you've found what you've been looking for, simply hit your ENTER-Key to "
 "load the answer into the ticket article. This way you don't have to throw "
@@ -6215,17 +6228,17 @@ msgstr ""
 "Taste, um die Antwort direkt in den Ticket-Artikel zu laden. So müssen Sie "
 "Ihrem Kunden keinen Link zuwerfen und liefern die Antwort direkt."
 
-#: ../extras/knowledge-base.rst:252
+#: ../extras/knowledge-base.rst:258
 msgid "Loading answers into articles *does not* replace article content."
 msgstr "Das Laden von Antworten in Artikel *ersetzt nicht* den Artikel-Inhalt."
 
-#: ../extras/knowledge-base.rst:258
+#: ../extras/knowledge-base.rst:264
 msgid "Screencast showing how to insert KB answers into articles"
 msgstr ""
 "Bildschirmaufzeichnung zeigt wie man Wissensdatenbankantworten in Artikeln "
 "einfügt"
 
-#: ../extras/knowledge-base.rst:258
+#: ../extras/knowledge-base.rst:264
 msgid "Use ``??`` to find and load knowledge base answers into ticket articles"
 msgstr ""
 "Benutzen Sie ``??`` um Knowledge Base Antworten zu finden und in Artikel zu "
@@ -8441,6 +8454,9 @@ msgstr ""
 "Sie lesen gerade die Benutzerdokumentation von Zammad. Es sind außerdem :"
 "docs:`System- </index.html>` und :admin-docs:`Admin-Dokumentationen </index."
 "html>` verfügbar."
+
+#~ msgid "Permissions of a parent category are inherited!"
+#~ msgstr "Zugriffsrechte für Eltern-Kategorien werden vererbt!"
 
 #~ msgid "`Google Authenticator`_"
 #~ msgstr "`Google Authenticator`_"

--- a/locale/es/LC_MESSAGES/user-docs.po
+++ b/locale/es/LC_MESSAGES/user-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-09 13:15+0100\n"
+"POT-Creation-Date: 2023-12-04 12:38+0100\n"
 "PO-Revision-Date: 2023-09-20 14:18+0000\n"
 "Last-Translator: Arturo <r2r0@posteo.de>\n"
 "Language-Team: Spanish <https://translations.zammad.org/projects/"
@@ -921,8 +921,8 @@ msgid ""
 "\"head\". Zammad will also allow you to use regular expressions, where ever "
 "the attributes allows it."
 msgstr ""
-"El primer ejemplo muestra todos los tickets que contienen la palabra \"heat"
-"\" - también puedes usar el operador difuso\"~\" para buscar palabras "
+"El primer ejemplo muestra todos los tickets que contienen la palabra "
+"\"heat\" - también puedes usar el operador difuso\"~\" para buscar palabras "
 "similares como por ejemplo \"head\". Zammad también te permitirá usar "
 "expresiones regulares, siempre que los atributos lo permitan."
 
@@ -1390,7 +1390,7 @@ msgid ""
 msgstr ""
 
 #: ../snippets/ticket-state-type-circles.rst:4
-#: ../snippets/ticket-state-type-circles.rst:6 ../extras/knowledge-base.rst:221
+#: ../snippets/ticket-state-type-circles.rst:6 ../extras/knowledge-base.rst:227
 msgid "|grn|"
 msgstr ""
 
@@ -2158,9 +2158,9 @@ msgstr ""
 
 #: ../basics/service-ticket/create.rst:58
 msgid ""
-"📞 For phone calls, record the details of your conversation. These notes will "
-"not be sent to the customer (though he may be able to see them if he has a "
-"Zammad account)."
+"📞 For phone calls, record the details of your conversation. These notes "
+"will not be sent to the customer (though he may be able to see them if he "
+"has a Zammad account)."
 msgstr ""
 
 #: ../basics/service-ticket/create.rst:62
@@ -2169,8 +2169,8 @@ msgstr ""
 
 #: ../snippets/ui-protip-message-editor-features.rst:3
 msgid ""
-"The message editor supports 📋 copying-and-pasting (or dragging-and-dropping) "
-"of **🔤 rich text**, **🌄 images** and **📎 file attachments**."
+"The message editor supports 📋 copying-and-pasting (or dragging-and-"
+"dropping) of **🔤 rich text**, **🌄 images** and **📎 file attachments**."
 msgstr ""
 
 #: ../snippets/ui-protip-message-editor-features.rst:6
@@ -2365,8 +2365,9 @@ msgstr ""
 msgid ""
 "What about the **deletion of articles**? In Zammad, you can only delete "
 "articles that you have created yourself and which are not older than 10 "
-"minutes. To see the \"delete\" button in articles of the type \"communication"
-"\" (emails, calls), their visibility has to be switched to internal first."
+"minutes. To see the \"delete\" button in articles of the type "
+"\"communication\" (emails, calls), their visibility has to be switched to "
+"internal first."
 msgstr ""
 
 #: ../basics/service-ticket/follow-up.rst:107
@@ -2587,7 +2588,8 @@ msgid ""
 "problematic *per se,* but it does lead to a lot of unnecessary clutter in "
 "the :doc:`overviews menu </basics/find-ticket>`. (It can be much worse when, "
 "for example, a customer service rep sees tickets meant for your HR "
-"department, and finds out how much their colleagues in sales are making! 💸💸💸)"
+"department, and finds out how much their colleagues in sales are making! 💸💸"
+"💸)"
 msgstr ""
 
 #: ../basics/service-ticket/settings/group.rst:25
@@ -4296,8 +4298,8 @@ msgstr ""
 
 #: ../extras/chat.rst:51
 msgid ""
-"📝 Chats can be **renamed** or **tagged**, and record technical details about "
-"the customer’s connection."
+"📝 Chats can be **renamed** or **tagged**, and record technical details "
+"about the customer’s connection."
 msgstr ""
 
 #: ../extras/chat.rst:0
@@ -4979,42 +4981,48 @@ msgid ""
 "permissions"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:0
-msgid "Permissions of a parent category are inherited!"
+#: ../extras/knowledge-base.rst:162
+msgid ""
+"In general, permissions of a parent category are inherited! If you want to "
+"grant edit permissions for a sub-category for a specific role for example, "
+"set the upper level to \"reader\" and the desired sub-category to "
+"\"editor\". The other way round is not possible (permissions can only be "
+"widened, not restricted). If you can't select permissions in the table, this "
+"could be the reason."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:0
-msgid "Public answers are always available!"
+#: ../extras/knowledge-base.rst:169
+msgid "Be aware that public answers are always available!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:165
+#: ../extras/knowledge-base.rst:171
 msgid "**⚙️ Roles require knowledge base reader permission**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:167
+#: ../extras/knowledge-base.rst:173
 msgid ""
 "Your administrator has to provide the relevant groups with reader "
 "permissions for the knowledge base."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:170
+#: ../extras/knowledge-base.rst:176
 msgid "**🥵 Beware of visibility levels**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:172
+#: ../extras/knowledge-base.rst:178
 msgid ""
 "Knowledge base reader permission means that affected users can see "
 "**internal answers**. This is a potential issue if you're not dividing "
 "carefully!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:176
+#: ../extras/knowledge-base.rst:182
 msgid ""
 "If you're unsure, please ask your administrator to configure the :admin-docs:"
 "`role permissions </manage/roles/agent-permissions.html>` accordingly."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:181
+#: ../extras/knowledge-base.rst:187
 msgid "Editing Answers"
 msgstr ""
 
@@ -5022,7 +5030,7 @@ msgstr ""
 msgid "Edit answer"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:187
+#: ../extras/knowledge-base.rst:193
 msgid ""
 "The knowledge base editor comes equipped with the same **rich text editing "
 "capabilities** available in the Zammad ticket composer. That means you can "
@@ -5031,19 +5039,19 @@ msgid ""
 "attachments and links!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:193
+#: ../extras/knowledge-base.rst:199
 msgid "🤷 **Why are there four kinds of links?**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:196
+#: ../extras/knowledge-base.rst:202
 msgid "🔗 **Weblink**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:196
+#: ../extras/knowledge-base.rst:202
 msgid "URLs pointing to other websites."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:200
+#: ../extras/knowledge-base.rst:206
 msgid "💡 **Link Answer**"
 msgstr ""
 
@@ -5055,7 +5063,7 @@ msgstr ""
 msgid "(Will not break if destination URL changes.)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:204
+#: ../extras/knowledge-base.rst:210
 msgid "📋 **Linked Tickets**"
 msgstr ""
 
@@ -5067,7 +5075,7 @@ msgstr ""
 msgid "(Visible only in Preview and Edit Modes.)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:211
+#: ../extras/knowledge-base.rst:217
 msgid "🏷️ **Tags**"
 msgstr ""
 
@@ -5085,38 +5093,38 @@ msgstr ""
 msgid "Screencast showing tags on answers"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:216
+#: ../extras/knowledge-base.rst:222
 msgid ""
 "🙈 Set the **visibility** of an answer to control who can see an article, or "
 "schedule it to be published at a later date. Articles are **color-coded** "
 "according to their visibility:"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:221
+#: ../extras/knowledge-base.rst:227
 msgid "**Public** (visible to everyone)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:223
+#: ../extras/knowledge-base.rst:229
 msgid "|blu|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:223
+#: ../extras/knowledge-base.rst:229
 msgid "**Internal** (visible to agents & editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:225
+#: ../extras/knowledge-base.rst:231
 msgid "|gry|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:225
+#: ../extras/knowledge-base.rst:231
 msgid "**Draft/Scheduled/Archived** (visible to editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:241
+#: ../extras/knowledge-base.rst:247
 msgid "Using answers in ticket articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:243
+#: ../extras/knowledge-base.rst:249
 msgid ""
 "As soon as the knowledge base contains one or more answers, you can use "
 "these just like text modules. Instead of ``::`` just use ``??`` to open the "
@@ -5124,22 +5132,22 @@ msgid ""
 "all languages available."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:248
+#: ../extras/knowledge-base.rst:254
 msgid ""
 "If you've found what you've been looking for, simply hit your ENTER-Key to "
 "load the answer into the ticket article. This way you don't have to throw "
 "URLs at your customer and provide the answer right away."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:252
+#: ../extras/knowledge-base.rst:258
 msgid "Loading answers into articles *does not* replace article content."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:258
+#: ../extras/knowledge-base.rst:264
 msgid "Screencast showing how to insert KB answers into articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:258
+#: ../extras/knowledge-base.rst:264
 msgid "Use ``??`` to find and load knowledge base answers into ticket articles"
 msgstr ""
 
@@ -6275,8 +6283,8 @@ msgstr ""
 
 #: ../extras/shared-drafts.rst:50
 msgid ""
-"If you're in a new ticket dialogue *after selecting the ticket group*, the 📝 "
-"button will indicate the shared drafts function to be available."
+"If you're in a new ticket dialogue *after selecting the ticket group*, the "
+"📝 button will indicate the shared drafts function to be available."
 msgstr ""
 
 #: ../extras/shared-drafts.rst:55
@@ -6365,8 +6373,8 @@ msgid ""
 "enter a meaning full name and click on the \"Create\" button."
 msgstr ""
 "Si estas listo para guardar el boceto, clickea en 📝 en el panel derecho del "
-"ticket, introduce un nombre completo significativo y clickea el botón \"Crear"
-"\"."
+"ticket, introduce un nombre completo significativo y clickea el botón "
+"\"Crear\"."
 
 #: ../extras/shared-drafts.rst:0
 msgid ""

--- a/locale/es_CO/LC_MESSAGES/user-docs.po
+++ b/locale/es_CO/LC_MESSAGES/user-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-09 13:15+0100\n"
+"POT-Creation-Date: 2023-12-04 12:38+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -1271,7 +1271,7 @@ msgid ""
 msgstr ""
 
 #: ../snippets/ticket-state-type-circles.rst:4
-#: ../snippets/ticket-state-type-circles.rst:6 ../extras/knowledge-base.rst:221
+#: ../snippets/ticket-state-type-circles.rst:6 ../extras/knowledge-base.rst:227
 msgid "|grn|"
 msgstr ""
 
@@ -2035,9 +2035,9 @@ msgstr ""
 
 #: ../basics/service-ticket/create.rst:58
 msgid ""
-"📞 For phone calls, record the details of your conversation. These notes will "
-"not be sent to the customer (though he may be able to see them if he has a "
-"Zammad account)."
+"📞 For phone calls, record the details of your conversation. These notes "
+"will not be sent to the customer (though he may be able to see them if he "
+"has a Zammad account)."
 msgstr ""
 
 #: ../basics/service-ticket/create.rst:62
@@ -2046,8 +2046,8 @@ msgstr ""
 
 #: ../snippets/ui-protip-message-editor-features.rst:3
 msgid ""
-"The message editor supports 📋 copying-and-pasting (or dragging-and-dropping) "
-"of **🔤 rich text**, **🌄 images** and **📎 file attachments**."
+"The message editor supports 📋 copying-and-pasting (or dragging-and-"
+"dropping) of **🔤 rich text**, **🌄 images** and **📎 file attachments**."
 msgstr ""
 
 #: ../snippets/ui-protip-message-editor-features.rst:6
@@ -2242,8 +2242,9 @@ msgstr ""
 msgid ""
 "What about the **deletion of articles**? In Zammad, you can only delete "
 "articles that you have created yourself and which are not older than 10 "
-"minutes. To see the \"delete\" button in articles of the type \"communication"
-"\" (emails, calls), their visibility has to be switched to internal first."
+"minutes. To see the \"delete\" button in articles of the type "
+"\"communication\" (emails, calls), their visibility has to be switched to "
+"internal first."
 msgstr ""
 
 #: ../basics/service-ticket/follow-up.rst:107
@@ -2464,7 +2465,8 @@ msgid ""
 "problematic *per se,* but it does lead to a lot of unnecessary clutter in "
 "the :doc:`overviews menu </basics/find-ticket>`. (It can be much worse when, "
 "for example, a customer service rep sees tickets meant for your HR "
-"department, and finds out how much their colleagues in sales are making! 💸💸💸)"
+"department, and finds out how much their colleagues in sales are making! 💸💸"
+"💸)"
 msgstr ""
 
 #: ../basics/service-ticket/settings/group.rst:25
@@ -4173,8 +4175,8 @@ msgstr ""
 
 #: ../extras/chat.rst:51
 msgid ""
-"📝 Chats can be **renamed** or **tagged**, and record technical details about "
-"the customer’s connection."
+"📝 Chats can be **renamed** or **tagged**, and record technical details "
+"about the customer’s connection."
 msgstr ""
 
 #: ../extras/chat.rst:0
@@ -4856,42 +4858,48 @@ msgid ""
 "permissions"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:0
-msgid "Permissions of a parent category are inherited!"
+#: ../extras/knowledge-base.rst:162
+msgid ""
+"In general, permissions of a parent category are inherited! If you want to "
+"grant edit permissions for a sub-category for a specific role for example, "
+"set the upper level to \"reader\" and the desired sub-category to "
+"\"editor\". The other way round is not possible (permissions can only be "
+"widened, not restricted). If you can't select permissions in the table, this "
+"could be the reason."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:0
-msgid "Public answers are always available!"
+#: ../extras/knowledge-base.rst:169
+msgid "Be aware that public answers are always available!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:165
+#: ../extras/knowledge-base.rst:171
 msgid "**⚙️ Roles require knowledge base reader permission**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:167
+#: ../extras/knowledge-base.rst:173
 msgid ""
 "Your administrator has to provide the relevant groups with reader "
 "permissions for the knowledge base."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:170
+#: ../extras/knowledge-base.rst:176
 msgid "**🥵 Beware of visibility levels**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:172
+#: ../extras/knowledge-base.rst:178
 msgid ""
 "Knowledge base reader permission means that affected users can see "
 "**internal answers**. This is a potential issue if you're not dividing "
 "carefully!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:176
+#: ../extras/knowledge-base.rst:182
 msgid ""
 "If you're unsure, please ask your administrator to configure the :admin-docs:"
 "`role permissions </manage/roles/agent-permissions.html>` accordingly."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:181
+#: ../extras/knowledge-base.rst:187
 msgid "Editing Answers"
 msgstr ""
 
@@ -4899,7 +4907,7 @@ msgstr ""
 msgid "Edit answer"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:187
+#: ../extras/knowledge-base.rst:193
 msgid ""
 "The knowledge base editor comes equipped with the same **rich text editing "
 "capabilities** available in the Zammad ticket composer. That means you can "
@@ -4908,19 +4916,19 @@ msgid ""
 "attachments and links!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:193
+#: ../extras/knowledge-base.rst:199
 msgid "🤷 **Why are there four kinds of links?**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:196
+#: ../extras/knowledge-base.rst:202
 msgid "🔗 **Weblink**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:196
+#: ../extras/knowledge-base.rst:202
 msgid "URLs pointing to other websites."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:200
+#: ../extras/knowledge-base.rst:206
 msgid "💡 **Link Answer**"
 msgstr ""
 
@@ -4932,7 +4940,7 @@ msgstr ""
 msgid "(Will not break if destination URL changes.)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:204
+#: ../extras/knowledge-base.rst:210
 msgid "📋 **Linked Tickets**"
 msgstr ""
 
@@ -4944,7 +4952,7 @@ msgstr ""
 msgid "(Visible only in Preview and Edit Modes.)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:211
+#: ../extras/knowledge-base.rst:217
 msgid "🏷️ **Tags**"
 msgstr ""
 
@@ -4962,38 +4970,38 @@ msgstr ""
 msgid "Screencast showing tags on answers"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:216
+#: ../extras/knowledge-base.rst:222
 msgid ""
 "🙈 Set the **visibility** of an answer to control who can see an article, or "
 "schedule it to be published at a later date. Articles are **color-coded** "
 "according to their visibility:"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:221
+#: ../extras/knowledge-base.rst:227
 msgid "**Public** (visible to everyone)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:223
+#: ../extras/knowledge-base.rst:229
 msgid "|blu|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:223
+#: ../extras/knowledge-base.rst:229
 msgid "**Internal** (visible to agents & editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:225
+#: ../extras/knowledge-base.rst:231
 msgid "|gry|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:225
+#: ../extras/knowledge-base.rst:231
 msgid "**Draft/Scheduled/Archived** (visible to editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:241
+#: ../extras/knowledge-base.rst:247
 msgid "Using answers in ticket articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:243
+#: ../extras/knowledge-base.rst:249
 msgid ""
 "As soon as the knowledge base contains one or more answers, you can use "
 "these just like text modules. Instead of ``::`` just use ``??`` to open the "
@@ -5001,22 +5009,22 @@ msgid ""
 "all languages available."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:248
+#: ../extras/knowledge-base.rst:254
 msgid ""
 "If you've found what you've been looking for, simply hit your ENTER-Key to "
 "load the answer into the ticket article. This way you don't have to throw "
 "URLs at your customer and provide the answer right away."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:252
+#: ../extras/knowledge-base.rst:258
 msgid "Loading answers into articles *does not* replace article content."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:258
+#: ../extras/knowledge-base.rst:264
 msgid "Screencast showing how to insert KB answers into articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:258
+#: ../extras/knowledge-base.rst:264
 msgid "Use ``??`` to find and load knowledge base answers into ticket articles"
 msgstr ""
 
@@ -6138,8 +6146,8 @@ msgstr ""
 
 #: ../extras/shared-drafts.rst:50
 msgid ""
-"If you're in a new ticket dialogue *after selecting the ticket group*, the 📝 "
-"button will indicate the shared drafts function to be available."
+"If you're in a new ticket dialogue *after selecting the ticket group*, the "
+"📝 button will indicate the shared drafts function to be available."
 msgstr ""
 
 #: ../extras/shared-drafts.rst:55

--- a/locale/es_MX/LC_MESSAGES/user-docs.po
+++ b/locale/es_MX/LC_MESSAGES/user-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-09 13:15+0100\n"
+"POT-Creation-Date: 2023-12-04 12:38+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -1271,7 +1271,7 @@ msgid ""
 msgstr ""
 
 #: ../snippets/ticket-state-type-circles.rst:4
-#: ../snippets/ticket-state-type-circles.rst:6 ../extras/knowledge-base.rst:221
+#: ../snippets/ticket-state-type-circles.rst:6 ../extras/knowledge-base.rst:227
 msgid "|grn|"
 msgstr ""
 
@@ -2035,9 +2035,9 @@ msgstr ""
 
 #: ../basics/service-ticket/create.rst:58
 msgid ""
-"📞 For phone calls, record the details of your conversation. These notes will "
-"not be sent to the customer (though he may be able to see them if he has a "
-"Zammad account)."
+"📞 For phone calls, record the details of your conversation. These notes "
+"will not be sent to the customer (though he may be able to see them if he "
+"has a Zammad account)."
 msgstr ""
 
 #: ../basics/service-ticket/create.rst:62
@@ -2046,8 +2046,8 @@ msgstr ""
 
 #: ../snippets/ui-protip-message-editor-features.rst:3
 msgid ""
-"The message editor supports 📋 copying-and-pasting (or dragging-and-dropping) "
-"of **🔤 rich text**, **🌄 images** and **📎 file attachments**."
+"The message editor supports 📋 copying-and-pasting (or dragging-and-"
+"dropping) of **🔤 rich text**, **🌄 images** and **📎 file attachments**."
 msgstr ""
 
 #: ../snippets/ui-protip-message-editor-features.rst:6
@@ -2242,8 +2242,9 @@ msgstr ""
 msgid ""
 "What about the **deletion of articles**? In Zammad, you can only delete "
 "articles that you have created yourself and which are not older than 10 "
-"minutes. To see the \"delete\" button in articles of the type \"communication"
-"\" (emails, calls), their visibility has to be switched to internal first."
+"minutes. To see the \"delete\" button in articles of the type "
+"\"communication\" (emails, calls), their visibility has to be switched to "
+"internal first."
 msgstr ""
 
 #: ../basics/service-ticket/follow-up.rst:107
@@ -2464,7 +2465,8 @@ msgid ""
 "problematic *per se,* but it does lead to a lot of unnecessary clutter in "
 "the :doc:`overviews menu </basics/find-ticket>`. (It can be much worse when, "
 "for example, a customer service rep sees tickets meant for your HR "
-"department, and finds out how much their colleagues in sales are making! 💸💸💸)"
+"department, and finds out how much their colleagues in sales are making! 💸💸"
+"💸)"
 msgstr ""
 
 #: ../basics/service-ticket/settings/group.rst:25
@@ -4173,8 +4175,8 @@ msgstr ""
 
 #: ../extras/chat.rst:51
 msgid ""
-"📝 Chats can be **renamed** or **tagged**, and record technical details about "
-"the customer’s connection."
+"📝 Chats can be **renamed** or **tagged**, and record technical details "
+"about the customer’s connection."
 msgstr ""
 
 #: ../extras/chat.rst:0
@@ -4856,42 +4858,48 @@ msgid ""
 "permissions"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:0
-msgid "Permissions of a parent category are inherited!"
+#: ../extras/knowledge-base.rst:162
+msgid ""
+"In general, permissions of a parent category are inherited! If you want to "
+"grant edit permissions for a sub-category for a specific role for example, "
+"set the upper level to \"reader\" and the desired sub-category to "
+"\"editor\". The other way round is not possible (permissions can only be "
+"widened, not restricted). If you can't select permissions in the table, this "
+"could be the reason."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:0
-msgid "Public answers are always available!"
+#: ../extras/knowledge-base.rst:169
+msgid "Be aware that public answers are always available!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:165
+#: ../extras/knowledge-base.rst:171
 msgid "**⚙️ Roles require knowledge base reader permission**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:167
+#: ../extras/knowledge-base.rst:173
 msgid ""
 "Your administrator has to provide the relevant groups with reader "
 "permissions for the knowledge base."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:170
+#: ../extras/knowledge-base.rst:176
 msgid "**🥵 Beware of visibility levels**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:172
+#: ../extras/knowledge-base.rst:178
 msgid ""
 "Knowledge base reader permission means that affected users can see "
 "**internal answers**. This is a potential issue if you're not dividing "
 "carefully!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:176
+#: ../extras/knowledge-base.rst:182
 msgid ""
 "If you're unsure, please ask your administrator to configure the :admin-docs:"
 "`role permissions </manage/roles/agent-permissions.html>` accordingly."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:181
+#: ../extras/knowledge-base.rst:187
 msgid "Editing Answers"
 msgstr ""
 
@@ -4899,7 +4907,7 @@ msgstr ""
 msgid "Edit answer"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:187
+#: ../extras/knowledge-base.rst:193
 msgid ""
 "The knowledge base editor comes equipped with the same **rich text editing "
 "capabilities** available in the Zammad ticket composer. That means you can "
@@ -4908,19 +4916,19 @@ msgid ""
 "attachments and links!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:193
+#: ../extras/knowledge-base.rst:199
 msgid "🤷 **Why are there four kinds of links?**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:196
+#: ../extras/knowledge-base.rst:202
 msgid "🔗 **Weblink**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:196
+#: ../extras/knowledge-base.rst:202
 msgid "URLs pointing to other websites."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:200
+#: ../extras/knowledge-base.rst:206
 msgid "💡 **Link Answer**"
 msgstr ""
 
@@ -4932,7 +4940,7 @@ msgstr ""
 msgid "(Will not break if destination URL changes.)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:204
+#: ../extras/knowledge-base.rst:210
 msgid "📋 **Linked Tickets**"
 msgstr ""
 
@@ -4944,7 +4952,7 @@ msgstr ""
 msgid "(Visible only in Preview and Edit Modes.)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:211
+#: ../extras/knowledge-base.rst:217
 msgid "🏷️ **Tags**"
 msgstr ""
 
@@ -4962,38 +4970,38 @@ msgstr ""
 msgid "Screencast showing tags on answers"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:216
+#: ../extras/knowledge-base.rst:222
 msgid ""
 "🙈 Set the **visibility** of an answer to control who can see an article, or "
 "schedule it to be published at a later date. Articles are **color-coded** "
 "according to their visibility:"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:221
+#: ../extras/knowledge-base.rst:227
 msgid "**Public** (visible to everyone)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:223
+#: ../extras/knowledge-base.rst:229
 msgid "|blu|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:223
+#: ../extras/knowledge-base.rst:229
 msgid "**Internal** (visible to agents & editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:225
+#: ../extras/knowledge-base.rst:231
 msgid "|gry|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:225
+#: ../extras/knowledge-base.rst:231
 msgid "**Draft/Scheduled/Archived** (visible to editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:241
+#: ../extras/knowledge-base.rst:247
 msgid "Using answers in ticket articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:243
+#: ../extras/knowledge-base.rst:249
 msgid ""
 "As soon as the knowledge base contains one or more answers, you can use "
 "these just like text modules. Instead of ``::`` just use ``??`` to open the "
@@ -5001,22 +5009,22 @@ msgid ""
 "all languages available."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:248
+#: ../extras/knowledge-base.rst:254
 msgid ""
 "If you've found what you've been looking for, simply hit your ENTER-Key to "
 "load the answer into the ticket article. This way you don't have to throw "
 "URLs at your customer and provide the answer right away."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:252
+#: ../extras/knowledge-base.rst:258
 msgid "Loading answers into articles *does not* replace article content."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:258
+#: ../extras/knowledge-base.rst:264
 msgid "Screencast showing how to insert KB answers into articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:258
+#: ../extras/knowledge-base.rst:264
 msgid "Use ``??`` to find and load knowledge base answers into ticket articles"
 msgstr ""
 
@@ -6138,8 +6146,8 @@ msgstr ""
 
 #: ../extras/shared-drafts.rst:50
 msgid ""
-"If you're in a new ticket dialogue *after selecting the ticket group*, the 📝 "
-"button will indicate the shared drafts function to be available."
+"If you're in a new ticket dialogue *after selecting the ticket group*, the "
+"📝 button will indicate the shared drafts function to be available."
 msgstr ""
 
 #: ../extras/shared-drafts.rst:55

--- a/locale/fa/LC_MESSAGES/user-docs.po
+++ b/locale/fa/LC_MESSAGES/user-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-09 13:15+0100\n"
+"POT-Creation-Date: 2023-12-04 12:38+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -1271,7 +1271,7 @@ msgid ""
 msgstr ""
 
 #: ../snippets/ticket-state-type-circles.rst:4
-#: ../snippets/ticket-state-type-circles.rst:6 ../extras/knowledge-base.rst:221
+#: ../snippets/ticket-state-type-circles.rst:6 ../extras/knowledge-base.rst:227
 msgid "|grn|"
 msgstr ""
 
@@ -2035,9 +2035,9 @@ msgstr ""
 
 #: ../basics/service-ticket/create.rst:58
 msgid ""
-"📞 For phone calls, record the details of your conversation. These notes will "
-"not be sent to the customer (though he may be able to see them if he has a "
-"Zammad account)."
+"📞 For phone calls, record the details of your conversation. These notes "
+"will not be sent to the customer (though he may be able to see them if he "
+"has a Zammad account)."
 msgstr ""
 
 #: ../basics/service-ticket/create.rst:62
@@ -2046,8 +2046,8 @@ msgstr ""
 
 #: ../snippets/ui-protip-message-editor-features.rst:3
 msgid ""
-"The message editor supports 📋 copying-and-pasting (or dragging-and-dropping) "
-"of **🔤 rich text**, **🌄 images** and **📎 file attachments**."
+"The message editor supports 📋 copying-and-pasting (or dragging-and-"
+"dropping) of **🔤 rich text**, **🌄 images** and **📎 file attachments**."
 msgstr ""
 
 #: ../snippets/ui-protip-message-editor-features.rst:6
@@ -2242,8 +2242,9 @@ msgstr ""
 msgid ""
 "What about the **deletion of articles**? In Zammad, you can only delete "
 "articles that you have created yourself and which are not older than 10 "
-"minutes. To see the \"delete\" button in articles of the type \"communication"
-"\" (emails, calls), their visibility has to be switched to internal first."
+"minutes. To see the \"delete\" button in articles of the type "
+"\"communication\" (emails, calls), their visibility has to be switched to "
+"internal first."
 msgstr ""
 
 #: ../basics/service-ticket/follow-up.rst:107
@@ -2464,7 +2465,8 @@ msgid ""
 "problematic *per se,* but it does lead to a lot of unnecessary clutter in "
 "the :doc:`overviews menu </basics/find-ticket>`. (It can be much worse when, "
 "for example, a customer service rep sees tickets meant for your HR "
-"department, and finds out how much their colleagues in sales are making! 💸💸💸)"
+"department, and finds out how much their colleagues in sales are making! 💸💸"
+"💸)"
 msgstr ""
 
 #: ../basics/service-ticket/settings/group.rst:25
@@ -4173,8 +4175,8 @@ msgstr ""
 
 #: ../extras/chat.rst:51
 msgid ""
-"📝 Chats can be **renamed** or **tagged**, and record technical details about "
-"the customer’s connection."
+"📝 Chats can be **renamed** or **tagged**, and record technical details "
+"about the customer’s connection."
 msgstr ""
 
 #: ../extras/chat.rst:0
@@ -4856,42 +4858,48 @@ msgid ""
 "permissions"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:0
-msgid "Permissions of a parent category are inherited!"
+#: ../extras/knowledge-base.rst:162
+msgid ""
+"In general, permissions of a parent category are inherited! If you want to "
+"grant edit permissions for a sub-category for a specific role for example, "
+"set the upper level to \"reader\" and the desired sub-category to "
+"\"editor\". The other way round is not possible (permissions can only be "
+"widened, not restricted). If you can't select permissions in the table, this "
+"could be the reason."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:0
-msgid "Public answers are always available!"
+#: ../extras/knowledge-base.rst:169
+msgid "Be aware that public answers are always available!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:165
+#: ../extras/knowledge-base.rst:171
 msgid "**⚙️ Roles require knowledge base reader permission**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:167
+#: ../extras/knowledge-base.rst:173
 msgid ""
 "Your administrator has to provide the relevant groups with reader "
 "permissions for the knowledge base."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:170
+#: ../extras/knowledge-base.rst:176
 msgid "**🥵 Beware of visibility levels**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:172
+#: ../extras/knowledge-base.rst:178
 msgid ""
 "Knowledge base reader permission means that affected users can see "
 "**internal answers**. This is a potential issue if you're not dividing "
 "carefully!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:176
+#: ../extras/knowledge-base.rst:182
 msgid ""
 "If you're unsure, please ask your administrator to configure the :admin-docs:"
 "`role permissions </manage/roles/agent-permissions.html>` accordingly."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:181
+#: ../extras/knowledge-base.rst:187
 msgid "Editing Answers"
 msgstr ""
 
@@ -4899,7 +4907,7 @@ msgstr ""
 msgid "Edit answer"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:187
+#: ../extras/knowledge-base.rst:193
 msgid ""
 "The knowledge base editor comes equipped with the same **rich text editing "
 "capabilities** available in the Zammad ticket composer. That means you can "
@@ -4908,19 +4916,19 @@ msgid ""
 "attachments and links!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:193
+#: ../extras/knowledge-base.rst:199
 msgid "🤷 **Why are there four kinds of links?**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:196
+#: ../extras/knowledge-base.rst:202
 msgid "🔗 **Weblink**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:196
+#: ../extras/knowledge-base.rst:202
 msgid "URLs pointing to other websites."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:200
+#: ../extras/knowledge-base.rst:206
 msgid "💡 **Link Answer**"
 msgstr ""
 
@@ -4932,7 +4940,7 @@ msgstr ""
 msgid "(Will not break if destination URL changes.)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:204
+#: ../extras/knowledge-base.rst:210
 msgid "📋 **Linked Tickets**"
 msgstr ""
 
@@ -4944,7 +4952,7 @@ msgstr ""
 msgid "(Visible only in Preview and Edit Modes.)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:211
+#: ../extras/knowledge-base.rst:217
 msgid "🏷️ **Tags**"
 msgstr ""
 
@@ -4962,38 +4970,38 @@ msgstr ""
 msgid "Screencast showing tags on answers"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:216
+#: ../extras/knowledge-base.rst:222
 msgid ""
 "🙈 Set the **visibility** of an answer to control who can see an article, or "
 "schedule it to be published at a later date. Articles are **color-coded** "
 "according to their visibility:"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:221
+#: ../extras/knowledge-base.rst:227
 msgid "**Public** (visible to everyone)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:223
+#: ../extras/knowledge-base.rst:229
 msgid "|blu|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:223
+#: ../extras/knowledge-base.rst:229
 msgid "**Internal** (visible to agents & editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:225
+#: ../extras/knowledge-base.rst:231
 msgid "|gry|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:225
+#: ../extras/knowledge-base.rst:231
 msgid "**Draft/Scheduled/Archived** (visible to editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:241
+#: ../extras/knowledge-base.rst:247
 msgid "Using answers in ticket articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:243
+#: ../extras/knowledge-base.rst:249
 msgid ""
 "As soon as the knowledge base contains one or more answers, you can use "
 "these just like text modules. Instead of ``::`` just use ``??`` to open the "
@@ -5001,22 +5009,22 @@ msgid ""
 "all languages available."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:248
+#: ../extras/knowledge-base.rst:254
 msgid ""
 "If you've found what you've been looking for, simply hit your ENTER-Key to "
 "load the answer into the ticket article. This way you don't have to throw "
 "URLs at your customer and provide the answer right away."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:252
+#: ../extras/knowledge-base.rst:258
 msgid "Loading answers into articles *does not* replace article content."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:258
+#: ../extras/knowledge-base.rst:264
 msgid "Screencast showing how to insert KB answers into articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:258
+#: ../extras/knowledge-base.rst:264
 msgid "Use ``??`` to find and load knowledge base answers into ticket articles"
 msgstr ""
 
@@ -6138,8 +6146,8 @@ msgstr ""
 
 #: ../extras/shared-drafts.rst:50
 msgid ""
-"If you're in a new ticket dialogue *after selecting the ticket group*, the 📝 "
-"button will indicate the shared drafts function to be available."
+"If you're in a new ticket dialogue *after selecting the ticket group*, the "
+"📝 button will indicate the shared drafts function to be available."
 msgstr ""
 
 #: ../extras/shared-drafts.rst:55

--- a/locale/fr/LC_MESSAGES/user-docs.po
+++ b/locale/fr/LC_MESSAGES/user-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-09 13:15+0100\n"
+"POT-Creation-Date: 2023-12-04 12:38+0100\n"
 "PO-Revision-Date: 2023-01-12 16:10+0000\n"
 "Last-Translator: LahutaeMalcis <hello@privacydream.eu>\n"
 "Language-Team: French <https://translations.zammad.org/projects/"
@@ -1429,7 +1429,7 @@ msgstr ""
 "**codés par couleur:**"
 
 #: ../snippets/ticket-state-type-circles.rst:4
-#: ../snippets/ticket-state-type-circles.rst:6 ../extras/knowledge-base.rst:221
+#: ../snippets/ticket-state-type-circles.rst:6 ../extras/knowledge-base.rst:227
 msgid "|grn|"
 msgstr "|grn|"
 
@@ -2338,9 +2338,9 @@ msgstr "Texte"
 
 #: ../basics/service-ticket/create.rst:58
 msgid ""
-"📞 For phone calls, record the details of your conversation. These notes will "
-"not be sent to the customer (though he may be able to see them if he has a "
-"Zammad account)."
+"📞 For phone calls, record the details of your conversation. These notes "
+"will not be sent to the customer (though he may be able to see them if he "
+"has a Zammad account)."
 msgstr ""
 "📞 pour les appels téléphoniques, pour conserver les détails de votre "
 "conversation. Ces notes ne seront pas envoyées au client (bien qu'il "
@@ -2352,11 +2352,11 @@ msgstr "📧 Pour les courriels, il s'agit du corps de votre message sortant."
 
 #: ../snippets/ui-protip-message-editor-features.rst:3
 msgid ""
-"The message editor supports 📋 copying-and-pasting (or dragging-and-dropping) "
-"of **🔤 rich text**, **🌄 images** and **📎 file attachments**."
+"The message editor supports 📋 copying-and-pasting (or dragging-and-"
+"dropping) of **🔤 rich text**, **🌄 images** and **📎 file attachments**."
 msgstr ""
-"L'éditeur de message supporte le 📋 copier-coller (ou glisser-déposer) de **🔤 "
-"texte riche**, **🌄 images** et **📎 pièces jointes**."
+"L'éditeur de message supporte le 📋 copier-coller (ou glisser-déposer) de "
+"**🔤 texte riche**, **🌄 images** et **📎 pièces jointes**."
 
 #: ../snippets/ui-protip-message-editor-features.rst:6
 msgid ""
@@ -2596,8 +2596,9 @@ msgstr ""
 msgid ""
 "What about the **deletion of articles**? In Zammad, you can only delete "
 "articles that you have created yourself and which are not older than 10 "
-"minutes. To see the \"delete\" button in articles of the type \"communication"
-"\" (emails, calls), their visibility has to be switched to internal first."
+"minutes. To see the \"delete\" button in articles of the type "
+"\"communication\" (emails, calls), their visibility has to be switched to "
+"internal first."
 msgstr ""
 
 #: ../basics/service-ticket/follow-up.rst:107
@@ -2857,15 +2858,16 @@ msgid ""
 "problematic *per se,* but it does lead to a lot of unnecessary clutter in "
 "the :doc:`overviews menu </basics/find-ticket>`. (It can be much worse when, "
 "for example, a customer service rep sees tickets meant for your HR "
-"department, and finds out how much their colleagues in sales are making! 💸💸💸)"
+"department, and finds out how much their colleagues in sales are making! 💸💸"
+"💸)"
 msgstr ""
 "Sans les groupes, vos dix opérateurs pourraient voir (et répondre) à chaque "
 "ticket qui arrive, peu importe pour quel service ils sont. Ce n'est pas en "
 "soi problématique, mais cela peut engendrer un encombrement inutile dans le :"
 "doc:`menu aperçus </basics/find-ticket>`. (cela peut être pire encore quand, "
 "par exemple, un responsable du service client voit des tickets pour le "
-"service RH, et trouve combien gagnent ses collègues du service des ventes! 💸💸"
-"💸)"
+"service RH, et trouve combien gagnent ses collègues du service des ventes! 💸"
+"💸💸)"
 
 #: ../basics/service-ticket/settings/group.rst:25
 msgid ""
@@ -4580,9 +4582,10 @@ msgid ""
 "👤 Click on unrecognized numbers to **create a new customer** or maybe "
 "entries to **update an existing customer**."
 msgstr ""
-"👤 Cliquez sur les numéros non reconnus dans le journal d'appels pour **créer "
-"un nouvel client et ticket**. (Les numéros de téléphones non reconnus ne "
-"peuvent pas être ajoutés de cette manière à des clients existants.)"
+"👤 Cliquez sur les numéros non reconnus dans le journal d'appels pour "
+"**créer un nouvel client et ticket**. (Les numéros de téléphones non "
+"reconnus ne peuvent pas être ajoutés de cette manière à des clients "
+"existants.)"
 
 #: ../extras/caller-log.rst:72
 msgid ""
@@ -4724,8 +4727,8 @@ msgstr ""
 
 #: ../extras/chat.rst:51
 msgid ""
-"📝 Chats can be **renamed** or **tagged**, and record technical details about "
-"the customer’s connection."
+"📝 Chats can be **renamed** or **tagged**, and record technical details "
+"about the customer’s connection."
 msgstr ""
 "📝 Les discussions peuvent être **renommées** ou **étiquetées**, et "
 "enregistrer des détails techniques concernant la connexion du client."
@@ -5346,8 +5349,8 @@ msgid ""
 "🚧 **What happens when a page hasn’t been translated into the selected "
 "language yet?**"
 msgstr ""
-"🚧 **Qu'arrive t-il quand une page n'a pas encore été traduite dans la langue "
-"sélectionnée?**"
+"🚧 **Qu'arrive t-il quand une page n'a pas encore été traduite dans la "
+"langue sélectionnée?**"
 
 #: ../extras/knowledge-base.rst:67
 msgid "in Edit Mode"
@@ -5501,42 +5504,48 @@ msgid ""
 "permissions"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:0
-msgid "Permissions of a parent category are inherited!"
+#: ../extras/knowledge-base.rst:162
+msgid ""
+"In general, permissions of a parent category are inherited! If you want to "
+"grant edit permissions for a sub-category for a specific role for example, "
+"set the upper level to \"reader\" and the desired sub-category to "
+"\"editor\". The other way round is not possible (permissions can only be "
+"widened, not restricted). If you can't select permissions in the table, this "
+"could be the reason."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:0
-msgid "Public answers are always available!"
+#: ../extras/knowledge-base.rst:169
+msgid "Be aware that public answers are always available!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:165
+#: ../extras/knowledge-base.rst:171
 msgid "**⚙️ Roles require knowledge base reader permission**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:167
+#: ../extras/knowledge-base.rst:173
 msgid ""
 "Your administrator has to provide the relevant groups with reader "
 "permissions for the knowledge base."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:170
+#: ../extras/knowledge-base.rst:176
 msgid "**🥵 Beware of visibility levels**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:172
+#: ../extras/knowledge-base.rst:178
 msgid ""
 "Knowledge base reader permission means that affected users can see "
 "**internal answers**. This is a potential issue if you're not dividing "
 "carefully!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:176
+#: ../extras/knowledge-base.rst:182
 msgid ""
 "If you're unsure, please ask your administrator to configure the :admin-docs:"
 "`role permissions </manage/roles/agent-permissions.html>` accordingly."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:181
+#: ../extras/knowledge-base.rst:187
 msgid "Editing Answers"
 msgstr "Éditer des réponses"
 
@@ -5544,7 +5553,7 @@ msgstr "Éditer des réponses"
 msgid "Edit answer"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:187
+#: ../extras/knowledge-base.rst:193
 msgid ""
 "The knowledge base editor comes equipped with the same **rich text editing "
 "capabilities** available in the Zammad ticket composer. That means you can "
@@ -5559,19 +5568,19 @@ msgstr ""
 "listes à puce, et plus encore. Vous pouvez même ajouter des pièces jointes "
 "et des liens!"
 
-#: ../extras/knowledge-base.rst:193
+#: ../extras/knowledge-base.rst:199
 msgid "🤷 **Why are there four kinds of links?**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:196
+#: ../extras/knowledge-base.rst:202
 msgid "🔗 **Weblink**"
 msgstr "🔗 **liens web**"
 
-#: ../extras/knowledge-base.rst:196
+#: ../extras/knowledge-base.rst:202
 msgid "URLs pointing to other websites."
 msgstr "URLs qui pointent vers d'autres sites web."
 
-#: ../extras/knowledge-base.rst:200
+#: ../extras/knowledge-base.rst:206
 msgid "💡 **Link Answer**"
 msgstr "💡 **Lien réponse**"
 
@@ -5583,7 +5592,7 @@ msgstr "Références internes vers d'autres réponses de la base de connaissance
 msgid "(Will not break if destination URL changes.)"
 msgstr "(qui ne casseront pas si l'URL de destination change.)"
 
-#: ../extras/knowledge-base.rst:204
+#: ../extras/knowledge-base.rst:210
 msgid "📋 **Linked Tickets**"
 msgstr "📋 **Tickets liés**"
 
@@ -5595,7 +5604,7 @@ msgstr "Références internes vers des tickets Zammad."
 msgid "(Visible only in Preview and Edit Modes.)"
 msgstr "(visibles seulement dans les modes prévisualisation et édition.)"
 
-#: ../extras/knowledge-base.rst:211
+#: ../extras/knowledge-base.rst:217
 msgid "🏷️ **Tags**"
 msgstr ""
 
@@ -5613,7 +5622,7 @@ msgstr ""
 msgid "Screencast showing tags on answers"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:216
+#: ../extras/knowledge-base.rst:222
 msgid ""
 "🙈 Set the **visibility** of an answer to control who can see an article, or "
 "schedule it to be published at a later date. Articles are **color-coded** "
@@ -5623,31 +5632,31 @@ msgstr ""
 "un article ou planifier sa publication à une date ultérieure. Les articles "
 "ont des **codes couleurs** en fonction de leur visibilité:"
 
-#: ../extras/knowledge-base.rst:221
+#: ../extras/knowledge-base.rst:227
 msgid "**Public** (visible to everyone)"
 msgstr "**Public** (visible pour tout le monde)"
 
-#: ../extras/knowledge-base.rst:223
+#: ../extras/knowledge-base.rst:229
 msgid "|blu|"
 msgstr "|blu|"
 
-#: ../extras/knowledge-base.rst:223
+#: ../extras/knowledge-base.rst:229
 msgid "**Internal** (visible to agents & editors only)"
 msgstr "**Interne** (visible seulement pour les opérateurs & rédacteurs)"
 
-#: ../extras/knowledge-base.rst:225
+#: ../extras/knowledge-base.rst:231
 msgid "|gry|"
 msgstr "|gry|"
 
-#: ../extras/knowledge-base.rst:225
+#: ../extras/knowledge-base.rst:231
 msgid "**Draft/Scheduled/Archived** (visible to editors only)"
 msgstr "**Brouillon/planifié/archivé** (visible seulement pour les rédacteurs)"
 
-#: ../extras/knowledge-base.rst:241
+#: ../extras/knowledge-base.rst:247
 msgid "Using answers in ticket articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:243
+#: ../extras/knowledge-base.rst:249
 msgid ""
 "As soon as the knowledge base contains one or more answers, you can use "
 "these just like text modules. Instead of ``::`` just use ``??`` to open the "
@@ -5655,22 +5664,22 @@ msgid ""
 "all languages available."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:248
+#: ../extras/knowledge-base.rst:254
 msgid ""
 "If you've found what you've been looking for, simply hit your ENTER-Key to "
 "load the answer into the ticket article. This way you don't have to throw "
 "URLs at your customer and provide the answer right away."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:252
+#: ../extras/knowledge-base.rst:258
 msgid "Loading answers into articles *does not* replace article content."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:258
+#: ../extras/knowledge-base.rst:264
 msgid "Screencast showing how to insert KB answers into articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:258
+#: ../extras/knowledge-base.rst:264
 msgid "Use ``??`` to find and load knowledge base answers into ticket articles"
 msgstr ""
 
@@ -6929,8 +6938,8 @@ msgstr ""
 
 #: ../extras/shared-drafts.rst:50
 msgid ""
-"If you're in a new ticket dialogue *after selecting the ticket group*, the 📝 "
-"button will indicate the shared drafts function to be available."
+"If you're in a new ticket dialogue *after selecting the ticket group*, the "
+"📝 button will indicate the shared drafts function to be available."
 msgstr ""
 
 #: ../extras/shared-drafts.rst:55

--- a/locale/fr_CA/LC_MESSAGES/user-docs.po
+++ b/locale/fr_CA/LC_MESSAGES/user-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-09 13:15+0100\n"
+"POT-Creation-Date: 2023-12-04 12:38+0100\n"
 "PO-Revision-Date: 2022-04-16 15:56+0000\n"
 "Last-Translator: Marcel Herrguth <github@thehomeofanime.de>\n"
 "Language-Team: French (Canada) <https://translations.zammad.org/projects/"
@@ -1375,7 +1375,7 @@ msgid ""
 msgstr ":doc:`Ticket states ` sont **color-coded:**"
 
 #: ../snippets/ticket-state-type-circles.rst:4
-#: ../snippets/ticket-state-type-circles.rst:6 ../extras/knowledge-base.rst:221
+#: ../snippets/ticket-state-type-circles.rst:6 ../extras/knowledge-base.rst:227
 msgid "|grn|"
 msgstr "|grn|"
 
@@ -2253,9 +2253,9 @@ msgstr ""
 
 #: ../basics/service-ticket/create.rst:58
 msgid ""
-"📞 For phone calls, record the details of your conversation. These notes will "
-"not be sent to the customer (though he may be able to see them if he has a "
-"Zammad account)."
+"📞 For phone calls, record the details of your conversation. These notes "
+"will not be sent to the customer (though he may be able to see them if he "
+"has a Zammad account)."
 msgstr ""
 
 #: ../basics/service-ticket/create.rst:62
@@ -2264,8 +2264,8 @@ msgstr ""
 
 #: ../snippets/ui-protip-message-editor-features.rst:3
 msgid ""
-"The message editor supports 📋 copying-and-pasting (or dragging-and-dropping) "
-"of **🔤 rich text**, **🌄 images** and **📎 file attachments**."
+"The message editor supports 📋 copying-and-pasting (or dragging-and-"
+"dropping) of **🔤 rich text**, **🌄 images** and **📎 file attachments**."
 msgstr ""
 
 #: ../snippets/ui-protip-message-editor-features.rst:6
@@ -2460,8 +2460,9 @@ msgstr ""
 msgid ""
 "What about the **deletion of articles**? In Zammad, you can only delete "
 "articles that you have created yourself and which are not older than 10 "
-"minutes. To see the \"delete\" button in articles of the type \"communication"
-"\" (emails, calls), their visibility has to be switched to internal first."
+"minutes. To see the \"delete\" button in articles of the type "
+"\"communication\" (emails, calls), their visibility has to be switched to "
+"internal first."
 msgstr ""
 
 #: ../basics/service-ticket/follow-up.rst:107
@@ -2682,7 +2683,8 @@ msgid ""
 "problematic *per se,* but it does lead to a lot of unnecessary clutter in "
 "the :doc:`overviews menu </basics/find-ticket>`. (It can be much worse when, "
 "for example, a customer service rep sees tickets meant for your HR "
-"department, and finds out how much their colleagues in sales are making! 💸💸💸)"
+"department, and finds out how much their colleagues in sales are making! 💸💸"
+"💸)"
 msgstr ""
 
 #: ../basics/service-ticket/settings/group.rst:25
@@ -4403,8 +4405,8 @@ msgstr ""
 
 #: ../extras/chat.rst:51
 msgid ""
-"📝 Chats can be **renamed** or **tagged**, and record technical details about "
-"the customer’s connection."
+"📝 Chats can be **renamed** or **tagged**, and record technical details "
+"about the customer’s connection."
 msgstr ""
 
 #: ../extras/chat.rst:0
@@ -5091,42 +5093,48 @@ msgid ""
 "permissions"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:0
-msgid "Permissions of a parent category are inherited!"
+#: ../extras/knowledge-base.rst:162
+msgid ""
+"In general, permissions of a parent category are inherited! If you want to "
+"grant edit permissions for a sub-category for a specific role for example, "
+"set the upper level to \"reader\" and the desired sub-category to "
+"\"editor\". The other way round is not possible (permissions can only be "
+"widened, not restricted). If you can't select permissions in the table, this "
+"could be the reason."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:0
-msgid "Public answers are always available!"
+#: ../extras/knowledge-base.rst:169
+msgid "Be aware that public answers are always available!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:165
+#: ../extras/knowledge-base.rst:171
 msgid "**⚙️ Roles require knowledge base reader permission**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:167
+#: ../extras/knowledge-base.rst:173
 msgid ""
 "Your administrator has to provide the relevant groups with reader "
 "permissions for the knowledge base."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:170
+#: ../extras/knowledge-base.rst:176
 msgid "**🥵 Beware of visibility levels**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:172
+#: ../extras/knowledge-base.rst:178
 msgid ""
 "Knowledge base reader permission means that affected users can see "
 "**internal answers**. This is a potential issue if you're not dividing "
 "carefully!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:176
+#: ../extras/knowledge-base.rst:182
 msgid ""
 "If you're unsure, please ask your administrator to configure the :admin-docs:"
 "`role permissions </manage/roles/agent-permissions.html>` accordingly."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:181
+#: ../extras/knowledge-base.rst:187
 msgid "Editing Answers"
 msgstr ""
 
@@ -5134,7 +5142,7 @@ msgstr ""
 msgid "Edit answer"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:187
+#: ../extras/knowledge-base.rst:193
 msgid ""
 "The knowledge base editor comes equipped with the same **rich text editing "
 "capabilities** available in the Zammad ticket composer. That means you can "
@@ -5143,19 +5151,19 @@ msgid ""
 "attachments and links!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:193
+#: ../extras/knowledge-base.rst:199
 msgid "🤷 **Why are there four kinds of links?**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:196
+#: ../extras/knowledge-base.rst:202
 msgid "🔗 **Weblink**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:196
+#: ../extras/knowledge-base.rst:202
 msgid "URLs pointing to other websites."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:200
+#: ../extras/knowledge-base.rst:206
 msgid "💡 **Link Answer**"
 msgstr ""
 
@@ -5167,7 +5175,7 @@ msgstr ""
 msgid "(Will not break if destination URL changes.)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:204
+#: ../extras/knowledge-base.rst:210
 msgid "📋 **Linked Tickets**"
 msgstr ""
 
@@ -5179,7 +5187,7 @@ msgstr ""
 msgid "(Visible only in Preview and Edit Modes.)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:211
+#: ../extras/knowledge-base.rst:217
 msgid "🏷️ **Tags**"
 msgstr ""
 
@@ -5197,38 +5205,38 @@ msgstr ""
 msgid "Screencast showing tags on answers"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:216
+#: ../extras/knowledge-base.rst:222
 msgid ""
 "🙈 Set the **visibility** of an answer to control who can see an article, or "
 "schedule it to be published at a later date. Articles are **color-coded** "
 "according to their visibility:"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:221
+#: ../extras/knowledge-base.rst:227
 msgid "**Public** (visible to everyone)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:223
+#: ../extras/knowledge-base.rst:229
 msgid "|blu|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:223
+#: ../extras/knowledge-base.rst:229
 msgid "**Internal** (visible to agents & editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:225
+#: ../extras/knowledge-base.rst:231
 msgid "|gry|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:225
+#: ../extras/knowledge-base.rst:231
 msgid "**Draft/Scheduled/Archived** (visible to editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:241
+#: ../extras/knowledge-base.rst:247
 msgid "Using answers in ticket articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:243
+#: ../extras/knowledge-base.rst:249
 msgid ""
 "As soon as the knowledge base contains one or more answers, you can use "
 "these just like text modules. Instead of ``::`` just use ``??`` to open the "
@@ -5236,22 +5244,22 @@ msgid ""
 "all languages available."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:248
+#: ../extras/knowledge-base.rst:254
 msgid ""
 "If you've found what you've been looking for, simply hit your ENTER-Key to "
 "load the answer into the ticket article. This way you don't have to throw "
 "URLs at your customer and provide the answer right away."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:252
+#: ../extras/knowledge-base.rst:258
 msgid "Loading answers into articles *does not* replace article content."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:258
+#: ../extras/knowledge-base.rst:264
 msgid "Screencast showing how to insert KB answers into articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:258
+#: ../extras/knowledge-base.rst:264
 msgid "Use ``??`` to find and load knowledge base answers into ticket articles"
 msgstr ""
 
@@ -6403,8 +6411,8 @@ msgstr ""
 
 #: ../extras/shared-drafts.rst:50
 msgid ""
-"If you're in a new ticket dialogue *after selecting the ticket group*, the 📝 "
-"button will indicate the shared drafts function to be available."
+"If you're in a new ticket dialogue *after selecting the ticket group*, the "
+"📝 button will indicate the shared drafts function to be available."
 msgstr ""
 
 #: ../extras/shared-drafts.rst:55

--- a/locale/hr/LC_MESSAGES/user-docs.po
+++ b/locale/hr/LC_MESSAGES/user-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-09 13:15+0100\n"
+"POT-Creation-Date: 2023-12-04 12:38+0100\n"
 "PO-Revision-Date: 2022-06-15 14:40+0000\n"
 "Last-Translator: Ivan Perovic <ip@zammad.com>\n"
 "Language-Team: Croatian <https://translations.zammad.org/projects/"
@@ -16,8 +16,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 4.12.1\n"
 
 #: ../advanced/keyboard-shortcuts.rst:4
@@ -1398,7 +1398,7 @@ msgid ""
 msgstr ""
 
 #: ../snippets/ticket-state-type-circles.rst:4
-#: ../snippets/ticket-state-type-circles.rst:6 ../extras/knowledge-base.rst:221
+#: ../snippets/ticket-state-type-circles.rst:6 ../extras/knowledge-base.rst:227
 msgid "|grn|"
 msgstr ""
 
@@ -2164,9 +2164,9 @@ msgstr ""
 
 #: ../basics/service-ticket/create.rst:58
 msgid ""
-"📞 For phone calls, record the details of your conversation. These notes will "
-"not be sent to the customer (though he may be able to see them if he has a "
-"Zammad account)."
+"📞 For phone calls, record the details of your conversation. These notes "
+"will not be sent to the customer (though he may be able to see them if he "
+"has a Zammad account)."
 msgstr ""
 
 #: ../basics/service-ticket/create.rst:62
@@ -2175,8 +2175,8 @@ msgstr ""
 
 #: ../snippets/ui-protip-message-editor-features.rst:3
 msgid ""
-"The message editor supports 📋 copying-and-pasting (or dragging-and-dropping) "
-"of **🔤 rich text**, **🌄 images** and **📎 file attachments**."
+"The message editor supports 📋 copying-and-pasting (or dragging-and-"
+"dropping) of **🔤 rich text**, **🌄 images** and **📎 file attachments**."
 msgstr ""
 
 #: ../snippets/ui-protip-message-editor-features.rst:6
@@ -2371,8 +2371,9 @@ msgstr ""
 msgid ""
 "What about the **deletion of articles**? In Zammad, you can only delete "
 "articles that you have created yourself and which are not older than 10 "
-"minutes. To see the \"delete\" button in articles of the type \"communication"
-"\" (emails, calls), their visibility has to be switched to internal first."
+"minutes. To see the \"delete\" button in articles of the type "
+"\"communication\" (emails, calls), their visibility has to be switched to "
+"internal first."
 msgstr ""
 
 #: ../basics/service-ticket/follow-up.rst:107
@@ -2593,7 +2594,8 @@ msgid ""
 "problematic *per se,* but it does lead to a lot of unnecessary clutter in "
 "the :doc:`overviews menu </basics/find-ticket>`. (It can be much worse when, "
 "for example, a customer service rep sees tickets meant for your HR "
-"department, and finds out how much their colleagues in sales are making! 💸💸💸)"
+"department, and finds out how much their colleagues in sales are making! 💸💸"
+"💸)"
 msgstr ""
 
 #: ../basics/service-ticket/settings/group.rst:25
@@ -4302,8 +4304,8 @@ msgstr ""
 
 #: ../extras/chat.rst:51
 msgid ""
-"📝 Chats can be **renamed** or **tagged**, and record technical details about "
-"the customer’s connection."
+"📝 Chats can be **renamed** or **tagged**, and record technical details "
+"about the customer’s connection."
 msgstr ""
 
 #: ../extras/chat.rst:0
@@ -4987,42 +4989,48 @@ msgid ""
 "permissions"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:0
-msgid "Permissions of a parent category are inherited!"
+#: ../extras/knowledge-base.rst:162
+msgid ""
+"In general, permissions of a parent category are inherited! If you want to "
+"grant edit permissions for a sub-category for a specific role for example, "
+"set the upper level to \"reader\" and the desired sub-category to "
+"\"editor\". The other way round is not possible (permissions can only be "
+"widened, not restricted). If you can't select permissions in the table, this "
+"could be the reason."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:0
-msgid "Public answers are always available!"
+#: ../extras/knowledge-base.rst:169
+msgid "Be aware that public answers are always available!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:165
+#: ../extras/knowledge-base.rst:171
 msgid "**⚙️ Roles require knowledge base reader permission**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:167
+#: ../extras/knowledge-base.rst:173
 msgid ""
 "Your administrator has to provide the relevant groups with reader "
 "permissions for the knowledge base."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:170
+#: ../extras/knowledge-base.rst:176
 msgid "**🥵 Beware of visibility levels**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:172
+#: ../extras/knowledge-base.rst:178
 msgid ""
 "Knowledge base reader permission means that affected users can see "
 "**internal answers**. This is a potential issue if you're not dividing "
 "carefully!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:176
+#: ../extras/knowledge-base.rst:182
 msgid ""
 "If you're unsure, please ask your administrator to configure the :admin-docs:"
 "`role permissions </manage/roles/agent-permissions.html>` accordingly."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:181
+#: ../extras/knowledge-base.rst:187
 msgid "Editing Answers"
 msgstr ""
 
@@ -5030,7 +5038,7 @@ msgstr ""
 msgid "Edit answer"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:187
+#: ../extras/knowledge-base.rst:193
 msgid ""
 "The knowledge base editor comes equipped with the same **rich text editing "
 "capabilities** available in the Zammad ticket composer. That means you can "
@@ -5039,19 +5047,19 @@ msgid ""
 "attachments and links!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:193
+#: ../extras/knowledge-base.rst:199
 msgid "🤷 **Why are there four kinds of links?**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:196
+#: ../extras/knowledge-base.rst:202
 msgid "🔗 **Weblink**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:196
+#: ../extras/knowledge-base.rst:202
 msgid "URLs pointing to other websites."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:200
+#: ../extras/knowledge-base.rst:206
 msgid "💡 **Link Answer**"
 msgstr ""
 
@@ -5063,7 +5071,7 @@ msgstr ""
 msgid "(Will not break if destination URL changes.)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:204
+#: ../extras/knowledge-base.rst:210
 msgid "📋 **Linked Tickets**"
 msgstr ""
 
@@ -5075,7 +5083,7 @@ msgstr ""
 msgid "(Visible only in Preview and Edit Modes.)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:211
+#: ../extras/knowledge-base.rst:217
 msgid "🏷️ **Tags**"
 msgstr ""
 
@@ -5093,38 +5101,38 @@ msgstr ""
 msgid "Screencast showing tags on answers"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:216
+#: ../extras/knowledge-base.rst:222
 msgid ""
 "🙈 Set the **visibility** of an answer to control who can see an article, or "
 "schedule it to be published at a later date. Articles are **color-coded** "
 "according to their visibility:"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:221
+#: ../extras/knowledge-base.rst:227
 msgid "**Public** (visible to everyone)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:223
+#: ../extras/knowledge-base.rst:229
 msgid "|blu|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:223
+#: ../extras/knowledge-base.rst:229
 msgid "**Internal** (visible to agents & editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:225
+#: ../extras/knowledge-base.rst:231
 msgid "|gry|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:225
+#: ../extras/knowledge-base.rst:231
 msgid "**Draft/Scheduled/Archived** (visible to editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:241
+#: ../extras/knowledge-base.rst:247
 msgid "Using answers in ticket articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:243
+#: ../extras/knowledge-base.rst:249
 msgid ""
 "As soon as the knowledge base contains one or more answers, you can use "
 "these just like text modules. Instead of ``::`` just use ``??`` to open the "
@@ -5132,22 +5140,22 @@ msgid ""
 "all languages available."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:248
+#: ../extras/knowledge-base.rst:254
 msgid ""
 "If you've found what you've been looking for, simply hit your ENTER-Key to "
 "load the answer into the ticket article. This way you don't have to throw "
 "URLs at your customer and provide the answer right away."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:252
+#: ../extras/knowledge-base.rst:258
 msgid "Loading answers into articles *does not* replace article content."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:258
+#: ../extras/knowledge-base.rst:264
 msgid "Screencast showing how to insert KB answers into articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:258
+#: ../extras/knowledge-base.rst:264
 msgid "Use ``??`` to find and load knowledge base answers into ticket articles"
 msgstr ""
 
@@ -6283,8 +6291,8 @@ msgstr ""
 
 #: ../extras/shared-drafts.rst:50
 msgid ""
-"If you're in a new ticket dialogue *after selecting the ticket group*, the 📝 "
-"button will indicate the shared drafts function to be available."
+"If you're in a new ticket dialogue *after selecting the ticket group*, the "
+"📝 button will indicate the shared drafts function to be available."
 msgstr ""
 
 #: ../extras/shared-drafts.rst:55

--- a/locale/hu/LC_MESSAGES/user-docs.po
+++ b/locale/hu/LC_MESSAGES/user-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-09 13:15+0100\n"
+"POT-Creation-Date: 2023-12-04 12:38+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -1271,7 +1271,7 @@ msgid ""
 msgstr ""
 
 #: ../snippets/ticket-state-type-circles.rst:4
-#: ../snippets/ticket-state-type-circles.rst:6 ../extras/knowledge-base.rst:221
+#: ../snippets/ticket-state-type-circles.rst:6 ../extras/knowledge-base.rst:227
 msgid "|grn|"
 msgstr ""
 
@@ -2035,9 +2035,9 @@ msgstr ""
 
 #: ../basics/service-ticket/create.rst:58
 msgid ""
-"📞 For phone calls, record the details of your conversation. These notes will "
-"not be sent to the customer (though he may be able to see them if he has a "
-"Zammad account)."
+"📞 For phone calls, record the details of your conversation. These notes "
+"will not be sent to the customer (though he may be able to see them if he "
+"has a Zammad account)."
 msgstr ""
 
 #: ../basics/service-ticket/create.rst:62
@@ -2046,8 +2046,8 @@ msgstr ""
 
 #: ../snippets/ui-protip-message-editor-features.rst:3
 msgid ""
-"The message editor supports 📋 copying-and-pasting (or dragging-and-dropping) "
-"of **🔤 rich text**, **🌄 images** and **📎 file attachments**."
+"The message editor supports 📋 copying-and-pasting (or dragging-and-"
+"dropping) of **🔤 rich text**, **🌄 images** and **📎 file attachments**."
 msgstr ""
 
 #: ../snippets/ui-protip-message-editor-features.rst:6
@@ -2242,8 +2242,9 @@ msgstr ""
 msgid ""
 "What about the **deletion of articles**? In Zammad, you can only delete "
 "articles that you have created yourself and which are not older than 10 "
-"minutes. To see the \"delete\" button in articles of the type \"communication"
-"\" (emails, calls), their visibility has to be switched to internal first."
+"minutes. To see the \"delete\" button in articles of the type "
+"\"communication\" (emails, calls), their visibility has to be switched to "
+"internal first."
 msgstr ""
 
 #: ../basics/service-ticket/follow-up.rst:107
@@ -2464,7 +2465,8 @@ msgid ""
 "problematic *per se,* but it does lead to a lot of unnecessary clutter in "
 "the :doc:`overviews menu </basics/find-ticket>`. (It can be much worse when, "
 "for example, a customer service rep sees tickets meant for your HR "
-"department, and finds out how much their colleagues in sales are making! 💸💸💸)"
+"department, and finds out how much their colleagues in sales are making! 💸💸"
+"💸)"
 msgstr ""
 
 #: ../basics/service-ticket/settings/group.rst:25
@@ -4173,8 +4175,8 @@ msgstr ""
 
 #: ../extras/chat.rst:51
 msgid ""
-"📝 Chats can be **renamed** or **tagged**, and record technical details about "
-"the customer’s connection."
+"📝 Chats can be **renamed** or **tagged**, and record technical details "
+"about the customer’s connection."
 msgstr ""
 
 #: ../extras/chat.rst:0
@@ -4856,42 +4858,48 @@ msgid ""
 "permissions"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:0
-msgid "Permissions of a parent category are inherited!"
+#: ../extras/knowledge-base.rst:162
+msgid ""
+"In general, permissions of a parent category are inherited! If you want to "
+"grant edit permissions for a sub-category for a specific role for example, "
+"set the upper level to \"reader\" and the desired sub-category to "
+"\"editor\". The other way round is not possible (permissions can only be "
+"widened, not restricted). If you can't select permissions in the table, this "
+"could be the reason."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:0
-msgid "Public answers are always available!"
+#: ../extras/knowledge-base.rst:169
+msgid "Be aware that public answers are always available!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:165
+#: ../extras/knowledge-base.rst:171
 msgid "**⚙️ Roles require knowledge base reader permission**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:167
+#: ../extras/knowledge-base.rst:173
 msgid ""
 "Your administrator has to provide the relevant groups with reader "
 "permissions for the knowledge base."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:170
+#: ../extras/knowledge-base.rst:176
 msgid "**🥵 Beware of visibility levels**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:172
+#: ../extras/knowledge-base.rst:178
 msgid ""
 "Knowledge base reader permission means that affected users can see "
 "**internal answers**. This is a potential issue if you're not dividing "
 "carefully!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:176
+#: ../extras/knowledge-base.rst:182
 msgid ""
 "If you're unsure, please ask your administrator to configure the :admin-docs:"
 "`role permissions </manage/roles/agent-permissions.html>` accordingly."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:181
+#: ../extras/knowledge-base.rst:187
 msgid "Editing Answers"
 msgstr ""
 
@@ -4899,7 +4907,7 @@ msgstr ""
 msgid "Edit answer"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:187
+#: ../extras/knowledge-base.rst:193
 msgid ""
 "The knowledge base editor comes equipped with the same **rich text editing "
 "capabilities** available in the Zammad ticket composer. That means you can "
@@ -4908,19 +4916,19 @@ msgid ""
 "attachments and links!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:193
+#: ../extras/knowledge-base.rst:199
 msgid "🤷 **Why are there four kinds of links?**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:196
+#: ../extras/knowledge-base.rst:202
 msgid "🔗 **Weblink**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:196
+#: ../extras/knowledge-base.rst:202
 msgid "URLs pointing to other websites."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:200
+#: ../extras/knowledge-base.rst:206
 msgid "💡 **Link Answer**"
 msgstr ""
 
@@ -4932,7 +4940,7 @@ msgstr ""
 msgid "(Will not break if destination URL changes.)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:204
+#: ../extras/knowledge-base.rst:210
 msgid "📋 **Linked Tickets**"
 msgstr ""
 
@@ -4944,7 +4952,7 @@ msgstr ""
 msgid "(Visible only in Preview and Edit Modes.)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:211
+#: ../extras/knowledge-base.rst:217
 msgid "🏷️ **Tags**"
 msgstr ""
 
@@ -4962,38 +4970,38 @@ msgstr ""
 msgid "Screencast showing tags on answers"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:216
+#: ../extras/knowledge-base.rst:222
 msgid ""
 "🙈 Set the **visibility** of an answer to control who can see an article, or "
 "schedule it to be published at a later date. Articles are **color-coded** "
 "according to their visibility:"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:221
+#: ../extras/knowledge-base.rst:227
 msgid "**Public** (visible to everyone)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:223
+#: ../extras/knowledge-base.rst:229
 msgid "|blu|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:223
+#: ../extras/knowledge-base.rst:229
 msgid "**Internal** (visible to agents & editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:225
+#: ../extras/knowledge-base.rst:231
 msgid "|gry|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:225
+#: ../extras/knowledge-base.rst:231
 msgid "**Draft/Scheduled/Archived** (visible to editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:241
+#: ../extras/knowledge-base.rst:247
 msgid "Using answers in ticket articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:243
+#: ../extras/knowledge-base.rst:249
 msgid ""
 "As soon as the knowledge base contains one or more answers, you can use "
 "these just like text modules. Instead of ``::`` just use ``??`` to open the "
@@ -5001,22 +5009,22 @@ msgid ""
 "all languages available."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:248
+#: ../extras/knowledge-base.rst:254
 msgid ""
 "If you've found what you've been looking for, simply hit your ENTER-Key to "
 "load the answer into the ticket article. This way you don't have to throw "
 "URLs at your customer and provide the answer right away."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:252
+#: ../extras/knowledge-base.rst:258
 msgid "Loading answers into articles *does not* replace article content."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:258
+#: ../extras/knowledge-base.rst:264
 msgid "Screencast showing how to insert KB answers into articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:258
+#: ../extras/knowledge-base.rst:264
 msgid "Use ``??`` to find and load knowledge base answers into ticket articles"
 msgstr ""
 
@@ -6138,8 +6146,8 @@ msgstr ""
 
 #: ../extras/shared-drafts.rst:50
 msgid ""
-"If you're in a new ticket dialogue *after selecting the ticket group*, the 📝 "
-"button will indicate the shared drafts function to be available."
+"If you're in a new ticket dialogue *after selecting the ticket group*, the "
+"📝 button will indicate the shared drafts function to be available."
 msgstr ""
 
 #: ../extras/shared-drafts.rst:55

--- a/locale/it/LC_MESSAGES/user-docs.po
+++ b/locale/it/LC_MESSAGES/user-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-09 13:15+0100\n"
+"POT-Creation-Date: 2023-12-04 12:38+0100\n"
 "PO-Revision-Date: 2023-07-28 09:18+0000\n"
 "Last-Translator: crnfpp <crnfpp@unife.it>\n"
 "Language-Team: Italian <https://translations.zammad.org/projects/"
@@ -1348,7 +1348,7 @@ msgstr ""
 "**identificato da un colore:**"
 
 #: ../snippets/ticket-state-type-circles.rst:4
-#: ../snippets/ticket-state-type-circles.rst:6 ../extras/knowledge-base.rst:221
+#: ../snippets/ticket-state-type-circles.rst:6 ../extras/knowledge-base.rst:227
 msgid "|grn|"
 msgstr "|grn|"
 
@@ -2006,7 +2006,8 @@ msgstr ""
 #: ../basics/find-ticket/search.rst:15
 msgid "**🔍 Here are just a few of the places the search engine will look:**"
 msgstr ""
-"**🔍 Queste sono alcune delle sezioni in cui il motore di ricerca esaminerà:**"
+"**🔍 Queste sono alcune delle sezioni in cui il motore di ricerca esaminerà:"
+"**"
 
 #: ../basics/find-ticket/search.rst:17
 msgid "📝 message subject/content"
@@ -2184,12 +2185,12 @@ msgstr "Messaggio"
 
 #: ../basics/service-ticket/create.rst:58
 msgid ""
-"📞 For phone calls, record the details of your conversation. These notes will "
-"not be sent to the customer (though he may be able to see them if he has a "
-"Zammad account)."
+"📞 For phone calls, record the details of your conversation. These notes "
+"will not be sent to the customer (though he may be able to see them if he "
+"has a Zammad account)."
 msgstr ""
-"📞 Per le chiamate, trascrivi i dettagli della conversazione. Queste note non "
-"verranno inviate al cliente (anche se potrebbe vederle se ha un account "
+"📞 Per le chiamate, trascrivi i dettagli della conversazione. Queste note "
+"non verranno inviate al cliente (anche se potrebbe vederle se ha un account "
 "Zammad)."
 
 #: ../basics/service-ticket/create.rst:62
@@ -2198,8 +2199,8 @@ msgstr "📧 Per le email, questo è il corpo del messaggio da inviare."
 
 #: ../snippets/ui-protip-message-editor-features.rst:3
 msgid ""
-"The message editor supports 📋 copying-and-pasting (or dragging-and-dropping) "
-"of **🔤 rich text**, **🌄 images** and **📎 file attachments**."
+"The message editor supports 📋 copying-and-pasting (or dragging-and-"
+"dropping) of **🔤 rich text**, **🌄 images** and **📎 file attachments**."
 msgstr ""
 "L'editor dei message supporta 📋 il copia e incolla (o il drag and drop) di "
 "**🔤 testo formattato**, **🌄 immagini** e **📎 allegati**."
@@ -2440,8 +2441,9 @@ msgstr ""
 msgid ""
 "What about the **deletion of articles**? In Zammad, you can only delete "
 "articles that you have created yourself and which are not older than 10 "
-"minutes. To see the \"delete\" button in articles of the type \"communication"
-"\" (emails, calls), their visibility has to be switched to internal first."
+"minutes. To see the \"delete\" button in articles of the type "
+"\"communication\" (emails, calls), their visibility has to be switched to "
+"internal first."
 msgstr ""
 
 #: ../basics/service-ticket/follow-up.rst:107
@@ -2708,15 +2710,16 @@ msgid ""
 "problematic *per se,* but it does lead to a lot of unnecessary clutter in "
 "the :doc:`overviews menu </basics/find-ticket>`. (It can be much worse when, "
 "for example, a customer service rep sees tickets meant for your HR "
-"department, and finds out how much their colleagues in sales are making! 💸💸💸)"
+"department, and finds out how much their colleagues in sales are making! 💸💸"
+"💸)"
 msgstr ""
 "Senza i gruppi, tutti e dieci gli agenti possono vedere e inserire risposte "
 "in ogni ticket, qualunque sia il loro team. Questo non è problematico di per "
 "se, ma porta a della confusione non necessaria nel :doc: menù panoramiche </"
 "basics/find-ticket>`. (Potrebbe essere molto peggio se, ad esempio, un "
 "agente dell'assistenza clienti vede un ticket per il dipartimento di risorse "
-"umane e scopre quanto guadagnano i suoi colleghi del dipartimento vendite! 💸💸"
-"💸)"
+"umane e scopre quanto guadagnano i suoi colleghi del dipartimento vendite! 💸"
+"💸💸)"
 
 #: ../basics/service-ticket/settings/group.rst:25
 msgid ""
@@ -4326,8 +4329,8 @@ msgid ""
 "instance**. The number of entries shown depends on the configuration your "
 "admin chose."
 msgstr ""
-"🏢 Il registro chiamate mostra tutte le chiamate in ingresso e in uscita **di "
-"tutto il team**."
+"🏢 Il registro chiamate mostra tutte le chiamate in ingresso e in uscita "
+"**di tutto il team**."
 
 #: ../extras/caller-log.rst:25
 msgid ""
@@ -4551,8 +4554,8 @@ msgstr ""
 
 #: ../extras/chat.rst:51
 msgid ""
-"📝 Chats can be **renamed** or **tagged**, and record technical details about "
-"the customer’s connection."
+"📝 Chats can be **renamed** or **tagged**, and record technical details "
+"about the customer’s connection."
 msgstr ""
 
 #: ../extras/chat.rst:0
@@ -5258,42 +5261,48 @@ msgid ""
 "permissions"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:0
-msgid "Permissions of a parent category are inherited!"
+#: ../extras/knowledge-base.rst:162
+msgid ""
+"In general, permissions of a parent category are inherited! If you want to "
+"grant edit permissions for a sub-category for a specific role for example, "
+"set the upper level to \"reader\" and the desired sub-category to "
+"\"editor\". The other way round is not possible (permissions can only be "
+"widened, not restricted). If you can't select permissions in the table, this "
+"could be the reason."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:0
-msgid "Public answers are always available!"
+#: ../extras/knowledge-base.rst:169
+msgid "Be aware that public answers are always available!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:165
+#: ../extras/knowledge-base.rst:171
 msgid "**⚙️ Roles require knowledge base reader permission**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:167
+#: ../extras/knowledge-base.rst:173
 msgid ""
 "Your administrator has to provide the relevant groups with reader "
 "permissions for the knowledge base."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:170
+#: ../extras/knowledge-base.rst:176
 msgid "**🥵 Beware of visibility levels**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:172
+#: ../extras/knowledge-base.rst:178
 msgid ""
 "Knowledge base reader permission means that affected users can see "
 "**internal answers**. This is a potential issue if you're not dividing "
 "carefully!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:176
+#: ../extras/knowledge-base.rst:182
 msgid ""
 "If you're unsure, please ask your administrator to configure the :admin-docs:"
 "`role permissions </manage/roles/agent-permissions.html>` accordingly."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:181
+#: ../extras/knowledge-base.rst:187
 msgid "Editing Answers"
 msgstr ""
 
@@ -5301,7 +5310,7 @@ msgstr ""
 msgid "Edit answer"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:187
+#: ../extras/knowledge-base.rst:193
 msgid ""
 "The knowledge base editor comes equipped with the same **rich text editing "
 "capabilities** available in the Zammad ticket composer. That means you can "
@@ -5310,19 +5319,19 @@ msgid ""
 "attachments and links!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:193
+#: ../extras/knowledge-base.rst:199
 msgid "🤷 **Why are there four kinds of links?**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:196
+#: ../extras/knowledge-base.rst:202
 msgid "🔗 **Weblink**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:196
+#: ../extras/knowledge-base.rst:202
 msgid "URLs pointing to other websites."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:200
+#: ../extras/knowledge-base.rst:206
 msgid "💡 **Link Answer**"
 msgstr ""
 
@@ -5334,7 +5343,7 @@ msgstr ""
 msgid "(Will not break if destination URL changes.)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:204
+#: ../extras/knowledge-base.rst:210
 msgid "📋 **Linked Tickets**"
 msgstr ""
 
@@ -5346,7 +5355,7 @@ msgstr ""
 msgid "(Visible only in Preview and Edit Modes.)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:211
+#: ../extras/knowledge-base.rst:217
 msgid "🏷️ **Tags**"
 msgstr ""
 
@@ -5364,38 +5373,38 @@ msgstr ""
 msgid "Screencast showing tags on answers"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:216
+#: ../extras/knowledge-base.rst:222
 msgid ""
 "🙈 Set the **visibility** of an answer to control who can see an article, or "
 "schedule it to be published at a later date. Articles are **color-coded** "
 "according to their visibility:"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:221
+#: ../extras/knowledge-base.rst:227
 msgid "**Public** (visible to everyone)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:223
+#: ../extras/knowledge-base.rst:229
 msgid "|blu|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:223
+#: ../extras/knowledge-base.rst:229
 msgid "**Internal** (visible to agents & editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:225
+#: ../extras/knowledge-base.rst:231
 msgid "|gry|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:225
+#: ../extras/knowledge-base.rst:231
 msgid "**Draft/Scheduled/Archived** (visible to editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:241
+#: ../extras/knowledge-base.rst:247
 msgid "Using answers in ticket articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:243
+#: ../extras/knowledge-base.rst:249
 msgid ""
 "As soon as the knowledge base contains one or more answers, you can use "
 "these just like text modules. Instead of ``::`` just use ``??`` to open the "
@@ -5403,22 +5412,22 @@ msgid ""
 "all languages available."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:248
+#: ../extras/knowledge-base.rst:254
 msgid ""
 "If you've found what you've been looking for, simply hit your ENTER-Key to "
 "load the answer into the ticket article. This way you don't have to throw "
 "URLs at your customer and provide the answer right away."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:252
+#: ../extras/knowledge-base.rst:258
 msgid "Loading answers into articles *does not* replace article content."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:258
+#: ../extras/knowledge-base.rst:264
 msgid "Screencast showing how to insert KB answers into articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:258
+#: ../extras/knowledge-base.rst:264
 msgid "Use ``??`` to find and load knowledge base answers into ticket articles"
 msgstr ""
 
@@ -6591,8 +6600,8 @@ msgstr ""
 
 #: ../extras/shared-drafts.rst:50
 msgid ""
-"If you're in a new ticket dialogue *after selecting the ticket group*, the 📝 "
-"button will indicate the shared drafts function to be available."
+"If you're in a new ticket dialogue *after selecting the ticket group*, the "
+"📝 button will indicate the shared drafts function to be available."
 msgstr ""
 
 #: ../extras/shared-drafts.rst:55
@@ -7290,8 +7299,8 @@ msgstr ""
 #~ "essere aggiunti a clienti esistenti in questo modo)"
 
 #~ msgid ""
-#~ "Click the **➕ button** to create a new ticket. The default ticket type is "
-#~ "**received call**."
+#~ "Click the **➕ button** to create a new ticket. The default ticket type "
+#~ "is **received call**."
 #~ msgstr ""
 #~ "Clicca il ** bottone➕** per creare un nuovo ticket. La tipologia del "
 #~ "ticket di default sarà **chiamata in ingresso**."

--- a/locale/nl/LC_MESSAGES/user-docs.po
+++ b/locale/nl/LC_MESSAGES/user-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-09 13:15+0100\n"
+"POT-Creation-Date: 2023-12-04 12:38+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -1271,7 +1271,7 @@ msgid ""
 msgstr ""
 
 #: ../snippets/ticket-state-type-circles.rst:4
-#: ../snippets/ticket-state-type-circles.rst:6 ../extras/knowledge-base.rst:221
+#: ../snippets/ticket-state-type-circles.rst:6 ../extras/knowledge-base.rst:227
 msgid "|grn|"
 msgstr ""
 
@@ -2035,9 +2035,9 @@ msgstr ""
 
 #: ../basics/service-ticket/create.rst:58
 msgid ""
-"📞 For phone calls, record the details of your conversation. These notes will "
-"not be sent to the customer (though he may be able to see them if he has a "
-"Zammad account)."
+"📞 For phone calls, record the details of your conversation. These notes "
+"will not be sent to the customer (though he may be able to see them if he "
+"has a Zammad account)."
 msgstr ""
 
 #: ../basics/service-ticket/create.rst:62
@@ -2046,8 +2046,8 @@ msgstr ""
 
 #: ../snippets/ui-protip-message-editor-features.rst:3
 msgid ""
-"The message editor supports 📋 copying-and-pasting (or dragging-and-dropping) "
-"of **🔤 rich text**, **🌄 images** and **📎 file attachments**."
+"The message editor supports 📋 copying-and-pasting (or dragging-and-"
+"dropping) of **🔤 rich text**, **🌄 images** and **📎 file attachments**."
 msgstr ""
 
 #: ../snippets/ui-protip-message-editor-features.rst:6
@@ -2242,8 +2242,9 @@ msgstr ""
 msgid ""
 "What about the **deletion of articles**? In Zammad, you can only delete "
 "articles that you have created yourself and which are not older than 10 "
-"minutes. To see the \"delete\" button in articles of the type \"communication"
-"\" (emails, calls), their visibility has to be switched to internal first."
+"minutes. To see the \"delete\" button in articles of the type "
+"\"communication\" (emails, calls), their visibility has to be switched to "
+"internal first."
 msgstr ""
 
 #: ../basics/service-ticket/follow-up.rst:107
@@ -2464,7 +2465,8 @@ msgid ""
 "problematic *per se,* but it does lead to a lot of unnecessary clutter in "
 "the :doc:`overviews menu </basics/find-ticket>`. (It can be much worse when, "
 "for example, a customer service rep sees tickets meant for your HR "
-"department, and finds out how much their colleagues in sales are making! 💸💸💸)"
+"department, and finds out how much their colleagues in sales are making! 💸💸"
+"💸)"
 msgstr ""
 
 #: ../basics/service-ticket/settings/group.rst:25
@@ -4173,8 +4175,8 @@ msgstr ""
 
 #: ../extras/chat.rst:51
 msgid ""
-"📝 Chats can be **renamed** or **tagged**, and record technical details about "
-"the customer’s connection."
+"📝 Chats can be **renamed** or **tagged**, and record technical details "
+"about the customer’s connection."
 msgstr ""
 
 #: ../extras/chat.rst:0
@@ -4856,42 +4858,48 @@ msgid ""
 "permissions"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:0
-msgid "Permissions of a parent category are inherited!"
+#: ../extras/knowledge-base.rst:162
+msgid ""
+"In general, permissions of a parent category are inherited! If you want to "
+"grant edit permissions for a sub-category for a specific role for example, "
+"set the upper level to \"reader\" and the desired sub-category to "
+"\"editor\". The other way round is not possible (permissions can only be "
+"widened, not restricted). If you can't select permissions in the table, this "
+"could be the reason."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:0
-msgid "Public answers are always available!"
+#: ../extras/knowledge-base.rst:169
+msgid "Be aware that public answers are always available!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:165
+#: ../extras/knowledge-base.rst:171
 msgid "**⚙️ Roles require knowledge base reader permission**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:167
+#: ../extras/knowledge-base.rst:173
 msgid ""
 "Your administrator has to provide the relevant groups with reader "
 "permissions for the knowledge base."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:170
+#: ../extras/knowledge-base.rst:176
 msgid "**🥵 Beware of visibility levels**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:172
+#: ../extras/knowledge-base.rst:178
 msgid ""
 "Knowledge base reader permission means that affected users can see "
 "**internal answers**. This is a potential issue if you're not dividing "
 "carefully!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:176
+#: ../extras/knowledge-base.rst:182
 msgid ""
 "If you're unsure, please ask your administrator to configure the :admin-docs:"
 "`role permissions </manage/roles/agent-permissions.html>` accordingly."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:181
+#: ../extras/knowledge-base.rst:187
 msgid "Editing Answers"
 msgstr ""
 
@@ -4899,7 +4907,7 @@ msgstr ""
 msgid "Edit answer"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:187
+#: ../extras/knowledge-base.rst:193
 msgid ""
 "The knowledge base editor comes equipped with the same **rich text editing "
 "capabilities** available in the Zammad ticket composer. That means you can "
@@ -4908,19 +4916,19 @@ msgid ""
 "attachments and links!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:193
+#: ../extras/knowledge-base.rst:199
 msgid "🤷 **Why are there four kinds of links?**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:196
+#: ../extras/knowledge-base.rst:202
 msgid "🔗 **Weblink**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:196
+#: ../extras/knowledge-base.rst:202
 msgid "URLs pointing to other websites."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:200
+#: ../extras/knowledge-base.rst:206
 msgid "💡 **Link Answer**"
 msgstr ""
 
@@ -4932,7 +4940,7 @@ msgstr ""
 msgid "(Will not break if destination URL changes.)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:204
+#: ../extras/knowledge-base.rst:210
 msgid "📋 **Linked Tickets**"
 msgstr ""
 
@@ -4944,7 +4952,7 @@ msgstr ""
 msgid "(Visible only in Preview and Edit Modes.)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:211
+#: ../extras/knowledge-base.rst:217
 msgid "🏷️ **Tags**"
 msgstr ""
 
@@ -4962,38 +4970,38 @@ msgstr ""
 msgid "Screencast showing tags on answers"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:216
+#: ../extras/knowledge-base.rst:222
 msgid ""
 "🙈 Set the **visibility** of an answer to control who can see an article, or "
 "schedule it to be published at a later date. Articles are **color-coded** "
 "according to their visibility:"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:221
+#: ../extras/knowledge-base.rst:227
 msgid "**Public** (visible to everyone)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:223
+#: ../extras/knowledge-base.rst:229
 msgid "|blu|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:223
+#: ../extras/knowledge-base.rst:229
 msgid "**Internal** (visible to agents & editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:225
+#: ../extras/knowledge-base.rst:231
 msgid "|gry|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:225
+#: ../extras/knowledge-base.rst:231
 msgid "**Draft/Scheduled/Archived** (visible to editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:241
+#: ../extras/knowledge-base.rst:247
 msgid "Using answers in ticket articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:243
+#: ../extras/knowledge-base.rst:249
 msgid ""
 "As soon as the knowledge base contains one or more answers, you can use "
 "these just like text modules. Instead of ``::`` just use ``??`` to open the "
@@ -5001,22 +5009,22 @@ msgid ""
 "all languages available."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:248
+#: ../extras/knowledge-base.rst:254
 msgid ""
 "If you've found what you've been looking for, simply hit your ENTER-Key to "
 "load the answer into the ticket article. This way you don't have to throw "
 "URLs at your customer and provide the answer right away."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:252
+#: ../extras/knowledge-base.rst:258
 msgid "Loading answers into articles *does not* replace article content."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:258
+#: ../extras/knowledge-base.rst:264
 msgid "Screencast showing how to insert KB answers into articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:258
+#: ../extras/knowledge-base.rst:264
 msgid "Use ``??`` to find and load knowledge base answers into ticket articles"
 msgstr ""
 
@@ -6138,8 +6146,8 @@ msgstr ""
 
 #: ../extras/shared-drafts.rst:50
 msgid ""
-"If you're in a new ticket dialogue *after selecting the ticket group*, the 📝 "
-"button will indicate the shared drafts function to be available."
+"If you're in a new ticket dialogue *after selecting the ticket group*, the "
+"📝 button will indicate the shared drafts function to be available."
 msgstr ""
 
 #: ../extras/shared-drafts.rst:55

--- a/locale/pl/LC_MESSAGES/user-docs.po
+++ b/locale/pl/LC_MESSAGES/user-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-09 13:15+0100\n"
+"POT-Creation-Date: 2023-12-04 12:38+0100\n"
 "PO-Revision-Date: 2023-09-29 11:18+0000\n"
 "Last-Translator: SamolJacek <samol.jacek@gmail.com>\n"
 "Language-Team: Polish <https://translations.zammad.org/projects/"
@@ -1426,7 +1426,7 @@ msgid ""
 msgstr ""
 
 #: ../snippets/ticket-state-type-circles.rst:4
-#: ../snippets/ticket-state-type-circles.rst:6 ../extras/knowledge-base.rst:221
+#: ../snippets/ticket-state-type-circles.rst:6 ../extras/knowledge-base.rst:227
 msgid "|grn|"
 msgstr ""
 
@@ -2190,9 +2190,9 @@ msgstr ""
 
 #: ../basics/service-ticket/create.rst:58
 msgid ""
-"📞 For phone calls, record the details of your conversation. These notes will "
-"not be sent to the customer (though he may be able to see them if he has a "
-"Zammad account)."
+"📞 For phone calls, record the details of your conversation. These notes "
+"will not be sent to the customer (though he may be able to see them if he "
+"has a Zammad account)."
 msgstr ""
 
 #: ../basics/service-ticket/create.rst:62
@@ -2201,8 +2201,8 @@ msgstr ""
 
 #: ../snippets/ui-protip-message-editor-features.rst:3
 msgid ""
-"The message editor supports 📋 copying-and-pasting (or dragging-and-dropping) "
-"of **🔤 rich text**, **🌄 images** and **📎 file attachments**."
+"The message editor supports 📋 copying-and-pasting (or dragging-and-"
+"dropping) of **🔤 rich text**, **🌄 images** and **📎 file attachments**."
 msgstr ""
 
 #: ../snippets/ui-protip-message-editor-features.rst:6
@@ -2397,8 +2397,9 @@ msgstr ""
 msgid ""
 "What about the **deletion of articles**? In Zammad, you can only delete "
 "articles that you have created yourself and which are not older than 10 "
-"minutes. To see the \"delete\" button in articles of the type \"communication"
-"\" (emails, calls), their visibility has to be switched to internal first."
+"minutes. To see the \"delete\" button in articles of the type "
+"\"communication\" (emails, calls), their visibility has to be switched to "
+"internal first."
 msgstr ""
 
 #: ../basics/service-ticket/follow-up.rst:107
@@ -2619,7 +2620,8 @@ msgid ""
 "problematic *per se,* but it does lead to a lot of unnecessary clutter in "
 "the :doc:`overviews menu </basics/find-ticket>`. (It can be much worse when, "
 "for example, a customer service rep sees tickets meant for your HR "
-"department, and finds out how much their colleagues in sales are making! 💸💸💸)"
+"department, and finds out how much their colleagues in sales are making! 💸💸"
+"💸)"
 msgstr ""
 
 #: ../basics/service-ticket/settings/group.rst:25
@@ -4340,8 +4342,8 @@ msgstr ""
 
 #: ../extras/chat.rst:51
 msgid ""
-"📝 Chats can be **renamed** or **tagged**, and record technical details about "
-"the customer’s connection."
+"📝 Chats can be **renamed** or **tagged**, and record technical details "
+"about the customer’s connection."
 msgstr ""
 
 #: ../extras/chat.rst:0
@@ -5023,42 +5025,48 @@ msgid ""
 "permissions"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:0
-msgid "Permissions of a parent category are inherited!"
+#: ../extras/knowledge-base.rst:162
+msgid ""
+"In general, permissions of a parent category are inherited! If you want to "
+"grant edit permissions for a sub-category for a specific role for example, "
+"set the upper level to \"reader\" and the desired sub-category to "
+"\"editor\". The other way round is not possible (permissions can only be "
+"widened, not restricted). If you can't select permissions in the table, this "
+"could be the reason."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:0
-msgid "Public answers are always available!"
+#: ../extras/knowledge-base.rst:169
+msgid "Be aware that public answers are always available!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:165
+#: ../extras/knowledge-base.rst:171
 msgid "**⚙️ Roles require knowledge base reader permission**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:167
+#: ../extras/knowledge-base.rst:173
 msgid ""
 "Your administrator has to provide the relevant groups with reader "
 "permissions for the knowledge base."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:170
+#: ../extras/knowledge-base.rst:176
 msgid "**🥵 Beware of visibility levels**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:172
+#: ../extras/knowledge-base.rst:178
 msgid ""
 "Knowledge base reader permission means that affected users can see "
 "**internal answers**. This is a potential issue if you're not dividing "
 "carefully!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:176
+#: ../extras/knowledge-base.rst:182
 msgid ""
 "If you're unsure, please ask your administrator to configure the :admin-docs:"
 "`role permissions </manage/roles/agent-permissions.html>` accordingly."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:181
+#: ../extras/knowledge-base.rst:187
 msgid "Editing Answers"
 msgstr ""
 
@@ -5066,7 +5074,7 @@ msgstr ""
 msgid "Edit answer"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:187
+#: ../extras/knowledge-base.rst:193
 msgid ""
 "The knowledge base editor comes equipped with the same **rich text editing "
 "capabilities** available in the Zammad ticket composer. That means you can "
@@ -5075,19 +5083,19 @@ msgid ""
 "attachments and links!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:193
+#: ../extras/knowledge-base.rst:199
 msgid "🤷 **Why are there four kinds of links?**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:196
+#: ../extras/knowledge-base.rst:202
 msgid "🔗 **Weblink**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:196
+#: ../extras/knowledge-base.rst:202
 msgid "URLs pointing to other websites."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:200
+#: ../extras/knowledge-base.rst:206
 msgid "💡 **Link Answer**"
 msgstr ""
 
@@ -5099,7 +5107,7 @@ msgstr ""
 msgid "(Will not break if destination URL changes.)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:204
+#: ../extras/knowledge-base.rst:210
 msgid "📋 **Linked Tickets**"
 msgstr ""
 
@@ -5111,7 +5119,7 @@ msgstr ""
 msgid "(Visible only in Preview and Edit Modes.)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:211
+#: ../extras/knowledge-base.rst:217
 msgid "🏷️ **Tags**"
 msgstr ""
 
@@ -5129,38 +5137,38 @@ msgstr ""
 msgid "Screencast showing tags on answers"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:216
+#: ../extras/knowledge-base.rst:222
 msgid ""
 "🙈 Set the **visibility** of an answer to control who can see an article, or "
 "schedule it to be published at a later date. Articles are **color-coded** "
 "according to their visibility:"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:221
+#: ../extras/knowledge-base.rst:227
 msgid "**Public** (visible to everyone)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:223
+#: ../extras/knowledge-base.rst:229
 msgid "|blu|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:223
+#: ../extras/knowledge-base.rst:229
 msgid "**Internal** (visible to agents & editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:225
+#: ../extras/knowledge-base.rst:231
 msgid "|gry|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:225
+#: ../extras/knowledge-base.rst:231
 msgid "**Draft/Scheduled/Archived** (visible to editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:241
+#: ../extras/knowledge-base.rst:247
 msgid "Using answers in ticket articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:243
+#: ../extras/knowledge-base.rst:249
 msgid ""
 "As soon as the knowledge base contains one or more answers, you can use "
 "these just like text modules. Instead of ``::`` just use ``??`` to open the "
@@ -5168,22 +5176,22 @@ msgid ""
 "all languages available."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:248
+#: ../extras/knowledge-base.rst:254
 msgid ""
 "If you've found what you've been looking for, simply hit your ENTER-Key to "
 "load the answer into the ticket article. This way you don't have to throw "
 "URLs at your customer and provide the answer right away."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:252
+#: ../extras/knowledge-base.rst:258
 msgid "Loading answers into articles *does not* replace article content."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:258
+#: ../extras/knowledge-base.rst:264
 msgid "Screencast showing how to insert KB answers into articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:258
+#: ../extras/knowledge-base.rst:264
 msgid "Use ``??`` to find and load knowledge base answers into ticket articles"
 msgstr ""
 
@@ -6305,8 +6313,8 @@ msgstr ""
 
 #: ../extras/shared-drafts.rst:50
 msgid ""
-"If you're in a new ticket dialogue *after selecting the ticket group*, the 📝 "
-"button will indicate the shared drafts function to be available."
+"If you're in a new ticket dialogue *after selecting the ticket group*, the "
+"📝 button will indicate the shared drafts function to be available."
 msgstr ""
 
 #: ../extras/shared-drafts.rst:55

--- a/locale/pt_BR/LC_MESSAGES/user-docs.po
+++ b/locale/pt_BR/LC_MESSAGES/user-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-09 13:15+0100\n"
+"POT-Creation-Date: 2023-12-04 12:38+0100\n"
 "PO-Revision-Date: 2022-08-01 14:09+0000\n"
 "Last-Translator: Erico Cesar <ericocesar@webck.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://translations.zammad.org/projects/"
@@ -1389,7 +1389,7 @@ msgstr ""
 "**representadas por cores:**"
 
 #: ../snippets/ticket-state-type-circles.rst:4
-#: ../snippets/ticket-state-type-circles.rst:6 ../extras/knowledge-base.rst:221
+#: ../snippets/ticket-state-type-circles.rst:6 ../extras/knowledge-base.rst:227
 msgid "|grn|"
 msgstr "|grn|"
 
@@ -1634,7 +1634,8 @@ msgstr ""
 #: ../advanced/ticket-actions/link.rst:12
 msgid "Click the *➕ Add Link* button to access the link dialog."
 msgstr ""
-"Clique no botão *➕ Adicionar associação* para acessar a janela de associação."
+"Clique no botão *➕ Adicionar associação* para acessar a janela de "
+"associação."
 
 #: ../advanced/ticket-actions/link.rst:18
 msgid "Link dialog"
@@ -2009,8 +2010,8 @@ msgid ""
 "📥 Think of overviews as **inboxes**, each with a different filter for the "
 "tickets it displays."
 msgstr ""
-"📥 Pense nas visões como **caixas de entrada**, cada uma exibindo um conjunto "
-"de chamados de acordo com filtros diferentes."
+"📥 Pense nas visões como **caixas de entrada**, cada uma exibindo um "
+"conjunto de chamados de acordo com filtros diferentes."
 
 #: ../basics/find-ticket/browse.rst:15
 msgid ""
@@ -2103,8 +2104,8 @@ msgstr ""
 #: ../basics/find-ticket/search.rst:15
 msgid "**🔍 Here are just a few of the places the search engine will look:**"
 msgstr ""
-"**🔍 Aqui está uma lista de alguns dos lugares em que o motor de pesquisa irá "
-"pesquisar:*"
+"**🔍 Aqui está uma lista de alguns dos lugares em que o motor de pesquisa "
+"irá pesquisar:*"
 
 #: ../basics/find-ticket/search.rst:17
 msgid "📝 message subject/content"
@@ -2288,12 +2289,12 @@ msgstr "Texto"
 
 #: ../basics/service-ticket/create.rst:58
 msgid ""
-"📞 For phone calls, record the details of your conversation. These notes will "
-"not be sent to the customer (though he may be able to see them if he has a "
-"Zammad account)."
+"📞 For phone calls, record the details of your conversation. These notes "
+"will not be sent to the customer (though he may be able to see them if he "
+"has a Zammad account)."
 msgstr ""
-"📞 Para chamados a partir de uma chamada de telefone, registre os detalhes da "
-"conversa. Estas notas não serão enviadas ao cliente (embora ele poderá vê-"
+"📞 Para chamados a partir de uma chamada de telefone, registre os detalhes "
+"da conversa. Estas notas não serão enviadas ao cliente (embora ele poderá vê-"
 "las, se tiver uma conta Zammad)."
 
 #: ../basics/service-ticket/create.rst:62
@@ -2302,8 +2303,8 @@ msgstr "📧 Para e-mails, este é o copo de sua mensagem."
 
 #: ../snippets/ui-protip-message-editor-features.rst:3
 msgid ""
-"The message editor supports 📋 copying-and-pasting (or dragging-and-dropping) "
-"of **🔤 rich text**, **🌄 images** and **📎 file attachments**."
+"The message editor supports 📋 copying-and-pasting (or dragging-and-"
+"dropping) of **🔤 rich text**, **🌄 images** and **📎 file attachments**."
 msgstr ""
 "O editor de mensagens suporta 📋 copiar e colar (ou arrastar e soltar) **🔤 "
 "texto formatado**, **🌄 imagens** e **📎 arquivos anexados**."
@@ -2530,7 +2531,8 @@ msgstr ""
 
 #: ../basics/service-ticket/follow-up.rst:91
 msgid "Click the 🔒 button to change the visibility of a note or message."
-msgstr "Clique no botão 🔒 para alterar a visibilidade de uma nota ou mensagem."
+msgstr ""
+"Clique no botão 🔒 para alterar a visibilidade de uma nota ou mensagem."
 
 #: ../basics/service-ticket/follow-up.rst:96
 msgid ""
@@ -2544,8 +2546,9 @@ msgstr ""
 msgid ""
 "What about the **deletion of articles**? In Zammad, you can only delete "
 "articles that you have created yourself and which are not older than 10 "
-"minutes. To see the \"delete\" button in articles of the type \"communication"
-"\" (emails, calls), their visibility has to be switched to internal first."
+"minutes. To see the \"delete\" button in articles of the type "
+"\"communication\" (emails, calls), their visibility has to be switched to "
+"internal first."
 msgstr ""
 
 #: ../basics/service-ticket/follow-up.rst:107
@@ -2805,7 +2808,8 @@ msgid ""
 "problematic *per se,* but it does lead to a lot of unnecessary clutter in "
 "the :doc:`overviews menu </basics/find-ticket>`. (It can be much worse when, "
 "for example, a customer service rep sees tickets meant for your HR "
-"department, and finds out how much their colleagues in sales are making! 💸💸💸)"
+"department, and finds out how much their colleagues in sales are making! 💸💸"
+"💸)"
 msgstr ""
 "Sem grupos, todo os agentes podem ver (e responder) qualquer chamado que "
 "chegar, independentemente, de qual departamento é o responsável. De fato, "
@@ -4667,8 +4671,8 @@ msgstr ""
 
 #: ../extras/chat.rst:51
 msgid ""
-"📝 Chats can be **renamed** or **tagged**, and record technical details about "
-"the customer’s connection."
+"📝 Chats can be **renamed** or **tagged**, and record technical details "
+"about the customer’s connection."
 msgstr ""
 "📝 Os bate-papos podem ser **renomeados** ou **rotulados** e armazenar "
 "detalhes técnicos sobre conexão do cliente."
@@ -5427,42 +5431,48 @@ msgid ""
 "permissions"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:0
-msgid "Permissions of a parent category are inherited!"
+#: ../extras/knowledge-base.rst:162
+msgid ""
+"In general, permissions of a parent category are inherited! If you want to "
+"grant edit permissions for a sub-category for a specific role for example, "
+"set the upper level to \"reader\" and the desired sub-category to "
+"\"editor\". The other way round is not possible (permissions can only be "
+"widened, not restricted). If you can't select permissions in the table, this "
+"could be the reason."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:0
-msgid "Public answers are always available!"
+#: ../extras/knowledge-base.rst:169
+msgid "Be aware that public answers are always available!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:165
+#: ../extras/knowledge-base.rst:171
 msgid "**⚙️ Roles require knowledge base reader permission**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:167
+#: ../extras/knowledge-base.rst:173
 msgid ""
 "Your administrator has to provide the relevant groups with reader "
 "permissions for the knowledge base."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:170
+#: ../extras/knowledge-base.rst:176
 msgid "**🥵 Beware of visibility levels**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:172
+#: ../extras/knowledge-base.rst:178
 msgid ""
 "Knowledge base reader permission means that affected users can see "
 "**internal answers**. This is a potential issue if you're not dividing "
 "carefully!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:176
+#: ../extras/knowledge-base.rst:182
 msgid ""
 "If you're unsure, please ask your administrator to configure the :admin-docs:"
 "`role permissions </manage/roles/agent-permissions.html>` accordingly."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:181
+#: ../extras/knowledge-base.rst:187
 msgid "Editing Answers"
 msgstr ""
 
@@ -5470,7 +5480,7 @@ msgstr ""
 msgid "Edit answer"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:187
+#: ../extras/knowledge-base.rst:193
 msgid ""
 "The knowledge base editor comes equipped with the same **rich text editing "
 "capabilities** available in the Zammad ticket composer. That means you can "
@@ -5479,19 +5489,19 @@ msgid ""
 "attachments and links!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:193
+#: ../extras/knowledge-base.rst:199
 msgid "🤷 **Why are there four kinds of links?**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:196
+#: ../extras/knowledge-base.rst:202
 msgid "🔗 **Weblink**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:196
+#: ../extras/knowledge-base.rst:202
 msgid "URLs pointing to other websites."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:200
+#: ../extras/knowledge-base.rst:206
 msgid "💡 **Link Answer**"
 msgstr ""
 
@@ -5503,7 +5513,7 @@ msgstr ""
 msgid "(Will not break if destination URL changes.)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:204
+#: ../extras/knowledge-base.rst:210
 msgid "📋 **Linked Tickets**"
 msgstr ""
 
@@ -5515,7 +5525,7 @@ msgstr ""
 msgid "(Visible only in Preview and Edit Modes.)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:211
+#: ../extras/knowledge-base.rst:217
 msgid "🏷️ **Tags**"
 msgstr ""
 
@@ -5533,38 +5543,38 @@ msgstr ""
 msgid "Screencast showing tags on answers"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:216
+#: ../extras/knowledge-base.rst:222
 msgid ""
 "🙈 Set the **visibility** of an answer to control who can see an article, or "
 "schedule it to be published at a later date. Articles are **color-coded** "
 "according to their visibility:"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:221
+#: ../extras/knowledge-base.rst:227
 msgid "**Public** (visible to everyone)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:223
+#: ../extras/knowledge-base.rst:229
 msgid "|blu|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:223
+#: ../extras/knowledge-base.rst:229
 msgid "**Internal** (visible to agents & editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:225
+#: ../extras/knowledge-base.rst:231
 msgid "|gry|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:225
+#: ../extras/knowledge-base.rst:231
 msgid "**Draft/Scheduled/Archived** (visible to editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:241
+#: ../extras/knowledge-base.rst:247
 msgid "Using answers in ticket articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:243
+#: ../extras/knowledge-base.rst:249
 msgid ""
 "As soon as the knowledge base contains one or more answers, you can use "
 "these just like text modules. Instead of ``::`` just use ``??`` to open the "
@@ -5572,22 +5582,22 @@ msgid ""
 "all languages available."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:248
+#: ../extras/knowledge-base.rst:254
 msgid ""
 "If you've found what you've been looking for, simply hit your ENTER-Key to "
 "load the answer into the ticket article. This way you don't have to throw "
 "URLs at your customer and provide the answer right away."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:252
+#: ../extras/knowledge-base.rst:258
 msgid "Loading answers into articles *does not* replace article content."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:258
+#: ../extras/knowledge-base.rst:264
 msgid "Screencast showing how to insert KB answers into articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:258
+#: ../extras/knowledge-base.rst:264
 msgid "Use ``??`` to find and load knowledge base answers into ticket articles"
 msgstr ""
 
@@ -6837,8 +6847,8 @@ msgstr ""
 
 #: ../extras/shared-drafts.rst:50
 msgid ""
-"If you're in a new ticket dialogue *after selecting the ticket group*, the 📝 "
-"button will indicate the shared drafts function to be available."
+"If you're in a new ticket dialogue *after selecting the ticket group*, the "
+"📝 button will indicate the shared drafts function to be available."
 msgstr ""
 
 #: ../extras/shared-drafts.rst:55
@@ -7555,8 +7565,8 @@ msgstr ""
 #~ "podem ser adicionados a clientes existentes desta forma"
 
 #~ msgid ""
-#~ "Click the **➕ button** to create a new ticket. The default ticket type is "
-#~ "**received call**."
+#~ "Click the **➕ button** to create a new ticket. The default ticket type "
+#~ "is **received call**."
 #~ msgstr ""
 #~ "Clique no **botão ➕** para criar um novo chamado .O tipo padrão de um "
 #~ "novo chamado é **ligação recebida**."

--- a/locale/ru/LC_MESSAGES/user-docs.po
+++ b/locale/ru/LC_MESSAGES/user-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-09 13:15+0100\n"
+"POT-Creation-Date: 2023-12-04 12:38+0100\n"
 "PO-Revision-Date: 2023-09-09 23:18+0000\n"
 "Last-Translator: ElectroKos <kosapashennyh@gmail.com>\n"
 "Language-Team: Russian <https://translations.zammad.org/projects/"
@@ -16,8 +16,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 5.0\n"
 
 #: ../advanced/keyboard-shortcuts.rst:4
@@ -1339,7 +1339,7 @@ msgid ""
 msgstr ""
 
 #: ../snippets/ticket-state-type-circles.rst:4
-#: ../snippets/ticket-state-type-circles.rst:6 ../extras/knowledge-base.rst:221
+#: ../snippets/ticket-state-type-circles.rst:6 ../extras/knowledge-base.rst:227
 msgid "|grn|"
 msgstr "|grn|"
 
@@ -2105,9 +2105,9 @@ msgstr ""
 
 #: ../basics/service-ticket/create.rst:58
 msgid ""
-"📞 For phone calls, record the details of your conversation. These notes will "
-"not be sent to the customer (though he may be able to see them if he has a "
-"Zammad account)."
+"📞 For phone calls, record the details of your conversation. These notes "
+"will not be sent to the customer (though he may be able to see them if he "
+"has a Zammad account)."
 msgstr ""
 
 #: ../basics/service-ticket/create.rst:62
@@ -2116,8 +2116,8 @@ msgstr ""
 
 #: ../snippets/ui-protip-message-editor-features.rst:3
 msgid ""
-"The message editor supports 📋 copying-and-pasting (or dragging-and-dropping) "
-"of **🔤 rich text**, **🌄 images** and **📎 file attachments**."
+"The message editor supports 📋 copying-and-pasting (or dragging-and-"
+"dropping) of **🔤 rich text**, **🌄 images** and **📎 file attachments**."
 msgstr ""
 
 #: ../snippets/ui-protip-message-editor-features.rst:6
@@ -2312,8 +2312,9 @@ msgstr ""
 msgid ""
 "What about the **deletion of articles**? In Zammad, you can only delete "
 "articles that you have created yourself and which are not older than 10 "
-"minutes. To see the \"delete\" button in articles of the type \"communication"
-"\" (emails, calls), their visibility has to be switched to internal first."
+"minutes. To see the \"delete\" button in articles of the type "
+"\"communication\" (emails, calls), their visibility has to be switched to "
+"internal first."
 msgstr ""
 
 #: ../basics/service-ticket/follow-up.rst:107
@@ -2534,7 +2535,8 @@ msgid ""
 "problematic *per se,* but it does lead to a lot of unnecessary clutter in "
 "the :doc:`overviews menu </basics/find-ticket>`. (It can be much worse when, "
 "for example, a customer service rep sees tickets meant for your HR "
-"department, and finds out how much their colleagues in sales are making! 💸💸💸)"
+"department, and finds out how much their colleagues in sales are making! 💸💸"
+"💸)"
 msgstr ""
 
 #: ../basics/service-ticket/settings/group.rst:25
@@ -4245,8 +4247,8 @@ msgstr ""
 
 #: ../extras/chat.rst:51
 msgid ""
-"📝 Chats can be **renamed** or **tagged**, and record technical details about "
-"the customer’s connection."
+"📝 Chats can be **renamed** or **tagged**, and record technical details "
+"about the customer’s connection."
 msgstr ""
 
 #: ../extras/chat.rst:0
@@ -4928,42 +4930,48 @@ msgid ""
 "permissions"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:0
-msgid "Permissions of a parent category are inherited!"
+#: ../extras/knowledge-base.rst:162
+msgid ""
+"In general, permissions of a parent category are inherited! If you want to "
+"grant edit permissions for a sub-category for a specific role for example, "
+"set the upper level to \"reader\" and the desired sub-category to "
+"\"editor\". The other way round is not possible (permissions can only be "
+"widened, not restricted). If you can't select permissions in the table, this "
+"could be the reason."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:0
-msgid "Public answers are always available!"
+#: ../extras/knowledge-base.rst:169
+msgid "Be aware that public answers are always available!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:165
+#: ../extras/knowledge-base.rst:171
 msgid "**⚙️ Roles require knowledge base reader permission**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:167
+#: ../extras/knowledge-base.rst:173
 msgid ""
 "Your administrator has to provide the relevant groups with reader "
 "permissions for the knowledge base."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:170
+#: ../extras/knowledge-base.rst:176
 msgid "**🥵 Beware of visibility levels**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:172
+#: ../extras/knowledge-base.rst:178
 msgid ""
 "Knowledge base reader permission means that affected users can see "
 "**internal answers**. This is a potential issue if you're not dividing "
 "carefully!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:176
+#: ../extras/knowledge-base.rst:182
 msgid ""
 "If you're unsure, please ask your administrator to configure the :admin-docs:"
 "`role permissions </manage/roles/agent-permissions.html>` accordingly."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:181
+#: ../extras/knowledge-base.rst:187
 msgid "Editing Answers"
 msgstr ""
 
@@ -4971,7 +4979,7 @@ msgstr ""
 msgid "Edit answer"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:187
+#: ../extras/knowledge-base.rst:193
 msgid ""
 "The knowledge base editor comes equipped with the same **rich text editing "
 "capabilities** available in the Zammad ticket composer. That means you can "
@@ -4980,19 +4988,19 @@ msgid ""
 "attachments and links!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:193
+#: ../extras/knowledge-base.rst:199
 msgid "🤷 **Why are there four kinds of links?**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:196
+#: ../extras/knowledge-base.rst:202
 msgid "🔗 **Weblink**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:196
+#: ../extras/knowledge-base.rst:202
 msgid "URLs pointing to other websites."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:200
+#: ../extras/knowledge-base.rst:206
 msgid "💡 **Link Answer**"
 msgstr ""
 
@@ -5004,7 +5012,7 @@ msgstr ""
 msgid "(Will not break if destination URL changes.)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:204
+#: ../extras/knowledge-base.rst:210
 msgid "📋 **Linked Tickets**"
 msgstr ""
 
@@ -5016,7 +5024,7 @@ msgstr ""
 msgid "(Visible only in Preview and Edit Modes.)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:211
+#: ../extras/knowledge-base.rst:217
 msgid "🏷️ **Tags**"
 msgstr ""
 
@@ -5034,38 +5042,38 @@ msgstr ""
 msgid "Screencast showing tags on answers"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:216
+#: ../extras/knowledge-base.rst:222
 msgid ""
 "🙈 Set the **visibility** of an answer to control who can see an article, or "
 "schedule it to be published at a later date. Articles are **color-coded** "
 "according to their visibility:"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:221
+#: ../extras/knowledge-base.rst:227
 msgid "**Public** (visible to everyone)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:223
+#: ../extras/knowledge-base.rst:229
 msgid "|blu|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:223
+#: ../extras/knowledge-base.rst:229
 msgid "**Internal** (visible to agents & editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:225
+#: ../extras/knowledge-base.rst:231
 msgid "|gry|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:225
+#: ../extras/knowledge-base.rst:231
 msgid "**Draft/Scheduled/Archived** (visible to editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:241
+#: ../extras/knowledge-base.rst:247
 msgid "Using answers in ticket articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:243
+#: ../extras/knowledge-base.rst:249
 msgid ""
 "As soon as the knowledge base contains one or more answers, you can use "
 "these just like text modules. Instead of ``::`` just use ``??`` to open the "
@@ -5073,22 +5081,22 @@ msgid ""
 "all languages available."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:248
+#: ../extras/knowledge-base.rst:254
 msgid ""
 "If you've found what you've been looking for, simply hit your ENTER-Key to "
 "load the answer into the ticket article. This way you don't have to throw "
 "URLs at your customer and provide the answer right away."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:252
+#: ../extras/knowledge-base.rst:258
 msgid "Loading answers into articles *does not* replace article content."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:258
+#: ../extras/knowledge-base.rst:264
 msgid "Screencast showing how to insert KB answers into articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:258
+#: ../extras/knowledge-base.rst:264
 msgid "Use ``??`` to find and load knowledge base answers into ticket articles"
 msgstr ""
 
@@ -6216,8 +6224,8 @@ msgstr ""
 
 #: ../extras/shared-drafts.rst:50
 msgid ""
-"If you're in a new ticket dialogue *after selecting the ticket group*, the 📝 "
-"button will indicate the shared drafts function to be available."
+"If you're in a new ticket dialogue *after selecting the ticket group*, the "
+"📝 button will indicate the shared drafts function to be available."
 msgstr ""
 
 #: ../extras/shared-drafts.rst:55

--- a/locale/sr/LC_MESSAGES/user-docs.po
+++ b/locale/sr/LC_MESSAGES/user-docs.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-09 13:15+0100\n"
-"PO-Revision-Date: 2023-11-21 11:00+0000\n"
+"POT-Creation-Date: 2023-12-04 12:38+0100\n"
+"PO-Revision-Date: 2023-12-09 17:00+0000\n"
 "Last-Translator: Dusan Vuckovic <dv@zammad.com>\n"
 "Language-Team: Serbian <https://translations.zammad.org/projects/"
 "documentations/user-documentation-pre-release/sr/>\n"
@@ -18,7 +18,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
 "n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
-"X-Generator: Weblate 5.0.2\n"
+"X-Generator: Weblate 5.2.1\n"
 
 #: ../advanced/keyboard-shortcuts.rst:4
 msgid "Keyboard Shortcuts"
@@ -1423,7 +1423,7 @@ msgstr ""
 "бојама:**"
 
 #: ../snippets/ticket-state-type-circles.rst:4
-#: ../snippets/ticket-state-type-circles.rst:6 ../extras/knowledge-base.rst:221
+#: ../snippets/ticket-state-type-circles.rst:6 ../extras/knowledge-base.rst:227
 msgid "|grn|"
 msgstr "|grn|"
 
@@ -1694,7 +1694,8 @@ msgstr "Панел тикета: Везе"
 
 #: ../advanced/ticket-actions/link.rst:12
 msgid "Click the *➕ Add Link* button to access the link dialog."
-msgstr "Кликните на дугме *➕ Додај везу* да бисте отворили дијалог повезивања."
+msgstr ""
+"Кликните на дугме *➕ Додај везу* да бисте отворили дијалог повезивања."
 
 #: ../advanced/ticket-actions/link.rst:18
 msgid "Link dialog"
@@ -2337,9 +2338,9 @@ msgstr "Текст"
 
 #: ../basics/service-ticket/create.rst:58
 msgid ""
-"📞 For phone calls, record the details of your conversation. These notes will "
-"not be sent to the customer (though he may be able to see them if he has a "
-"Zammad account)."
+"📞 For phone calls, record the details of your conversation. These notes "
+"will not be sent to the customer (though he may be able to see them if he "
+"has a Zammad account)."
 msgstr ""
 "📞 За телефонске позиве, забележите детаље вашег разговора. Ове белешке неће "
 "бити послате купцу (иако ће можда моћи да их види уколико поседује Zammad "
@@ -2351,8 +2352,8 @@ msgstr "📧 За имејлове, ово ће бити текст ваше о�
 
 #: ../snippets/ui-protip-message-editor-features.rst:3
 msgid ""
-"The message editor supports 📋 copying-and-pasting (or dragging-and-dropping) "
-"of **🔤 rich text**, **🌄 images** and **📎 file attachments**."
+"The message editor supports 📋 copying-and-pasting (or dragging-and-"
+"dropping) of **🔤 rich text**, **🌄 images** and **📎 file attachments**."
 msgstr ""
 "Уредник порука подржава 📋 копирање и налепљивање (или превлачење и пуштање) "
 "**🔤 богатог текста**, **🌄 слика** и **📎 датотека прилога**."
@@ -2440,16 +2441,16 @@ msgid ""
 "`⚙️ Manage ticket settings <settings>` in the **ticket pane** on the right."
 msgstr ""
 "Тикети су конверзације које се састоје од порука и напомена о проблему "
-"клијента. :doc:`⚙️ Управљајте подацима тикета <settings>` у **панелу тикета**"
-" са десне стране."
+"клијента. :doc:`⚙️ Управљајте подацима тикета <settings>` у **панелу тикета** "
+"са десне стране."
 
 #: ../basics/service-ticket/follow-up.rst:23
 msgid ""
 "📇 Any time you open a ticket, a new entry will appear in your :doc:`tab "
 "list</advanced/tabs>` in the main menu."
 msgstr ""
-"📇 Сваки пут када отворите приказ тикета, нова ставка ће се појавити у вашој :"
-"doc:`листи прозора </advanced/tabs>` у главном менију."
+"📇 Сваки пут када отворите приказ тикета, нова ставка ће се појавити у "
+"вашој :doc:`листи прозора </advanced/tabs>` у главном менију."
 
 #: ../basics/service-ticket/follow-up.rst:26
 msgid ""
@@ -2505,8 +2506,8 @@ msgid ""
 "This way, you can share correspondences with people who don't have Zammad "
 "(like a third-party supplier)."
 msgstr ""
-"На овај начин можете да поделите преписку са људима који немају Zammad ("
-"попут вашег подизвођача)."
+"На овај начин можете да поделите преписку са људима који немају Zammad "
+"(попут вашег подизвођача)."
 
 #: ../basics/service-ticket/follow-up.rst:57
 msgid "Click on a message to see detailed information about it."
@@ -2585,8 +2586,9 @@ msgstr ""
 msgid ""
 "What about the **deletion of articles**? In Zammad, you can only delete "
 "articles that you have created yourself and which are not older than 10 "
-"minutes. To see the \"delete\" button in articles of the type \"communication"
-"\" (emails, calls), their visibility has to be switched to internal first."
+"minutes. To see the \"delete\" button in articles of the type "
+"\"communication\" (emails, calls), their visibility has to be switched to "
+"internal first."
 msgstr ""
 "А шта са **брисањем чланака**? У Zammad-у, можете обрисати само чланке које "
 "сте додали сами и који нису старији од 10 минута. Да бисте видели дугме за "
@@ -2863,7 +2865,8 @@ msgid ""
 "problematic *per se,* but it does lead to a lot of unnecessary clutter in "
 "the :doc:`overviews menu </basics/find-ticket>`. (It can be much worse when, "
 "for example, a customer service rep sees tickets meant for your HR "
-"department, and finds out how much their colleagues in sales are making! 💸💸💸)"
+"department, and finds out how much their colleagues in sales are making! 💸💸"
+"💸)"
 msgstr ""
 "Без група, свих десет оператера може да види (и да одговори на) сваки "
 "појединачни долазни тикет, без обзира о ком одељењу се ради. Ово није "
@@ -5017,8 +5020,8 @@ msgid ""
 "🔍 Use the :doc:`search bar </basics/find-ticket/search>` to pull up old "
 "chats from the archive anytime."
 msgstr ""
-"🔍 Користите :doc:`траку за претрагу </basics/find-ticket/search>` да бисте у "
-"било ком тренутку извукли стара ћаскања из архиве."
+"🔍 Користите :doc:`траку за претрагу </basics/find-ticket/search>` да бисте "
+"у било ком тренутку извукли стара ћаскања из архиве."
 
 #: ../extras/chat.rst:49
 msgid "📋 Copy & paste **supports 🌄 inline images** as well as plain text."
@@ -5033,8 +5036,8 @@ msgstr ""
 
 #: ../extras/chat.rst:51
 msgid ""
-"📝 Chats can be **renamed** or **tagged**, and record technical details about "
-"the customer’s connection."
+"📝 Chats can be **renamed** or **tagged**, and record technical details "
+"about the customer’s connection."
 msgstr ""
 "📝 Могуће је **променити назив** ћаскања или **означити** га, и забележити "
 "техничке детаље о вези клијента."
@@ -5091,7 +5094,8 @@ msgstr "Панел тикета (приказ клијента)"
 
 #: ../extras/customers.rst:10
 msgid "Click the 👨 tab in the ticket pane to see the customer's profile."
-msgstr "Кликните на 👨 језичак у панелу тикета да бисте видели профил клијента."
+msgstr ""
+"Кликните на 👨 језичак у панелу тикета да бисте видели профил клијента."
 
 #: ../extras/customers.rst:0
 msgid "Customer ticket summary (mouseover)"
@@ -5854,19 +5858,30 @@ msgstr ""
 "Снимак екрана који приказује опцију видљивости за ограничене дозволе "
 "категорије"
 
-#: ../extras/knowledge-base.rst:0
-msgid "Permissions of a parent category are inherited!"
-msgstr "Дозволе надређене категорије се наслеђују!"
+#: ../extras/knowledge-base.rst:162
+msgid ""
+"In general, permissions of a parent category are inherited! If you want to "
+"grant edit permissions for a sub-category for a specific role for example, "
+"set the upper level to \"reader\" and the desired sub-category to "
+"\"editor\". The other way round is not possible (permissions can only be "
+"widened, not restricted). If you can't select permissions in the table, this "
+"could be the reason."
+msgstr ""
+"Уопштено, дозволе надређених катеорија се не наслеђују! Уколико нпр. желите "
+"да доделите дозволу уређивања за подређену категорију одговарајућој улози, "
+"поставите горњи ново на „читалац” и жељену подкатегорију на „уредник”. "
+"Обрнуто није могуће (дозволе се могу само увећати, не и ограничити). Уколико "
+"не можете да одаберете дозволе у овој табели, ово може бити разлог за то."
 
-#: ../extras/knowledge-base.rst:0
-msgid "Public answers are always available!"
-msgstr "Јавни чланци су увек доступни!"
+#: ../extras/knowledge-base.rst:169
+msgid "Be aware that public answers are always available!"
+msgstr "Будите свесни да су јавни чланци увек доступни!"
 
-#: ../extras/knowledge-base.rst:165
+#: ../extras/knowledge-base.rst:171
 msgid "**⚙️ Roles require knowledge base reader permission**"
 msgstr "**⚙️ Улоге захтевају дозволу за читање базе знања**"
 
-#: ../extras/knowledge-base.rst:167
+#: ../extras/knowledge-base.rst:173
 msgid ""
 "Your administrator has to provide the relevant groups with reader "
 "permissions for the knowledge base."
@@ -5874,11 +5889,11 @@ msgstr ""
 "Ваш администратор мора да обезбеди релевантним групама дозволе за читање за "
 "базу знања."
 
-#: ../extras/knowledge-base.rst:170
+#: ../extras/knowledge-base.rst:176
 msgid "**🥵 Beware of visibility levels**"
 msgstr "**🥵 Пазите на нивое видљивости**"
 
-#: ../extras/knowledge-base.rst:172
+#: ../extras/knowledge-base.rst:178
 msgid ""
 "Knowledge base reader permission means that affected users can see "
 "**internal answers**. This is a potential issue if you're not dividing "
@@ -5887,7 +5902,7 @@ msgstr ""
 "Дозвола за читање базе знања значи да корисници могу да виде **интерне "
 "чланке**. Ово је потенцијални проблем ако не делите пажљиво!"
 
-#: ../extras/knowledge-base.rst:176
+#: ../extras/knowledge-base.rst:182
 msgid ""
 "If you're unsure, please ask your administrator to configure the :admin-docs:"
 "`role permissions </manage/roles/agent-permissions.html>` accordingly."
@@ -5896,7 +5911,7 @@ msgstr ""
 "конфигурише :admin-docs:`дозволе улоге </manage/roles/agent-permissions."
 "html>`."
 
-#: ../extras/knowledge-base.rst:181
+#: ../extras/knowledge-base.rst:187
 msgid "Editing Answers"
 msgstr "Уређивање чланака"
 
@@ -5904,7 +5919,7 @@ msgstr "Уређивање чланака"
 msgid "Edit answer"
 msgstr "Уредите чланак"
 
-#: ../extras/knowledge-base.rst:187
+#: ../extras/knowledge-base.rst:193
 msgid ""
 "The knowledge base editor comes equipped with the same **rich text editing "
 "capabilities** available in the Zammad ticket composer. That means you can "
@@ -5918,19 +5933,19 @@ msgstr ""
 "бисте уметнули форматирани текст, листе са ознакама и још много тога. Можете "
 "чак додати датотеке прилога и везе!"
 
-#: ../extras/knowledge-base.rst:193
+#: ../extras/knowledge-base.rst:199
 msgid "🤷 **Why are there four kinds of links?**"
 msgstr "🤷 **Зашто постоје четири врсте веза?**"
 
-#: ../extras/knowledge-base.rst:196
+#: ../extras/knowledge-base.rst:202
 msgid "🔗 **Weblink**"
 msgstr "🔗 **Интернет веза**"
 
-#: ../extras/knowledge-base.rst:196
+#: ../extras/knowledge-base.rst:202
 msgid "URLs pointing to other websites."
 msgstr "URL адресе које упућују на друге интернет локације."
 
-#: ../extras/knowledge-base.rst:200
+#: ../extras/knowledge-base.rst:206
 msgid "💡 **Link Answer**"
 msgstr "💡 **Веза ка чланку**"
 
@@ -5942,7 +5957,7 @@ msgstr "Интерне референце на друге чланке базе 
 msgid "(Will not break if destination URL changes.)"
 msgstr "(Неће се прекинути ако се одредишна URL адреса промени.)"
 
-#: ../extras/knowledge-base.rst:204
+#: ../extras/knowledge-base.rst:210
 msgid "📋 **Linked Tickets**"
 msgstr "📋 **Везе ка тикетима**"
 
@@ -5954,7 +5969,7 @@ msgstr "Интерне референце на Zammad тикете."
 msgid "(Visible only in Preview and Edit Modes.)"
 msgstr "(Видљиво само у режимима приказа и уређивања.)"
 
-#: ../extras/knowledge-base.rst:211
+#: ../extras/knowledge-base.rst:217
 msgid "🏷️ **Tags**"
 msgstr "🏷 **Ознаке**"
 
@@ -5976,41 +5991,41 @@ msgstr ""
 msgid "Screencast showing tags on answers"
 msgstr "Снимак екрана који приказује ознаке у чланкцима"
 
-#: ../extras/knowledge-base.rst:216
+#: ../extras/knowledge-base.rst:222
 msgid ""
 "🙈 Set the **visibility** of an answer to control who can see an article, or "
 "schedule it to be published at a later date. Articles are **color-coded** "
 "according to their visibility:"
 msgstr ""
-"🙈 Подесите **видљивост** чланка да бисте контролисали ко може да види чланак "
-"или закажите његово објављивање за касније. Чланци су **означени бојама** "
-"према њиховој видљивости:"
+"🙈 Подесите **видљивост** чланка да бисте контролисали ко може да види "
+"чланак или закажите његово објављивање за касније. Чланци су **означени "
+"бојама** према њиховој видљивости:"
 
-#: ../extras/knowledge-base.rst:221
+#: ../extras/knowledge-base.rst:227
 msgid "**Public** (visible to everyone)"
 msgstr "**Јавно** (видљиво свима)"
 
-#: ../extras/knowledge-base.rst:223
+#: ../extras/knowledge-base.rst:229
 msgid "|blu|"
 msgstr "|blu|"
 
-#: ../extras/knowledge-base.rst:223
+#: ../extras/knowledge-base.rst:229
 msgid "**Internal** (visible to agents & editors only)"
 msgstr "**Интерно** (видљиво само оператерима и уредницима)"
 
-#: ../extras/knowledge-base.rst:225
+#: ../extras/knowledge-base.rst:231
 msgid "|gry|"
 msgstr "|gry|"
 
-#: ../extras/knowledge-base.rst:225
+#: ../extras/knowledge-base.rst:231
 msgid "**Draft/Scheduled/Archived** (visible to editors only)"
 msgstr "**Нацрт/Заказано/Архивирано** (видљиво само уредницима)"
 
-#: ../extras/knowledge-base.rst:241
+#: ../extras/knowledge-base.rst:247
 msgid "Using answers in ticket articles"
 msgstr "Коришћење чланака у тикетима"
 
-#: ../extras/knowledge-base.rst:243
+#: ../extras/knowledge-base.rst:249
 msgid ""
 "As soon as the knowledge base contains one or more answers, you can use "
 "these just like text modules. Instead of ``::`` just use ``??`` to open the "
@@ -6022,7 +6037,7 @@ msgstr ""
 "претраге. Претрага се врши по целом тексту чланка и у наслову на свим "
 "доступним језицима."
 
-#: ../extras/knowledge-base.rst:248
+#: ../extras/knowledge-base.rst:254
 msgid ""
 "If you've found what you've been looking for, simply hit your ENTER-Key to "
 "load the answer into the ticket article. This way you don't have to throw "
@@ -6032,16 +6047,16 @@ msgstr ""
 "бисте учитали чланак у тикет. На овај начин не морате да шаљете URL адресе "
 "својим клијентима и можете одмах да им одговорите."
 
-#: ../extras/knowledge-base.rst:252
+#: ../extras/knowledge-base.rst:258
 msgid "Loading answers into articles *does not* replace article content."
 msgstr "Учитавање чланака *не* замењује садржај чланка тикета."
 
-#: ../extras/knowledge-base.rst:258
+#: ../extras/knowledge-base.rst:264
 msgid "Screencast showing how to insert KB answers into articles"
 msgstr ""
 "Снимак екрана који показује како да уметнете чланке базе знања у тикете"
 
-#: ../extras/knowledge-base.rst:258
+#: ../extras/knowledge-base.rst:264
 msgid "Use ``??`` to find and load knowledge base answers into ticket articles"
 msgstr "Користите ``??`` да пронађете и учитате чланке базе знања у тикете"
 
@@ -6369,7 +6384,8 @@ msgstr "Панел тикета (приказ организације)"
 #: ../extras/organizations.rst:18
 msgid "Click the 👪 tab in the ticket pane to see the organization’s profile."
 msgstr ""
-"Кликните на језичак 👪 у панелу тикета да бисте приказали профил организације."
+"Кликните на језичак 👪 у панелу тикета да бисте приказали профил "
+"организације."
 
 #: ../extras/organizations.rst:20
 msgid "To edit the organization’s profile, use the **organization submenu**:"
@@ -6987,7 +7003,8 @@ msgid ""
 "The 🔒 and ✅ icons at the top of a message indicate its encryption and "
 "signing status."
 msgstr ""
-"Иконице 🔒 и ✅ при врху поруке означавају њен статус шифровања и потписивања."
+"Иконице 🔒 и ✅ при врху поруке означавају њен статус шифровања и "
+"потписивања."
 
 #: ../extras/secure-email.rst:75
 msgid "Screencast showing details of encryption and signing status"
@@ -7100,9 +7117,9 @@ msgid ""
 "🔒 **Encrypt** and ✅ **Sign** buttons are present on both new tickets and "
 "replies. Hover over the buttons to show details."
 msgstr ""
-"Дугмићи 🔒 **Шифровање** и ✅ **Потписивање** су присутни и на новим тикетима "
-"и на одговорима. Пређите курсором преко дугмића да бисте приказали више "
-"информација."
+"Дугмићи 🔒 **Шифровање** и ✅ **Потписивање** су присутни и на новим "
+"тикетима и на одговорима. Пређите курсором преко дугмића да бисте приказали "
+"више информација."
 
 #: ../extras/secure-email.rst:116
 msgid "Status Icons (Outgoing)"
@@ -7348,8 +7365,8 @@ msgstr "Примена нацрта ради исто почевши од пре
 
 #: ../extras/shared-drafts.rst:50
 msgid ""
-"If you're in a new ticket dialogue *after selecting the ticket group*, the 📝 "
-"button will indicate the shared drafts function to be available."
+"If you're in a new ticket dialogue *after selecting the ticket group*, the "
+"📝 button will indicate the shared drafts function to be available."
 msgstr ""
 "Ако сте у дијалогу новог тикета и *након што изаберете групу тикета*, дугме "
 "📝 ће означити да је функција заједничких нацрта доступна."
@@ -8199,6 +8216,9 @@ msgstr ""
 "`системски </index.html>` и :admin-docs:`администраторски </index.html>` "
 "приручници."
 
+#~ msgid "Permissions of a parent category are inherited!"
+#~ msgstr "Дозволе надређене категорије се наслеђују!"
+
 #~ msgid "`Google Authenticator`_"
 #~ msgstr "`Google Authenticator`_"
 
@@ -8384,8 +8404,8 @@ msgstr ""
 #~ msgstr "Можете бити сигурни да је аутентична и да њен садржај није измењен."
 
 #~ msgid ""
-#~ "🔒 **Encrypt** and ✅ **Sign** buttons are present on both new tickets and "
-#~ "replies. Hover over the buttons to show a certificate/CA summary."
+#~ "🔒 **Encrypt** and ✅ **Sign** buttons are present on both new tickets "
+#~ "and replies. Hover over the buttons to show a certificate/CA summary."
 #~ msgstr ""
 #~ "Дугмићи 🔒 **Шифровање** и ✅ **Потписивање** су присутни и на новим "
 #~ "тикетима и на одговорима. Пређите курсором преко дугмића да бисте "

--- a/locale/sv/LC_MESSAGES/user-docs.po
+++ b/locale/sv/LC_MESSAGES/user-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-09 13:15+0100\n"
+"POT-Creation-Date: 2023-12-04 12:38+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -1271,7 +1271,7 @@ msgid ""
 msgstr ""
 
 #: ../snippets/ticket-state-type-circles.rst:4
-#: ../snippets/ticket-state-type-circles.rst:6 ../extras/knowledge-base.rst:221
+#: ../snippets/ticket-state-type-circles.rst:6 ../extras/knowledge-base.rst:227
 msgid "|grn|"
 msgstr ""
 
@@ -2035,9 +2035,9 @@ msgstr ""
 
 #: ../basics/service-ticket/create.rst:58
 msgid ""
-"📞 For phone calls, record the details of your conversation. These notes will "
-"not be sent to the customer (though he may be able to see them if he has a "
-"Zammad account)."
+"📞 For phone calls, record the details of your conversation. These notes "
+"will not be sent to the customer (though he may be able to see them if he "
+"has a Zammad account)."
 msgstr ""
 
 #: ../basics/service-ticket/create.rst:62
@@ -2046,8 +2046,8 @@ msgstr ""
 
 #: ../snippets/ui-protip-message-editor-features.rst:3
 msgid ""
-"The message editor supports 📋 copying-and-pasting (or dragging-and-dropping) "
-"of **🔤 rich text**, **🌄 images** and **📎 file attachments**."
+"The message editor supports 📋 copying-and-pasting (or dragging-and-"
+"dropping) of **🔤 rich text**, **🌄 images** and **📎 file attachments**."
 msgstr ""
 
 #: ../snippets/ui-protip-message-editor-features.rst:6
@@ -2242,8 +2242,9 @@ msgstr ""
 msgid ""
 "What about the **deletion of articles**? In Zammad, you can only delete "
 "articles that you have created yourself and which are not older than 10 "
-"minutes. To see the \"delete\" button in articles of the type \"communication"
-"\" (emails, calls), their visibility has to be switched to internal first."
+"minutes. To see the \"delete\" button in articles of the type "
+"\"communication\" (emails, calls), their visibility has to be switched to "
+"internal first."
 msgstr ""
 
 #: ../basics/service-ticket/follow-up.rst:107
@@ -2464,7 +2465,8 @@ msgid ""
 "problematic *per se,* but it does lead to a lot of unnecessary clutter in "
 "the :doc:`overviews menu </basics/find-ticket>`. (It can be much worse when, "
 "for example, a customer service rep sees tickets meant for your HR "
-"department, and finds out how much their colleagues in sales are making! 💸💸💸)"
+"department, and finds out how much their colleagues in sales are making! 💸💸"
+"💸)"
 msgstr ""
 
 #: ../basics/service-ticket/settings/group.rst:25
@@ -4173,8 +4175,8 @@ msgstr ""
 
 #: ../extras/chat.rst:51
 msgid ""
-"📝 Chats can be **renamed** or **tagged**, and record technical details about "
-"the customer’s connection."
+"📝 Chats can be **renamed** or **tagged**, and record technical details "
+"about the customer’s connection."
 msgstr ""
 
 #: ../extras/chat.rst:0
@@ -4856,42 +4858,48 @@ msgid ""
 "permissions"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:0
-msgid "Permissions of a parent category are inherited!"
+#: ../extras/knowledge-base.rst:162
+msgid ""
+"In general, permissions of a parent category are inherited! If you want to "
+"grant edit permissions for a sub-category for a specific role for example, "
+"set the upper level to \"reader\" and the desired sub-category to "
+"\"editor\". The other way round is not possible (permissions can only be "
+"widened, not restricted). If you can't select permissions in the table, this "
+"could be the reason."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:0
-msgid "Public answers are always available!"
+#: ../extras/knowledge-base.rst:169
+msgid "Be aware that public answers are always available!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:165
+#: ../extras/knowledge-base.rst:171
 msgid "**⚙️ Roles require knowledge base reader permission**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:167
+#: ../extras/knowledge-base.rst:173
 msgid ""
 "Your administrator has to provide the relevant groups with reader "
 "permissions for the knowledge base."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:170
+#: ../extras/knowledge-base.rst:176
 msgid "**🥵 Beware of visibility levels**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:172
+#: ../extras/knowledge-base.rst:178
 msgid ""
 "Knowledge base reader permission means that affected users can see "
 "**internal answers**. This is a potential issue if you're not dividing "
 "carefully!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:176
+#: ../extras/knowledge-base.rst:182
 msgid ""
 "If you're unsure, please ask your administrator to configure the :admin-docs:"
 "`role permissions </manage/roles/agent-permissions.html>` accordingly."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:181
+#: ../extras/knowledge-base.rst:187
 msgid "Editing Answers"
 msgstr ""
 
@@ -4899,7 +4907,7 @@ msgstr ""
 msgid "Edit answer"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:187
+#: ../extras/knowledge-base.rst:193
 msgid ""
 "The knowledge base editor comes equipped with the same **rich text editing "
 "capabilities** available in the Zammad ticket composer. That means you can "
@@ -4908,19 +4916,19 @@ msgid ""
 "attachments and links!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:193
+#: ../extras/knowledge-base.rst:199
 msgid "🤷 **Why are there four kinds of links?**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:196
+#: ../extras/knowledge-base.rst:202
 msgid "🔗 **Weblink**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:196
+#: ../extras/knowledge-base.rst:202
 msgid "URLs pointing to other websites."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:200
+#: ../extras/knowledge-base.rst:206
 msgid "💡 **Link Answer**"
 msgstr ""
 
@@ -4932,7 +4940,7 @@ msgstr ""
 msgid "(Will not break if destination URL changes.)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:204
+#: ../extras/knowledge-base.rst:210
 msgid "📋 **Linked Tickets**"
 msgstr ""
 
@@ -4944,7 +4952,7 @@ msgstr ""
 msgid "(Visible only in Preview and Edit Modes.)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:211
+#: ../extras/knowledge-base.rst:217
 msgid "🏷️ **Tags**"
 msgstr ""
 
@@ -4962,38 +4970,38 @@ msgstr ""
 msgid "Screencast showing tags on answers"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:216
+#: ../extras/knowledge-base.rst:222
 msgid ""
 "🙈 Set the **visibility** of an answer to control who can see an article, or "
 "schedule it to be published at a later date. Articles are **color-coded** "
 "according to their visibility:"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:221
+#: ../extras/knowledge-base.rst:227
 msgid "**Public** (visible to everyone)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:223
+#: ../extras/knowledge-base.rst:229
 msgid "|blu|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:223
+#: ../extras/knowledge-base.rst:229
 msgid "**Internal** (visible to agents & editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:225
+#: ../extras/knowledge-base.rst:231
 msgid "|gry|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:225
+#: ../extras/knowledge-base.rst:231
 msgid "**Draft/Scheduled/Archived** (visible to editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:241
+#: ../extras/knowledge-base.rst:247
 msgid "Using answers in ticket articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:243
+#: ../extras/knowledge-base.rst:249
 msgid ""
 "As soon as the knowledge base contains one or more answers, you can use "
 "these just like text modules. Instead of ``::`` just use ``??`` to open the "
@@ -5001,22 +5009,22 @@ msgid ""
 "all languages available."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:248
+#: ../extras/knowledge-base.rst:254
 msgid ""
 "If you've found what you've been looking for, simply hit your ENTER-Key to "
 "load the answer into the ticket article. This way you don't have to throw "
 "URLs at your customer and provide the answer right away."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:252
+#: ../extras/knowledge-base.rst:258
 msgid "Loading answers into articles *does not* replace article content."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:258
+#: ../extras/knowledge-base.rst:264
 msgid "Screencast showing how to insert KB answers into articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:258
+#: ../extras/knowledge-base.rst:264
 msgid "Use ``??`` to find and load knowledge base answers into ticket articles"
 msgstr ""
 
@@ -6138,8 +6146,8 @@ msgstr ""
 
 #: ../extras/shared-drafts.rst:50
 msgid ""
-"If you're in a new ticket dialogue *after selecting the ticket group*, the 📝 "
-"button will indicate the shared drafts function to be available."
+"If you're in a new ticket dialogue *after selecting the ticket group*, the "
+"📝 button will indicate the shared drafts function to be available."
 msgstr ""
 
 #: ../extras/shared-drafts.rst:55

--- a/locale/th/LC_MESSAGES/user-docs.po
+++ b/locale/th/LC_MESSAGES/user-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-09 13:15+0100\n"
+"POT-Creation-Date: 2023-12-04 12:38+0100\n"
 "PO-Revision-Date: 2022-04-16 15:56+0000\n"
 "Last-Translator: LAO <sumonchai@gmail.com>\n"
 "Language-Team: Thai <https://translations.zammad.org/projects/documentations/"
@@ -1298,7 +1298,7 @@ msgid ""
 msgstr ""
 
 #: ../snippets/ticket-state-type-circles.rst:4
-#: ../snippets/ticket-state-type-circles.rst:6 ../extras/knowledge-base.rst:221
+#: ../snippets/ticket-state-type-circles.rst:6 ../extras/knowledge-base.rst:227
 msgid "|grn|"
 msgstr "|grn|"
 
@@ -2064,9 +2064,9 @@ msgstr "ข้อความ"
 
 #: ../basics/service-ticket/create.rst:58
 msgid ""
-"📞 For phone calls, record the details of your conversation. These notes will "
-"not be sent to the customer (though he may be able to see them if he has a "
-"Zammad account)."
+"📞 For phone calls, record the details of your conversation. These notes "
+"will not be sent to the customer (though he may be able to see them if he "
+"has a Zammad account)."
 msgstr ""
 
 #: ../basics/service-ticket/create.rst:62
@@ -2075,8 +2075,8 @@ msgstr ""
 
 #: ../snippets/ui-protip-message-editor-features.rst:3
 msgid ""
-"The message editor supports 📋 copying-and-pasting (or dragging-and-dropping) "
-"of **🔤 rich text**, **🌄 images** and **📎 file attachments**."
+"The message editor supports 📋 copying-and-pasting (or dragging-and-"
+"dropping) of **🔤 rich text**, **🌄 images** and **📎 file attachments**."
 msgstr ""
 
 #: ../snippets/ui-protip-message-editor-features.rst:6
@@ -2271,8 +2271,9 @@ msgstr ""
 msgid ""
 "What about the **deletion of articles**? In Zammad, you can only delete "
 "articles that you have created yourself and which are not older than 10 "
-"minutes. To see the \"delete\" button in articles of the type \"communication"
-"\" (emails, calls), their visibility has to be switched to internal first."
+"minutes. To see the \"delete\" button in articles of the type "
+"\"communication\" (emails, calls), their visibility has to be switched to "
+"internal first."
 msgstr ""
 
 #: ../basics/service-ticket/follow-up.rst:107
@@ -2495,7 +2496,8 @@ msgid ""
 "problematic *per se,* but it does lead to a lot of unnecessary clutter in "
 "the :doc:`overviews menu </basics/find-ticket>`. (It can be much worse when, "
 "for example, a customer service rep sees tickets meant for your HR "
-"department, and finds out how much their colleagues in sales are making! 💸💸💸)"
+"department, and finds out how much their colleagues in sales are making! 💸💸"
+"💸)"
 msgstr ""
 
 #: ../basics/service-ticket/settings/group.rst:25
@@ -4212,8 +4214,8 @@ msgstr ""
 
 #: ../extras/chat.rst:51
 msgid ""
-"📝 Chats can be **renamed** or **tagged**, and record technical details about "
-"the customer’s connection."
+"📝 Chats can be **renamed** or **tagged**, and record technical details "
+"about the customer’s connection."
 msgstr ""
 
 #: ../extras/chat.rst:0
@@ -4897,42 +4899,48 @@ msgid ""
 "permissions"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:0
-msgid "Permissions of a parent category are inherited!"
+#: ../extras/knowledge-base.rst:162
+msgid ""
+"In general, permissions of a parent category are inherited! If you want to "
+"grant edit permissions for a sub-category for a specific role for example, "
+"set the upper level to \"reader\" and the desired sub-category to "
+"\"editor\". The other way round is not possible (permissions can only be "
+"widened, not restricted). If you can't select permissions in the table, this "
+"could be the reason."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:0
-msgid "Public answers are always available!"
+#: ../extras/knowledge-base.rst:169
+msgid "Be aware that public answers are always available!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:165
+#: ../extras/knowledge-base.rst:171
 msgid "**⚙️ Roles require knowledge base reader permission**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:167
+#: ../extras/knowledge-base.rst:173
 msgid ""
 "Your administrator has to provide the relevant groups with reader "
 "permissions for the knowledge base."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:170
+#: ../extras/knowledge-base.rst:176
 msgid "**🥵 Beware of visibility levels**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:172
+#: ../extras/knowledge-base.rst:178
 msgid ""
 "Knowledge base reader permission means that affected users can see "
 "**internal answers**. This is a potential issue if you're not dividing "
 "carefully!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:176
+#: ../extras/knowledge-base.rst:182
 msgid ""
 "If you're unsure, please ask your administrator to configure the :admin-docs:"
 "`role permissions </manage/roles/agent-permissions.html>` accordingly."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:181
+#: ../extras/knowledge-base.rst:187
 msgid "Editing Answers"
 msgstr "กำลังแก้ไขคำตอบ"
 
@@ -4940,7 +4948,7 @@ msgstr "กำลังแก้ไขคำตอบ"
 msgid "Edit answer"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:187
+#: ../extras/knowledge-base.rst:193
 msgid ""
 "The knowledge base editor comes equipped with the same **rich text editing "
 "capabilities** available in the Zammad ticket composer. That means you can "
@@ -4949,19 +4957,19 @@ msgid ""
 "attachments and links!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:193
+#: ../extras/knowledge-base.rst:199
 msgid "🤷 **Why are there four kinds of links?**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:196
+#: ../extras/knowledge-base.rst:202
 msgid "🔗 **Weblink**"
 msgstr "🔗 **ลิ้งเข้าถึง**"
 
-#: ../extras/knowledge-base.rst:196
+#: ../extras/knowledge-base.rst:202
 msgid "URLs pointing to other websites."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:200
+#: ../extras/knowledge-base.rst:206
 msgid "💡 **Link Answer**"
 msgstr "💡 **ไป ดูคำตอบ**"
 
@@ -4973,7 +4981,7 @@ msgstr ""
 msgid "(Will not break if destination URL changes.)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:204
+#: ../extras/knowledge-base.rst:210
 msgid "📋 **Linked Tickets**"
 msgstr "📋 **เชื่อม ใบแจ้งซ่อม**"
 
@@ -4985,7 +4993,7 @@ msgstr ""
 msgid "(Visible only in Preview and Edit Modes.)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:211
+#: ../extras/knowledge-base.rst:217
 msgid "🏷️ **Tags**"
 msgstr ""
 
@@ -5003,38 +5011,38 @@ msgstr ""
 msgid "Screencast showing tags on answers"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:216
+#: ../extras/knowledge-base.rst:222
 msgid ""
 "🙈 Set the **visibility** of an answer to control who can see an article, or "
 "schedule it to be published at a later date. Articles are **color-coded** "
 "according to their visibility:"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:221
+#: ../extras/knowledge-base.rst:227
 msgid "**Public** (visible to everyone)"
 msgstr "**เผยแพร่** (ทุกคนเข้าดูได้)"
 
-#: ../extras/knowledge-base.rst:223
+#: ../extras/knowledge-base.rst:229
 msgid "|blu|"
 msgstr "|blu|"
 
-#: ../extras/knowledge-base.rst:223
+#: ../extras/knowledge-base.rst:229
 msgid "**Internal** (visible to agents & editors only)"
 msgstr "**ภายใน** (เจ้าหน้าที่ และผู้แก้ไข)"
 
-#: ../extras/knowledge-base.rst:225
+#: ../extras/knowledge-base.rst:231
 msgid "|gry|"
 msgstr "|gry|"
 
-#: ../extras/knowledge-base.rst:225
+#: ../extras/knowledge-base.rst:231
 msgid "**Draft/Scheduled/Archived** (visible to editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:241
+#: ../extras/knowledge-base.rst:247
 msgid "Using answers in ticket articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:243
+#: ../extras/knowledge-base.rst:249
 msgid ""
 "As soon as the knowledge base contains one or more answers, you can use "
 "these just like text modules. Instead of ``::`` just use ``??`` to open the "
@@ -5042,22 +5050,22 @@ msgid ""
 "all languages available."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:248
+#: ../extras/knowledge-base.rst:254
 msgid ""
 "If you've found what you've been looking for, simply hit your ENTER-Key to "
 "load the answer into the ticket article. This way you don't have to throw "
 "URLs at your customer and provide the answer right away."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:252
+#: ../extras/knowledge-base.rst:258
 msgid "Loading answers into articles *does not* replace article content."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:258
+#: ../extras/knowledge-base.rst:264
 msgid "Screencast showing how to insert KB answers into articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:258
+#: ../extras/knowledge-base.rst:264
 msgid "Use ``??`` to find and load knowledge base answers into ticket articles"
 msgstr ""
 
@@ -6209,8 +6217,8 @@ msgstr ""
 
 #: ../extras/shared-drafts.rst:50
 msgid ""
-"If you're in a new ticket dialogue *after selecting the ticket group*, the 📝 "
-"button will indicate the shared drafts function to be available."
+"If you're in a new ticket dialogue *after selecting the ticket group*, the "
+"📝 button will indicate the shared drafts function to be available."
 msgstr ""
 
 #: ../extras/shared-drafts.rst:55

--- a/locale/tr/LC_MESSAGES/user-docs.po
+++ b/locale/tr/LC_MESSAGES/user-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-09 13:15+0100\n"
+"POT-Creation-Date: 2023-12-04 12:38+0100\n"
 "PO-Revision-Date: 2022-04-16 15:57+0000\n"
 "Last-Translator: TRANSFER FROM TRANSIFEX <support@zammad.com>\n"
 "Language-Team: Turkish <https://translations.zammad.org/projects/"
@@ -1473,7 +1473,7 @@ msgstr ""
 "kodları:**"
 
 #: ../snippets/ticket-state-type-circles.rst:4
-#: ../snippets/ticket-state-type-circles.rst:6 ../extras/knowledge-base.rst:221
+#: ../snippets/ticket-state-type-circles.rst:6 ../extras/knowledge-base.rst:227
 msgid "|grn|"
 msgstr "|grn|"
 
@@ -2279,8 +2279,8 @@ msgstr ""
 #: ../basics/service-ticket/create.rst:16
 #, fuzzy
 #| msgid ""
-#| "Click the **➕ button** to create a new ticket. The default ticket type is "
-#| "**received call**."
+#| "Click the **➕ button** to create a new ticket. The default ticket type "
+#| "is **received call**."
 msgid ""
 "Click the **➕ button** to create a new ticket. The default ticket type is "
 "**Received Call**."
@@ -2380,9 +2380,9 @@ msgstr "Metin"
 
 #: ../basics/service-ticket/create.rst:58
 msgid ""
-"📞 For phone calls, record the details of your conversation. These notes will "
-"not be sent to the customer (though he may be able to see them if he has a "
-"Zammad account)."
+"📞 For phone calls, record the details of your conversation. These notes "
+"will not be sent to the customer (though he may be able to see them if he "
+"has a Zammad account)."
 msgstr ""
 "📞 Telefon görüşmeleri için, görüşmenizin ayrıntılarını kaydedin. Bu notlar "
 "müşteriye gönderilmeyecektir (ancak bir Zammad hesabı varsa bunları "
@@ -2394,8 +2394,8 @@ msgstr "📧 E-postalar için, burası giden mesajınızın gövdesi."
 
 #: ../snippets/ui-protip-message-editor-features.rst:3
 msgid ""
-"The message editor supports 📋 copying-and-pasting (or dragging-and-dropping) "
-"of **🔤 rich text**, **🌄 images** and **📎 file attachments**."
+"The message editor supports 📋 copying-and-pasting (or dragging-and-"
+"dropping) of **🔤 rich text**, **🌄 images** and **📎 file attachments**."
 msgstr ""
 "Mesaj editörü 📋,  **🔤 zengin metin**, **🌄 görseller** and **📎 dosya "
 "ekleri**ni koplaya ve yapıştır (veya sürükle ve bırak) yapmayı destekler."
@@ -2639,8 +2639,9 @@ msgstr ""
 msgid ""
 "What about the **deletion of articles**? In Zammad, you can only delete "
 "articles that you have created yourself and which are not older than 10 "
-"minutes. To see the \"delete\" button in articles of the type \"communication"
-"\" (emails, calls), their visibility has to be switched to internal first."
+"minutes. To see the \"delete\" button in articles of the type "
+"\"communication\" (emails, calls), their visibility has to be switched to "
+"internal first."
 msgstr ""
 
 #: ../basics/service-ticket/follow-up.rst:107
@@ -2903,7 +2904,8 @@ msgid ""
 "problematic *per se,* but it does lead to a lot of unnecessary clutter in "
 "the :doc:`overviews menu </basics/find-ticket>`. (It can be much worse when, "
 "for example, a customer service rep sees tickets meant for your HR "
-"department, and finds out how much their colleagues in sales are making! 💸💸💸)"
+"department, and finds out how much their colleagues in sales are making! 💸💸"
+"💸)"
 msgstr ""
 "Gruplar olmadan, on temsilcinin tümü, hangi departman için olduğuna "
 "bakılmaksızın gelen her bir bileti görebilir (ve yanıt verebilir). Bu *başlı "
@@ -3151,8 +3153,8 @@ msgstr ""
 "Durumlar, ilerlemeyi belirtmekten fazlasını yapar: Zammad, müşterilerinin "
 "yeni bir biletine yanıt verilmesinin veya sorunlarının tamamen "
 "çözülmesininin ne kadar sürdüğünü ölçmek için durum bilgilerini kullanan "
-"ayrıntılı bir zaman izleme özelliğine (buna “\\ `hizmet düzeyi anlaşmaları `_"
-"\\ ” veya SLA'lar denir) sahiptir."
+"ayrıntılı bir zaman izleme özelliğine (buna “\\ `hizmet düzeyi anlaşmaları "
+"`_\\ ” veya SLA'lar denir) sahiptir."
 
 #: ../basics/service-ticket/settings/state.rst:38
 msgid ""
@@ -4834,8 +4836,8 @@ msgstr ""
 
 #: ../extras/chat.rst:51
 msgid ""
-"📝 Chats can be **renamed** or **tagged**, and record technical details about "
-"the customer’s connection."
+"📝 Chats can be **renamed** or **tagged**, and record technical details "
+"about the customer’s connection."
 msgstr ""
 "📝 Sohbetler **yeniden adlandırılabilir** veya **etiketlenebilir**, ve "
 "müşterinin bağlantısıyla ilgili teknik detaylar kaydedilebilir."
@@ -5132,7 +5134,8 @@ msgstr ""
 
 #: ../extras/github-gitlab-integration.rst:7
 msgid "🤔 **Huh? I don’t see** |github| **or** |gitlab| **tabs...**"
-msgstr "🤔 **Pardon? * |github| **veya** |gitlab| **sekmelerini görmüyorum...**"
+msgstr ""
+"🤔 **Pardon? * |github| **veya** |gitlab| **sekmelerini görmüyorum...**"
 
 #: ../extras/github-gitlab-integration.rst:45
 msgid "GitHub logo"
@@ -5672,42 +5675,48 @@ msgid ""
 "permissions"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:0
-msgid "Permissions of a parent category are inherited!"
+#: ../extras/knowledge-base.rst:162
+msgid ""
+"In general, permissions of a parent category are inherited! If you want to "
+"grant edit permissions for a sub-category for a specific role for example, "
+"set the upper level to \"reader\" and the desired sub-category to "
+"\"editor\". The other way round is not possible (permissions can only be "
+"widened, not restricted). If you can't select permissions in the table, this "
+"could be the reason."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:0
-msgid "Public answers are always available!"
+#: ../extras/knowledge-base.rst:169
+msgid "Be aware that public answers are always available!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:165
+#: ../extras/knowledge-base.rst:171
 msgid "**⚙️ Roles require knowledge base reader permission**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:167
+#: ../extras/knowledge-base.rst:173
 msgid ""
 "Your administrator has to provide the relevant groups with reader "
 "permissions for the knowledge base."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:170
+#: ../extras/knowledge-base.rst:176
 msgid "**🥵 Beware of visibility levels**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:172
+#: ../extras/knowledge-base.rst:178
 msgid ""
 "Knowledge base reader permission means that affected users can see "
 "**internal answers**. This is a potential issue if you're not dividing "
 "carefully!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:176
+#: ../extras/knowledge-base.rst:182
 msgid ""
 "If you're unsure, please ask your administrator to configure the :admin-docs:"
 "`role permissions </manage/roles/agent-permissions.html>` accordingly."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:181
+#: ../extras/knowledge-base.rst:187
 msgid "Editing Answers"
 msgstr "Cevapları Düzenlemek"
 
@@ -5715,7 +5724,7 @@ msgstr "Cevapları Düzenlemek"
 msgid "Edit answer"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:187
+#: ../extras/knowledge-base.rst:193
 msgid ""
 "The knowledge base editor comes equipped with the same **rich text editing "
 "capabilities** available in the Zammad ticket composer. That means you can "
@@ -5730,19 +5739,19 @@ msgstr ""
 "kullanabileceğiniz anlamına gelir. Hatta dosya ekleri ve bağlantılar "
 "ekleyebilirsiniz!"
 
-#: ../extras/knowledge-base.rst:193
+#: ../extras/knowledge-base.rst:199
 msgid "🤷 **Why are there four kinds of links?**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:196
+#: ../extras/knowledge-base.rst:202
 msgid "🔗 **Weblink**"
 msgstr "🔗 **Web bağlantısı**"
 
-#: ../extras/knowledge-base.rst:196
+#: ../extras/knowledge-base.rst:202
 msgid "URLs pointing to other websites."
 msgstr "URL'ler diğer web sitelerini gösteriyor."
 
-#: ../extras/knowledge-base.rst:200
+#: ../extras/knowledge-base.rst:206
 msgid "💡 **Link Answer**"
 msgstr "💡 **Bağlantılı Cevap**"
 
@@ -5754,7 +5763,7 @@ msgstr "Diğer bilgi tabanı cevaplarından iç referanslar."
 msgid "(Will not break if destination URL changes.)"
 msgstr "(Hedef URL değişirse bozulmaz.)"
 
-#: ../extras/knowledge-base.rst:204
+#: ../extras/knowledge-base.rst:210
 msgid "📋 **Linked Tickets**"
 msgstr "📋 **Bağlı Biletler**"
 
@@ -5766,7 +5775,7 @@ msgstr "Zammad biletlerinden iç referanslar."
 msgid "(Visible only in Preview and Edit Modes.)"
 msgstr "(Sadece Önizleme ve Düzenleme Modlarında görünür.)"
 
-#: ../extras/knowledge-base.rst:211
+#: ../extras/knowledge-base.rst:217
 msgid "🏷️ **Tags**"
 msgstr ""
 
@@ -5784,7 +5793,7 @@ msgstr ""
 msgid "Screencast showing tags on answers"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:216
+#: ../extras/knowledge-base.rst:222
 msgid ""
 "🙈 Set the **visibility** of an answer to control who can see an article, or "
 "schedule it to be published at a later date. Articles are **color-coded** "
@@ -5794,31 +5803,31 @@ msgstr ""
 "tarihte yayınlanmasını planlamak için yanıtın **görünürlüğünü** ayarlayın. "
 "Makaleler, görünürlüklerine göre **renk kodu** alır:"
 
-#: ../extras/knowledge-base.rst:221
+#: ../extras/knowledge-base.rst:227
 msgid "**Public** (visible to everyone)"
 msgstr "**Herkese Açık** (herkes tarafından görülebilir)"
 
-#: ../extras/knowledge-base.rst:223
+#: ../extras/knowledge-base.rst:229
 msgid "|blu|"
 msgstr "|blu|"
 
-#: ../extras/knowledge-base.rst:223
+#: ../extras/knowledge-base.rst:229
 msgid "**Internal** (visible to agents & editors only)"
 msgstr "**Dahili** (sadece aracılar ve editörler görebilir)"
 
-#: ../extras/knowledge-base.rst:225
+#: ../extras/knowledge-base.rst:231
 msgid "|gry|"
 msgstr "|gry|"
 
-#: ../extras/knowledge-base.rst:225
+#: ../extras/knowledge-base.rst:231
 msgid "**Draft/Scheduled/Archived** (visible to editors only)"
 msgstr "**Taslak/Planlanmış/Arşiv** (sadece editörler görebilir)"
 
-#: ../extras/knowledge-base.rst:241
+#: ../extras/knowledge-base.rst:247
 msgid "Using answers in ticket articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:243
+#: ../extras/knowledge-base.rst:249
 msgid ""
 "As soon as the knowledge base contains one or more answers, you can use "
 "these just like text modules. Instead of ``::`` just use ``??`` to open the "
@@ -5826,22 +5835,22 @@ msgid ""
 "all languages available."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:248
+#: ../extras/knowledge-base.rst:254
 msgid ""
 "If you've found what you've been looking for, simply hit your ENTER-Key to "
 "load the answer into the ticket article. This way you don't have to throw "
 "URLs at your customer and provide the answer right away."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:252
+#: ../extras/knowledge-base.rst:258
 msgid "Loading answers into articles *does not* replace article content."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:258
+#: ../extras/knowledge-base.rst:264
 msgid "Screencast showing how to insert KB answers into articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:258
+#: ../extras/knowledge-base.rst:264
 msgid "Use ``??`` to find and load knowledge base answers into ticket articles"
 msgstr ""
 
@@ -6850,7 +6859,8 @@ msgid ""
 "The 🔒 and ✅ icons at the top of a message indicate its encryption and "
 "signing status."
 msgstr ""
-"Bir mesajın üst kısmındaki 🔒 ve ✅ simgeleri mesajın S/MIME durumunu gösterir."
+"Bir mesajın üst kısmındaki 🔒 ve ✅ simgeleri mesajın S/MIME durumunu "
+"gösterir."
 
 #: ../extras/secure-email.rst:75
 msgid "Screencast showing details of encryption and signing status"
@@ -6978,8 +6988,8 @@ msgstr ""
 #: ../extras/secure-email.rst:113
 #, fuzzy
 #| msgid ""
-#| "🔒 **Encrypt** and ✅ **Sign** buttons are present on both new tickets and "
-#| "replies. Hover over the buttons to show a certificate/CA summary."
+#| "🔒 **Encrypt** and ✅ **Sign** buttons are present on both new tickets "
+#| "and replies. Hover over the buttons to show a certificate/CA summary."
 msgid ""
 "🔒 **Encrypt** and ✅ **Sign** buttons are present on both new tickets and "
 "replies. Hover over the buttons to show details."
@@ -7263,8 +7273,8 @@ msgstr ""
 
 #: ../extras/shared-drafts.rst:50
 msgid ""
-"If you're in a new ticket dialogue *after selecting the ticket group*, the 📝 "
-"button will indicate the shared drafts function to be available."
+"If you're in a new ticket dialogue *after selecting the ticket group*, the "
+"📝 button will indicate the shared drafts function to be available."
 msgstr ""
 
 #: ../extras/shared-drafts.rst:55

--- a/locale/zh_Hans/LC_MESSAGES/user-docs.po
+++ b/locale/zh_Hans/LC_MESSAGES/user-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-09 13:15+0100\n"
+"POT-Creation-Date: 2023-12-04 12:38+0100\n"
 "PO-Revision-Date: 2022-11-04 15:14+0000\n"
 "Last-Translator: Never Min <59808@qq.com>\n"
 "Language-Team: Chinese (Simplified) <https://translations.zammad.org/"
@@ -1360,7 +1360,7 @@ msgid ""
 msgstr ""
 
 #: ../snippets/ticket-state-type-circles.rst:4
-#: ../snippets/ticket-state-type-circles.rst:6 ../extras/knowledge-base.rst:221
+#: ../snippets/ticket-state-type-circles.rst:6 ../extras/knowledge-base.rst:227
 msgid "|grn|"
 msgstr ""
 
@@ -2126,9 +2126,9 @@ msgstr ""
 
 #: ../basics/service-ticket/create.rst:58
 msgid ""
-"📞 For phone calls, record the details of your conversation. These notes will "
-"not be sent to the customer (though he may be able to see them if he has a "
-"Zammad account)."
+"📞 For phone calls, record the details of your conversation. These notes "
+"will not be sent to the customer (though he may be able to see them if he "
+"has a Zammad account)."
 msgstr ""
 
 #: ../basics/service-ticket/create.rst:62
@@ -2137,8 +2137,8 @@ msgstr ""
 
 #: ../snippets/ui-protip-message-editor-features.rst:3
 msgid ""
-"The message editor supports 📋 copying-and-pasting (or dragging-and-dropping) "
-"of **🔤 rich text**, **🌄 images** and **📎 file attachments**."
+"The message editor supports 📋 copying-and-pasting (or dragging-and-"
+"dropping) of **🔤 rich text**, **🌄 images** and **📎 file attachments**."
 msgstr ""
 
 #: ../snippets/ui-protip-message-editor-features.rst:6
@@ -2333,8 +2333,9 @@ msgstr ""
 msgid ""
 "What about the **deletion of articles**? In Zammad, you can only delete "
 "articles that you have created yourself and which are not older than 10 "
-"minutes. To see the \"delete\" button in articles of the type \"communication"
-"\" (emails, calls), their visibility has to be switched to internal first."
+"minutes. To see the \"delete\" button in articles of the type "
+"\"communication\" (emails, calls), their visibility has to be switched to "
+"internal first."
 msgstr ""
 
 #: ../basics/service-ticket/follow-up.rst:107
@@ -2555,7 +2556,8 @@ msgid ""
 "problematic *per se,* but it does lead to a lot of unnecessary clutter in "
 "the :doc:`overviews menu </basics/find-ticket>`. (It can be much worse when, "
 "for example, a customer service rep sees tickets meant for your HR "
-"department, and finds out how much their colleagues in sales are making! 💸💸💸)"
+"department, and finds out how much their colleagues in sales are making! 💸💸"
+"💸)"
 msgstr ""
 
 #: ../basics/service-ticket/settings/group.rst:25
@@ -4264,8 +4266,8 @@ msgstr ""
 
 #: ../extras/chat.rst:51
 msgid ""
-"📝 Chats can be **renamed** or **tagged**, and record technical details about "
-"the customer’s connection."
+"📝 Chats can be **renamed** or **tagged**, and record technical details "
+"about the customer’s connection."
 msgstr ""
 
 #: ../extras/chat.rst:0
@@ -4947,42 +4949,48 @@ msgid ""
 "permissions"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:0
-msgid "Permissions of a parent category are inherited!"
+#: ../extras/knowledge-base.rst:162
+msgid ""
+"In general, permissions of a parent category are inherited! If you want to "
+"grant edit permissions for a sub-category for a specific role for example, "
+"set the upper level to \"reader\" and the desired sub-category to "
+"\"editor\". The other way round is not possible (permissions can only be "
+"widened, not restricted). If you can't select permissions in the table, this "
+"could be the reason."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:0
-msgid "Public answers are always available!"
+#: ../extras/knowledge-base.rst:169
+msgid "Be aware that public answers are always available!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:165
+#: ../extras/knowledge-base.rst:171
 msgid "**⚙️ Roles require knowledge base reader permission**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:167
+#: ../extras/knowledge-base.rst:173
 msgid ""
 "Your administrator has to provide the relevant groups with reader "
 "permissions for the knowledge base."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:170
+#: ../extras/knowledge-base.rst:176
 msgid "**🥵 Beware of visibility levels**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:172
+#: ../extras/knowledge-base.rst:178
 msgid ""
 "Knowledge base reader permission means that affected users can see "
 "**internal answers**. This is a potential issue if you're not dividing "
 "carefully!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:176
+#: ../extras/knowledge-base.rst:182
 msgid ""
 "If you're unsure, please ask your administrator to configure the :admin-docs:"
 "`role permissions </manage/roles/agent-permissions.html>` accordingly."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:181
+#: ../extras/knowledge-base.rst:187
 msgid "Editing Answers"
 msgstr ""
 
@@ -4990,7 +4998,7 @@ msgstr ""
 msgid "Edit answer"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:187
+#: ../extras/knowledge-base.rst:193
 msgid ""
 "The knowledge base editor comes equipped with the same **rich text editing "
 "capabilities** available in the Zammad ticket composer. That means you can "
@@ -4999,19 +5007,19 @@ msgid ""
 "attachments and links!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:193
+#: ../extras/knowledge-base.rst:199
 msgid "🤷 **Why are there four kinds of links?**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:196
+#: ../extras/knowledge-base.rst:202
 msgid "🔗 **Weblink**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:196
+#: ../extras/knowledge-base.rst:202
 msgid "URLs pointing to other websites."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:200
+#: ../extras/knowledge-base.rst:206
 msgid "💡 **Link Answer**"
 msgstr ""
 
@@ -5023,7 +5031,7 @@ msgstr ""
 msgid "(Will not break if destination URL changes.)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:204
+#: ../extras/knowledge-base.rst:210
 msgid "📋 **Linked Tickets**"
 msgstr ""
 
@@ -5035,7 +5043,7 @@ msgstr ""
 msgid "(Visible only in Preview and Edit Modes.)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:211
+#: ../extras/knowledge-base.rst:217
 msgid "🏷️ **Tags**"
 msgstr ""
 
@@ -5053,38 +5061,38 @@ msgstr ""
 msgid "Screencast showing tags on answers"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:216
+#: ../extras/knowledge-base.rst:222
 msgid ""
 "🙈 Set the **visibility** of an answer to control who can see an article, or "
 "schedule it to be published at a later date. Articles are **color-coded** "
 "according to their visibility:"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:221
+#: ../extras/knowledge-base.rst:227
 msgid "**Public** (visible to everyone)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:223
+#: ../extras/knowledge-base.rst:229
 msgid "|blu|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:223
+#: ../extras/knowledge-base.rst:229
 msgid "**Internal** (visible to agents & editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:225
+#: ../extras/knowledge-base.rst:231
 msgid "|gry|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:225
+#: ../extras/knowledge-base.rst:231
 msgid "**Draft/Scheduled/Archived** (visible to editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:241
+#: ../extras/knowledge-base.rst:247
 msgid "Using answers in ticket articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:243
+#: ../extras/knowledge-base.rst:249
 msgid ""
 "As soon as the knowledge base contains one or more answers, you can use "
 "these just like text modules. Instead of ``::`` just use ``??`` to open the "
@@ -5092,22 +5100,22 @@ msgid ""
 "all languages available."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:248
+#: ../extras/knowledge-base.rst:254
 msgid ""
 "If you've found what you've been looking for, simply hit your ENTER-Key to "
 "load the answer into the ticket article. This way you don't have to throw "
 "URLs at your customer and provide the answer right away."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:252
+#: ../extras/knowledge-base.rst:258
 msgid "Loading answers into articles *does not* replace article content."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:258
+#: ../extras/knowledge-base.rst:264
 msgid "Screencast showing how to insert KB answers into articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:258
+#: ../extras/knowledge-base.rst:264
 msgid "Use ``??`` to find and load knowledge base answers into ticket articles"
 msgstr ""
 
@@ -6233,8 +6241,8 @@ msgstr ""
 
 #: ../extras/shared-drafts.rst:50
 msgid ""
-"If you're in a new ticket dialogue *after selecting the ticket group*, the 📝 "
-"button will indicate the shared drafts function to be available."
+"If you're in a new ticket dialogue *after selecting the ticket group*, the "
+"📝 button will indicate the shared drafts function to be available."
 msgstr ""
 
 #: ../extras/shared-drafts.rst:55


### PR DESCRIPTION
Translations update from [Zammad-Translations](https://translations.zammad.org) for [Documentation/User Documentation (pre-release)](https://translations.zammad.org/projects/documentations/user-documentation-pre-release/).



Current translation status:

![Weblate translation status](https://translations.zammad.org/widget/documentations/user-documentation-pre-release/horizontal-auto.svg)