### PR TITLE
Translations update from Zammad-Translations

### DIFF
--- a/locale/cs/LC_MESSAGES/user-docs.po
+++ b/locale/cs/LC_MESSAGES/user-docs.po
@@ -7085,3 +7085,15 @@ msgid ""
 "docs:`system </index.html>` and :admin-docs:`administration manuals </index."
 "html>` available."
 msgstr ""
+
+#: ../basics/zammad-glossary.rst:618
+msgid "Bottom section:"
+msgstr ""
+
+#: ../basics/zammad-glossary.rst:732
+msgid ""
+"The title of a ticket is different based on the channel it came in. You can "
+"find the title in the sidebar and in the top area in the ticket view. If the "
+"title is not very meaningful, you can change it by clicking on the title in "
+"a ticket view."
+msgstr ""

--- a/locale/da/LC_MESSAGES/user-docs.po
+++ b/locale/da/LC_MESSAGES/user-docs.po
@@ -7085,3 +7085,15 @@ msgid ""
 "docs:`system </index.html>` and :admin-docs:`administration manuals </index."
 "html>` available."
 msgstr ""
+
+#: ../basics/zammad-glossary.rst:618
+msgid "Bottom section:"
+msgstr ""
+
+#: ../basics/zammad-glossary.rst:732
+msgid ""
+"The title of a ticket is different based on the channel it came in. You can "
+"find the title in the sidebar and in the top area in the ticket view. If the "
+"title is not very meaningful, you can change it by clicking on the title in "
+"a ticket view."
+msgstr ""

--- a/locale/de/LC_MESSAGES/user-docs.po
+++ b/locale/de/LC_MESSAGES/user-docs.po
@@ -3609,7 +3609,7 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:54
 msgid "Auto Response"
-msgstr ""
+msgstr "Automatische Antwort"
 
 #: ../basics/zammad-glossary.rst:51
 msgid ""
@@ -3618,6 +3618,11 @@ msgid ""
 "received and to provide the ticket number to the customer). Your admin may "
 "change this or even add more auto generated messages."
 msgstr ""
+"Zammad kann automatisch generierte Antworten an Kunden senden. Standardmäßig "
+"ist dies für neu erstellte Tickets konfiguriert (um zu bestätigen, dass die "
+"E-Mail empfangen wurde und um dem Kunden die Ticket-Nummer mitzuteilen). Ihr "
+"Administrator kann dies ändern oder sogar weitere automatisch generierte "
+"Nachrichten hinzufügen."
 
 #: ../basics/zammad-glossary.rst:60
 msgid "Automation"
@@ -3671,6 +3676,11 @@ msgid ""
 "To customize it, go to the avatar section in your :doc:`user profile </"
 "extras/profile-and-settings>`."
 msgstr ""
+"Ein Avatar ist im Grunde eine grafische Darstellung eines Benutzers. "
+"Standardmäßig besteht der Avatar des Benutzers aus den Initialen des "
+"Benutzers. Es kann aber auch ein Bild verwendet werden. Um ihn anzupassen, "
+"gehen Sie zum Abschnitt Avatar in Ihrem :doc:`Benutzerprofil </extras/"
+"profile-and-settings>`."
 
 #: ../basics/zammad-glossary.rst:78
 msgid ""
@@ -3678,6 +3688,10 @@ msgid ""
 "you can see it next to an article in a ticket or in the bottom bar if "
 "another agent is viewing or editing the same ticket."
 msgstr ""
+"Der Avatar eines Benutzers ist an verschiedenen Stellen in Zammad sichtbar. "
+"Sie können ihn zum Beispiel neben einem Artikel in einem Ticket oder in der "
+"unteren Leiste sehen, wenn ein anderer Agent dasselbe Ticket betrachtet oder "
+"bearbeitet."
 
 #: ../basics/zammad-glossary.rst:84
 msgid "B"
@@ -3731,10 +3745,8 @@ msgstr ""
 "blob/stable/CHANGELOG.md>`_ finden!"
 
 #: ../basics/zammad-glossary.rst:105
-#, fuzzy
-#| msgid "Changelog"
 msgid "Channel"
-msgstr "Änderungslog"
+msgstr "Kanal"
 
 #: ../basics/zammad-glossary.rst:104
 msgid ""
@@ -3742,6 +3754,9 @@ msgid ""
 "channels are email and phone. Additional channels can be configured by your "
 "admin."
 msgstr ""
+"Ein Kanal ist eine Möglichkeit, wie Kunden mit Ihnen in Kontakt treten "
+"können. Standardkanäle sind E-Mail und Telefon. Zusätzliche Kanäle können "
+"von Ihrem Administrator konfiguriert werden."
 
 #: ../basics/zammad-glossary.rst:114
 msgid "Checkmk"
@@ -3905,22 +3920,26 @@ msgstr ""
 "zur Fertigstellung)."
 
 #: ../basics/zammad-glossary.rst:172
-#, fuzzy
-#| msgid "Modify customer attributes"
 msgid "Custom Object Attributes"
-msgstr "Ändern von Kundenattributen"
+msgstr "Benutzerdefinierte Objektattribute"
 
 #: ../basics/zammad-glossary.rst:168
 msgid ""
 "Zammad allows the creation of custom object attributes by admins. This can "
 "be done on ticket level, user level, organization level or group level."
 msgstr ""
+"Zammad ermöglicht die Erstellung von benutzerdefinierten Objektattributen "
+"durch Administratoren. Dies kann auf Ticket-, Benutzer-, Organisations- oder "
+"Gruppen-Ebene geschehen."
 
 #: ../basics/zammad-glossary.rst:171
 msgid ""
 "You can think of such a custom object attribute as a new field which has a "
 "pre-defined format and optionally selectable values."
 msgstr ""
+"Sie können sich ein solches benutzerdefiniertes Objektattribut wie ein neues "
+"Feld vorstellen, das ein vordefiniertes Format und optional auswählbare "
+"Werte hat."
 
 #: ../basics/zammad-glossary.rst:175
 msgid ""
@@ -4581,10 +4600,16 @@ msgid ""
 "response, Zammad can't assign the message to the existing ticket but creates "
 "a new one."
 msgstr ""
+"Wenn Sie zwei (oder mehr) Tickets für dasselbe Problem haben, können Sie "
+"diese zusammenführen. Standardmäßig prüft Zammad, ob eine Nachricht von "
+"einer externen Partei zu einem bestehenden Ticket gehört. Wenn Ihr Kunde "
+"jedoch zum Beispiel eine völlig neue E-Mail schreibt, anstatt die "
+"automatische Antwort zu beantworten, kann Zammad die Nachricht nicht dem "
+"bestehenden Ticket zuordnen, sondern erstellt ein neues."
 
 #: ../basics/zammad-glossary.rst:458
 msgid "See :doc:`/advanced/ticket-actions` for further information."
-msgstr ""
+msgstr "Siehe :doc:`/advanced/ticket-actions` für weitere Informationen."
 
 #: ../basics/zammad-glossary.rst:464
 msgid "Migrator / Migration Wizard"
@@ -4664,16 +4689,16 @@ msgid ""
 "notification settings in your user profile. You can even mention other users "
 "or subscribe to a specific ticket if you are interested how it proceeds."
 msgstr ""
+"Um zu vermeiden, dass Sie neue Nachrichten (z.B. von einem Kunden) "
+"übersehen, benachrichtigt Zammad Sie standardmäßig über jede relevante "
+"Änderung. Sie können Ihre allgemeinen Benachrichtigungseinstellungen in "
+"Ihrem Benutzerprofil anpassen. Sie können sogar andere Benutzer erwähnen "
+"oder ein bestimmtes Ticket abonnieren, wenn Sie auf dem Laufenden bleiben "
+"wollen."
 
 #: ../basics/zammad-glossary.rst:490
-#, fuzzy
-#| msgid ""
-#| "Check your :doc:`/extras/profile-and-settings` to customize how you "
-#| "receive notifications."
 msgid "See :doc:`/extras/profile-and-settings` for more information."
-msgstr ""
-"Prüfen Sie :doc:`/extras/profile-and-settings` um Benachrichtigungen für "
-"Abonnements zu verwalten."
+msgstr "Siehe :doc:`/extras/profile-and-settings` für weitere Informationen."
 
 #: ../basics/zammad-glossary.rst:493
 msgid "O"
@@ -4708,11 +4733,16 @@ msgid ""
 "shipped with Zammad by default. If you want to have a custom overview, ask "
 "your admin to create it."
 msgstr ""
+"Übersichten sind Ihr Ausgangspunkt für die Bearbeitung von Tickets. Sie "
+"können sich die Übersichten als eine Art Filter für bestehende Tickets "
+"vorstellen. Einige grundlegende Übersichten werden standardmäßig mit Zammad "
+"ausgeliefert. Wenn Sie eine benutzerdefinierte Übersicht haben möchten, "
+"bitten Sie Ihren Administrator, diese zu erstellen."
 
 #: ../basics/zammad-glossary.rst:507
 msgid ""
 "For more information please have a look in :doc:`/basics/find-ticket/browse`."
-msgstr ""
+msgstr "Weitere Informationen finden Sie in :doc:`/basics/find-ticket/browse`."
 
 #: ../basics/zammad-glossary.rst:511
 msgid ""
@@ -4815,6 +4845,9 @@ msgid ""
 "administrator can find more information :admin-docs:`here </system/objects."
 "html#system-attributes>`."
 msgstr ""
+"Die Prioritäten können sogar an Ihre Bedürfnisse angepasst oder erweitert "
+"werden. Ihr Administrator kann weitere Informationen :admin-docs:`hier </"
+"system/objects.html#system-attributes>` finden."
 
 #: ../basics/zammad-glossary.rst:557
 msgid "Q"
@@ -4849,10 +4882,8 @@ msgstr ""
 "2.1, ...) und bringen kleinere Änderungen."
 
 #: ../basics/zammad-glossary.rst:580 ../basics/zammad-glossary.rst:621
-#, fuzzy
-#| msgid "Reports"
 msgid "Reporting"
-msgstr "Auswertungen"
+msgstr "Berichte"
 
 #: ../basics/zammad-glossary.rst:575
 msgid ""
@@ -4860,18 +4891,17 @@ msgid ""
 "tickets per month). There are two types of reporting: the reporting "
 "functionality integrated in Zammad and the reporting with external tools."
 msgstr ""
+"Die Berichte helfen, eine Übersicht über Statistiken und Zahlen zu behalten "
+"(z.B. erstellte Tickets pro Monat). Es gibt zwei Arten von Berichten: die in "
+"Zammad integrierte Berichtsfunktion und die Berichte mit externen Tools."
 
 #: ../basics/zammad-glossary.rst:579
-#, fuzzy
-#| msgid ""
-#| "Administrators can learn more about customizing text modules :admin-docs:"
-#| "`here </manage/text-modules.html>`."
 msgid ""
 "Admins can find further information :admin-docs:`here </manage/report-"
 "profiles.html>`."
 msgstr ""
-"Administratoren können :admin-docs:`hier </manage/text-modules.html>` mehr "
-"über das Anpassen von Textbausteinen erfahren."
+"Admins können :admin-docs:`hier </manage/report-profiles.html>` weitere "
+"Informationen finden."
 
 #: ../basics/zammad-glossary.rst:593
 msgid "Role"
@@ -4915,7 +4945,7 @@ msgstr "S"
 
 #: ../basics/zammad-glossary.rst:603
 msgid "Scheduler"
-msgstr ""
+msgstr "Automatisierung"
 
 #: ../basics/zammad-glossary.rst:599
 msgid ""
@@ -4925,10 +4955,15 @@ msgid ""
 "documentation in the :admin-docs:`scheduler section </manage/scheduler."
 "html>`."
 msgstr ""
+"Der Scheduler ist eine der Automatisierungsfunktionen von Zammad. Ein "
+"Administrator kann spezifische Bedingungen und Aktionen definieren, die auf "
+"Tickets mit übereinstimmenden Bedingungen zeitbasiert angewendet werden. "
+"Weitere Informationen finden Sie in der Admin-Dokumentation im Abschnitt :"
+"admin-docs:`Automatisierung </manage/scheduler.html>`."
 
 #: ../basics/zammad-glossary.rst:623
 msgid "Sidebar"
-msgstr ""
+msgstr "Seitenleiste"
 
 #: ../basics/zammad-glossary.rst:606
 msgid ""
@@ -4936,60 +4971,50 @@ msgid ""
 "might need. Depending on the configured channels and your permissions, it "
 "might not include all sections which are listed below:"
 msgstr ""
+"Die Seitenleiste auf der linken Seite enthält alle relevanten Orte und "
+"Objekte, die Sie möglicherweise benötigen. Je nach den konfigurierten "
+"Kanälen und Ihren Berechtigungen enthält sie möglicherweise nicht alle "
+"Abschnitte, die unten aufgeführt sind:"
 
 #: ../basics/zammad-glossary.rst:610
-#, fuzzy
-#| msgid "Search phrase"
 msgid "Search bar"
-msgstr "Suchphrase"
+msgstr "Suchleiste"
 
 #: ../basics/zammad-glossary.rst:611
-#, fuzzy
-#| msgid "Notifications"
 msgid "Notification section"
-msgstr "Benachrichtigungen"
+msgstr "Benachrichtigungs-Bereich"
 
 #: ../basics/zammad-glossary.rst:613 ../extras/profile-and-settings.rst:0
 msgid "Overviews"
 msgstr "Übersichten"
 
 #: ../basics/zammad-glossary.rst:615
-#, fuzzy
-#| msgid "Customer"
 msgid "Customer Chat"
-msgstr "Kunde"
+msgstr "Kunden-Chat"
 
 #: ../basics/zammad-glossary.rst:616
 msgid "Phone"
-msgstr ""
+msgstr "Telefon"
 
 #: ../basics/zammad-glossary.rst:617
-#, fuzzy
-#| msgid "How to merge tickets?"
 msgid "One or more open tickets"
-msgstr "Wie fasst man Tickets zusammen?"
+msgstr "Ein oder mehrere offene Tickets"
 
 #: ../basics/zammad-glossary.rst:618
 msgid "Bootom section:"
 msgstr ""
 
 #: ../basics/zammad-glossary.rst:622
-#, fuzzy
-#| msgid "Ticket Settings"
 msgid "Admin settings"
-msgstr "Ticket-Einstellungen"
+msgstr "Admin-Einstellungen"
 
 #: ../basics/zammad-glossary.rst:623
-#, fuzzy
-#| msgid "Text modules on ticket creation"
 msgid "Button for ticket creation"
-msgstr "Text Bausteine bei der Ticket-Erstellung"
+msgstr "Schaltfläche zur Erstellung eines Tickets"
 
 #: ../basics/zammad-glossary.rst:632
-#, fuzzy
-#| msgid "Feature"
 msgid "Signature"
-msgstr "Feature"
+msgstr "Signatur"
 
 #: ../basics/zammad-glossary.rst:626
 msgid ""
@@ -4997,12 +5022,17 @@ msgid ""
 "contact details and the name of your company/department there. It can even "
 "contain your :ref:`avatar image <glossary-avatar>`."
 msgstr ""
+"Die Signatur ist Ihre Fußzeile in einer ausgehenden Nachricht. Ihre Kunden "
+"können dort Kontaktinformationen und den Namen Ihrer Firma/Abteilung finden. "
+"Sie kann sogar Ihr :ref:`Avatar-Bild <glossary-avatar>` enthalten."
 
 #: ../basics/zammad-glossary.rst:631
 msgid ""
 "It can be customized by your admin. Further information can be found :admin-"
 "docs:`here </channels/email/signatures.html>`."
 msgstr ""
+"Sie kann von Ihrem Admin angepasst werden. Weitere Informationen finden Sie :"
+"admin-docs:`hier </channels/email/signatures.html>`."
 
 #: ../basics/zammad-glossary.rst:642
 msgid "Sipgate"
@@ -5066,10 +5096,8 @@ msgstr ""
 "zammad.com/en/product/features/sla>`_."
 
 #: ../basics/zammad-glossary.rst:663
-#, fuzzy
-#| msgid "Splitting Tickets"
 msgid "Splitting tickets"
-msgstr "Tickets spalten"
+msgstr "Tickets abspalten"
 
 #: ../basics/zammad-glossary.rst:660
 msgid ""
@@ -5078,6 +5106,11 @@ msgid ""
 "based on the selected article for splitting. See :doc:`/advanced/ticket-"
 "actions` for more information."
 msgstr ""
+"Wenn ein Ticket mehr als ein Problem enthält und Sie es in einem separaten "
+"Ticket bearbeiten möchten, können Sie das Ticket in ein neues abspalten. "
+"Zammad erstellt dann ein neues Ticket auf der Grundlage des für die "
+"Aufteilung ausgewählten Artikels. Siehe :doc:`/advanced/ticket-actions` für "
+"weitere Informationen."
 
 #: ../basics/zammad-glossary.rst:672
 msgid "SSO"
@@ -5108,34 +5141,30 @@ msgstr ""
 "zammad.com/en/product/features/sso>`_."
 
 #: ../basics/zammad-glossary.rst:675
-#, fuzzy
-#| msgid ""
-#| "Every ticket has a status. You can change it once you've updated the "
-#| "ticket. There are four types of status, and they are all color-coded."
 msgid ""
 "Every ticket has a state. You can change it once you've updated the ticket. "
 "There are four types of states, and they are all color-coded."
 msgstr ""
-"Jedes Ticket hat einen Status. Sie können diese mit dem Update eines Tickets "
-"ändern. Es gibt für Statustypen, diese sind farbkodiert."
+"Jedes Ticket hat einen Status. Sie können ihn ändern, sobald Sie das Ticket "
+"aktualisiert haben. Es gibt vier Arten von Status, die alle farblich "
+"gekennzeichnet sind."
 
 #: ../basics/zammad-glossary.rst:678
-#, fuzzy
-#| msgid ""
-#| "Learn more about states and they color coding on this page: :doc:`/basics/"
-#| "service-ticket/settings/state`"
 msgid ""
 "Learn more about states and their color coding on this page: :doc:`/basics/"
 "service-ticket/settings/state`"
 msgstr ""
-"Zu Farbkodierungen und Status erfahren Sie mehr auf dieser Seite: :doc:`/"
-"basics/service-ticket/settings/state`"
+"Zu Status und deren Farben erfahren Sie mehr auf dieser Seite: :doc:`/basics/"
+"service-ticket/settings/state`"
 
 #: ../basics/zammad-glossary.rst:681
 msgid ""
 "The available states can be changed or extended. Your admin can find further "
 "information :admin-docs:`here </system/objects.html#system-attributes>`."
 msgstr ""
+"Die verfügbaren Status können geändert oder erweitert werden. Ihr Admin "
+"findet weitere Informationen :admin-docs:`hier </system/objects.html#system-"
+"attributes>`."
 
 #: ../basics/zammad-glossary.rst:692
 msgid "S/MIME"
@@ -5254,10 +5283,8 @@ msgid ""
 msgstr ""
 
 #: ../basics/zammad-glossary.rst:741
-#, fuzzy
-#| msgid "Ticket Macros"
 msgid "Ticket hook"
-msgstr "Ticket-Makros"
+msgstr "Ticket-Hook"
 
 #: ../basics/zammad-glossary.rst:738
 msgid ""
@@ -5266,10 +5293,14 @@ msgid ""
 "admin. See :admin-docs:`here </settings/ticket.html>` for further "
 "information."
 msgstr ""
+"Der Ticket-Hook dient zur Identifizierung eines Tickets. Standardmäßig "
+"lautet er ``Ticket#`` mit einer angehängten Nummer (z.B. ``Ticket#904627``). "
+"Er kann von einem Administrator geändert werden. Siehe :admin-docs:``hier </"
+"settings/ticket.html>`` für weitere Informationen."
 
 #: ../basics/zammad-glossary.rst:748
 msgid "Trigger"
-msgstr ""
+msgstr "Trigger"
 
 #: ../basics/zammad-glossary.rst:744
 msgid ""
@@ -5278,6 +5309,11 @@ msgid ""
 "conditions. More information in the admin documentation in the :admin-docs:"
 "`trigger section </manage/trigger.html>`."
 msgstr ""
+"Trigger sind eine der Automatisierungsfunktionen von Zammad. Ein "
+"Administrator kann bestimmte Bedingungen und Aktionen definieren, die auf "
+"Tickets mit passenden Bedingungen angewendet werden. Weitere Informationen "
+"finden Sie in der Admin-Dokumentation im Abschnitt :admin-docs:`Trigger </"
+"manage/trigger.html>`."
 
 #: ../basics/zammad-glossary.rst:751
 msgid "U"
@@ -8844,6 +8880,22 @@ msgstr ""
 "docs:`System- </index.html>` und :admin-docs:`Admin-Dokumentationen </index."
 "html>` verfügbar."
 
+#: ../basics/zammad-glossary.rst:618
+msgid "Bottom section:"
+msgstr "Unterer Abschnitt:"
+
+#: ../basics/zammad-glossary.rst:732
+msgid ""
+"The title of a ticket is different based on the channel it came in. You can "
+"find the title in the sidebar and in the top area in the ticket view. If the "
+"title is not very meaningful, you can change it by clicking on the title in "
+"a ticket view."
+msgstr ""
+"Der Titel eines Tickets unterscheidet sich je nach Kanal, in dem es erstellt "
+"wurde. Sie finden den Titel in der Seitenleiste und im oberen Bereich in der "
+"Ticket-Ansicht. Wenn der Titel nicht wirklich aussagekräftig ist, können Sie "
+"ihn ändern, indem Sie in einer Ticket-Ansicht auf den Titel klicken."
+
 #~ msgid "Status"
 #~ msgstr "Status"
 
@@ -9555,3 +9607,17 @@ msgstr ""
 #~ msgstr ""
 #~ "Das ursprüngliche Ticket ist mit dem neuen Ticket :doc:`verlinkt <link>`, "
 #~ "was im Ticket-Dialog eingesehen werden kann."
+
+#~ msgid ""
+#~ "Every ticket has a status. You can change it once you've updated the "
+#~ "ticket. There are four types of status, and they are all color-coded."
+#~ msgstr ""
+#~ "Jedes Ticket hat einen Status. Sie können diese mit dem Update eines "
+#~ "Tickets ändern. Es gibt für Statustypen, diese sind farbkodiert."
+
+#~ msgid ""
+#~ "Learn more about states and they color coding on this page: :doc:`/basics/"
+#~ "service-ticket/settings/state`"
+#~ msgstr ""
+#~ "Zu Farbkodierungen und Status erfahren Sie mehr auf dieser Seite: :doc:`/"
+#~ "basics/service-ticket/settings/state`"

--- a/locale/es/LC_MESSAGES/user-docs.po
+++ b/locale/es/LC_MESSAGES/user-docs.po
@@ -25,9 +25,6 @@ msgstr "atajo de teclado"
 
 #: ../advanced/keyboard-shortcuts.rst:6
 #, fuzzy
-#| msgid ""
-#| "Zammad supports a wide array of keyboard shortcuts to expedite your "
-#| "workflow as an expert user."
 msgid ""
 "Zammad supports a wide array of keyboard shortcuts to expedite your workflow "
 "as an expert user. But don't be afraid, you don't have to remember all of "
@@ -55,9 +52,6 @@ msgstr "Submenú de usuario"
 
 #: ../advanced/keyboard-shortcuts.rst:20
 #, fuzzy
-#| msgid ""
-#| "Alternately, bring it up with one of the shortcuts below (shortcut-"
-#| "ception!)"
 msgid "Alternatively, open it with one of the shortcuts below:"
 msgstr ""
 "Alternativamente, sube el tema con uno de los siguientes atajos (¡Atajo-"
@@ -65,13 +59,11 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:22
 #, fuzzy
-#| msgid "``Ctrl`` + ``Shift`` + ``H`` (on Windows)"
 msgid "``ctrl`` + ``shift`` + ``h`` (on Linux and Windows)"
 msgstr "``Ctrl`` + ``Shift`` + ``H`` (en Windows)"
 
 #: ../advanced/keyboard-shortcuts.rst:23
 #, fuzzy
-#| msgid "``Cmd`` + ``Ctrl`` + ``Shift`` + ``H`` (on macOS)"
 msgid "``cmd`` + ``ctrl`` + ``shift`` + ``h`` (on macOS)"
 msgstr "``Cmd`` + ``Ctrl`` + ``Shift`` + ``H`` (en macOS)"
 
@@ -87,19 +79,16 @@ msgstr "Chuleta de atajos de teclado"
 
 #: ../advanced/keyboard-shortcuts.rst:33
 #, fuzzy
-#| msgid "Keyboard shortcut cheat sheet"
 msgid "The keyboard shortcut cheat sheet."
 msgstr "Chuleta de atajos de teclado"
 
 #: ../advanced/keyboard-shortcuts.rst:37
 #, fuzzy
-#| msgid "Keyboard Shortcuts"
 msgid "List of Available Keyboard Shortcuts"
 msgstr "atajo de teclado"
 
 #: ../advanced/keyboard-shortcuts.rst:40
 #, fuzzy
-#| msgid "organization"
 msgid "Navigation"
 msgstr "organización"
 
@@ -129,7 +118,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:46
 #, fuzzy
-#| msgid "Search phrase"
 msgid "Show overviews"
 msgstr "Frase de búsqueda"
 
@@ -191,7 +179,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:54
 #, fuzzy
-#| msgid "``Cmd`` + ``Ctrl`` + ``Shift`` + ``H`` (on macOS)"
 msgid "``shift`` + ``ctrl`` + ``shift+tab``"
 msgstr "``Cmd`` + ``Ctrl`` + ``Shift`` + ``H`` (en macOS)"
 
@@ -257,7 +244,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:66
 #, fuzzy
-#| msgid "organization"
 msgid "Translations"
 msgstr "organización"
 
@@ -287,7 +273,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:86
 #, fuzzy
-#| msgid "Macros"
 msgid "Tickets"
 msgstr "Macros"
 
@@ -325,7 +310,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:95
 #, fuzzy
-#| msgid "``Cmd`` + ``Ctrl`` + ``Shift`` + ``H`` (on macOS)"
 msgid "``shift`` + ``ctrl`` + ``←`` / ``→``"
 msgstr "``Cmd`` + ``Ctrl`` + ``Shift`` + ``H`` (en macOS)"
 
@@ -375,7 +359,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:109
 #, fuzzy
-#| msgid "Press ``Cmd`` + ``I`` to enter Italics mode,"
 msgid "Press ``cmd`` + ``i`` to enter *italics* mode,"
 msgstr "Presiona ``Cmd`` + ``I`` para entrar en modo de cursiva,"
 
@@ -385,7 +368,6 @@ msgstr "introduce el texto deseado, y"
 
 #: ../advanced/keyboard-shortcuts.rst:111
 #, fuzzy
-#| msgid "press ``Cmd`` + ``I`` again to return to normal text mode."
 msgid "press ``cmd`` + ``i`` again to return to normal text mode."
 msgstr "presiona ``Cmd`` + ``I`` de nuevo para volver al modo de texto normal."
 
@@ -403,7 +385,6 @@ msgstr "haga clic y arrastre con el ratón para seleccionarlo, y"
 
 #: ../advanced/keyboard-shortcuts.rst:117
 #, fuzzy
-#| msgid "press ``Cmd`` + ``I`` to italicize."
 msgid "press ``cmd`` + ``i`` to set the text in *italics*."
 msgstr "presiona ``Cmd`` + ``I`` para poner en cursiva."
 
@@ -453,7 +434,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:128
 #, fuzzy
-#| msgid "``Ctrl`` + ``Shift`` + ``H`` (on Linux)"
 msgid "``ctrl`` + ``shift`` + ``v``"
 msgstr "``Ctrl`` + ``Shift`` + ``H`` (en Linux)"
 
@@ -467,7 +447,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:129
 #, fuzzy
-#| msgid "Formatting Text"
 msgid "Remove formatting of text"
 msgstr "Formatear texto"
 
@@ -556,10 +535,6 @@ msgstr ""
 
 #: ../advanced/macros.rst:10
 #, fuzzy
-#| msgid ""
-#| "You don’t – that’s the `administrator’s job <https://admin-docs.zammad."
-#| "org/en/latest/manage/macros.html>`_. If you have an idea for a macro "
-#| "you’d like to use, your Zammad admin can probably make it happen."
 msgid ""
 "Macros can be created by your :admin-docs:`administrator </manage/macros."
 "html>`. If you have an idea for a macro you'd like to use, your Zammad admin "
@@ -572,8 +547,6 @@ msgstr ""
 
 #: ../advanced/macros.rst:14
 #, fuzzy
-#| msgid ""
-#| "Macros can be applied in one of two ways: on a single ticket, or in bulk."
 msgid "Macros can be applied in two ways: on a single ticket, or in bulk."
 msgstr ""
 "Las macros se pueden aplicar de dos maneras: en un solo ticket o en bloque."
@@ -584,9 +557,6 @@ msgstr "En un solo ticket"
 
 #: ../advanced/macros.rst:19
 #, fuzzy
-#| msgid ""
-#| "The simplest way to apply a macro is to select it from the **Update ᐱ** "
-#| "submenu in the Ticket View:"
 msgid ""
 "The simplest way to apply a macro is to select it from the **Update ^** "
 "submenu in the Ticket View:"
@@ -605,10 +575,6 @@ msgstr "💾 **Macro = Actualizar**"
 
 #: ../advanced/macros.rst:29
 #, fuzzy
-#| msgid ""
-#| "If you’ve made changes to any other :ref:`settings on the ticket "
-#| "<ticket_settings>` (including typing up a reply to the customer), "
-#| "applying a macro will save them, too."
 msgid ""
 "If you've made changes to any other :ref:`settings on the ticket "
 "<ticket_settings>` (including typing up a reply to the customer), applying a "
@@ -620,10 +586,6 @@ msgstr ""
 
 #: ../advanced/macros.rst:34
 #, fuzzy
-#| msgid ""
-#| "⚠️ **But beware:** in the event of a conflict, the macro’s actions "
-#| "override any manual changes – including messages to the customer! When in "
-#| "doubt, apply your macro and your manual changes *separately.*"
 msgid ""
 "⚠️ **But beware:** in the event of a conflict, the macro's actions override "
 "any manual changes - including messages to the customer! When in doubt, "
@@ -702,10 +664,6 @@ msgstr "Búsqueda avanzada"
 
 #: ../advanced/search.rst:4
 #, fuzzy
-#| msgid ""
-#| "With Zammad, you can limit your search to specific Information. This "
-#| "allows you to find e.g. Tickets with specific key words and states. Below "
-#| "information will help you to improve your search results."
 msgid ""
 "With Zammad, you can limit your search to specific attributes. This allows "
 "you to find e.g. tickets with specific key words and states. Below "
@@ -730,9 +688,6 @@ msgstr "o::"
 
 #: ../advanced/search.rst:18
 #, fuzzy
-#| msgid ""
-#| "If you want to run a more complex search you can use conditions with "
-#| "``()`` and ``AND``/``OR`` options::"
 msgid ""
 "If you want to run a more complex search, you can use conditions with ``()`` "
 "and ``AND``/``OR`` options::"
@@ -927,7 +882,6 @@ msgstr ""
 
 #: ../advanced/search.rst:48
 #, fuzzy
-#| msgid "Search phrase"
 msgid "Combining search phrases"
 msgstr "Frase de búsqueda"
 
@@ -1746,7 +1700,6 @@ msgstr ""
 
 #: ../advanced/ticket-actions/merge.rst:40
 #, fuzzy
-#| msgid "Macros"
 msgid "Merge dialog"
 msgstr "Macros"
 
@@ -1981,7 +1934,6 @@ msgstr ""
 
 #: ../advanced/time-accounting.rst:57
 #, fuzzy
-#| msgid "Screencast showing how to save a shared draft within ticket zoom"
 msgid "Screenshot showing accounted times in ticket pane"
 msgstr ""
 "Captura de pantalla mostrando como guardar un boceto compartido dentro de un "
@@ -4138,7 +4090,6 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:610
 #, fuzzy
-#| msgid "Search phrase"
 msgid "Search bar"
 msgstr "Frase de búsqueda"
 
@@ -4236,7 +4187,6 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:663
 #, fuzzy
-#| msgid "Existing ticket"
 msgid "Splitting tickets"
 msgstr "Ticket existente"
 
@@ -4376,7 +4326,6 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:741
 #, fuzzy
-#| msgid "Macros"
 msgid "Ticket hook"
 msgstr "Macros"
 
@@ -4501,7 +4450,6 @@ msgstr ""
 
 #: ../extras/caller-log.rst:34
 #, fuzzy
-#| msgid "Macros"
 msgid "New Ticket dialog"
 msgstr "Macros"
 
@@ -5593,7 +5541,6 @@ msgstr ""
 
 #: ../extras/mobile-view.rst:39
 #, fuzzy
-#| msgid "Search phrase"
 msgid "Search & Overview"
 msgstr "Frase de búsqueda"
 
@@ -5607,13 +5554,11 @@ msgstr ""
 
 #: ../extras/mobile-view.rst:0
 #, fuzzy
-#| msgid "open a ticket overview;"
 msgid "Mobile View Ticket Overview"
 msgstr "abrir el resumen de un ticket;"
 
 #: ../extras/mobile-view.rst:55
 #, fuzzy
-#| msgid "open a ticket overview;"
 msgid "Ticket Overview"
 msgstr "abrir el resumen de un ticket;"
 
@@ -5672,13 +5617,11 @@ msgstr ""
 
 #: ../extras/mobile-view.rst:117
 #, fuzzy
-#| msgid "open a ticket overview;"
 msgid "Manage & use your ticket overviews"
 msgstr "abrir el resumen de un ticket;"
 
 #: ../extras/mobile-view.rst:118
 #, fuzzy
-#| msgid "Search for a Ticketnumber"
 msgid "Search for existing records"
 msgstr "Buscar un número de ticket"
 
@@ -5742,7 +5685,6 @@ msgstr ""
 
 #: ../extras/mobile-view.rst:141
 #, fuzzy
-#| msgid "Macros"
 msgid "Ticket Macros"
 msgstr "Macros"
 
@@ -5863,7 +5805,6 @@ msgstr ""
 
 #: ../extras/organizations.rst:35
 #, fuzzy
-#| msgid "organization"
 msgid "Organization edit dialog"
 msgstr "organización"
 
@@ -5907,9 +5848,6 @@ msgstr ""
 
 #: ../extras/profile-and-settings.rst:4
 #, fuzzy
-#| msgid ""
-#| "Click on your avatar at the bottom of the main menu to access the "
-#| "**keyboard shortcuts cheat sheet**."
 msgid ""
 "Click on your avatar or initials at the bottom of the main menu to access "
 "your **profile and settings**."
@@ -5925,7 +5863,6 @@ msgstr ""
 
 #: ../extras/profile-and-settings.rst:17
 #, fuzzy
-#| msgid "User submenu"
 msgid "User Menu"
 msgstr "Submenú de usuario"
 
@@ -6057,7 +5994,6 @@ msgstr ""
 
 #: ../extras/profile-and-settings.rst:0
 #, fuzzy
-#| msgid "Password"
 msgid "Password & Auth"
 msgstr "Contraseña"
 
@@ -6737,11 +6673,6 @@ msgstr "Actualizar bocetos existentes"
 
 #: ../extras/shared-drafts.rst:90
 #, fuzzy
-#| msgid ""
-#| "In order to update or rename existing shared drafts for new tickets, "
-#| "simply load the draft in question. Change the information (e.g. ticket "
-#| "settings or content) needed and, if needed, update the drafts name on the "
-#| "right hand side of the ticket."
 msgid ""
 "In order to update or rename existing shared drafts for new tickets, simply "
 "load the draft in question. Change the information (e.g. ticket settings or "
@@ -6766,10 +6697,6 @@ msgstr "Ticket existente"
 
 #: ../extras/shared-drafts.rst:100
 #, fuzzy
-#| msgid ""
-#| "Use the ᐱ button next to the update button. If the group of the ticket "
-#| "(or in your selection) allows shared drafts, Zammad will provide the "
-#| "option \"Save Draft\"."
 msgid ""
 "Use the ^ button next to the update button. If the group of the ticket (or "
 "in your selection) allows shared drafts, Zammad will provide the option "
@@ -7294,7 +7221,6 @@ msgstr "Extras"
 
 #: ../index.rst:2
 #, fuzzy
-#| msgid "Zammad Agent Documentation"
 msgid "Zammad User Documentation"
 msgstr "Documentación del Agente de Zammad"
 
@@ -7303,6 +7229,18 @@ msgid ""
 "You are currently reading the Zammad user documentation. There are also :"
 "docs:`system </index.html>` and :admin-docs:`administration manuals </index."
 "html>` available."
+msgstr ""
+
+#: ../basics/zammad-glossary.rst:618
+msgid "Bottom section:"
+msgstr ""
+
+#: ../basics/zammad-glossary.rst:732
+msgid ""
+"The title of a ticket is different based on the channel it came in. You can "
+"find the title in the sidebar and in the top area in the ticket view. If the "
+"title is not very meaningful, you can change it by clicking on the title in "
+"a ticket view."
 msgstr ""
 
 #~ msgid "🤔 **How do I make macros?**"

--- a/locale/es_CO/LC_MESSAGES/user-docs.po
+++ b/locale/es_CO/LC_MESSAGES/user-docs.po
@@ -7085,3 +7085,15 @@ msgid ""
 "docs:`system </index.html>` and :admin-docs:`administration manuals </index."
 "html>` available."
 msgstr ""
+
+#: ../basics/zammad-glossary.rst:618
+msgid "Bottom section:"
+msgstr ""
+
+#: ../basics/zammad-glossary.rst:732
+msgid ""
+"The title of a ticket is different based on the channel it came in. You can "
+"find the title in the sidebar and in the top area in the ticket view. If the "
+"title is not very meaningful, you can change it by clicking on the title in "
+"a ticket view."
+msgstr ""

--- a/locale/es_MX/LC_MESSAGES/user-docs.po
+++ b/locale/es_MX/LC_MESSAGES/user-docs.po
@@ -7085,3 +7085,15 @@ msgid ""
 "docs:`system </index.html>` and :admin-docs:`administration manuals </index."
 "html>` available."
 msgstr ""
+
+#: ../basics/zammad-glossary.rst:618
+msgid "Bottom section:"
+msgstr ""
+
+#: ../basics/zammad-glossary.rst:732
+msgid ""
+"The title of a ticket is different based on the channel it came in. You can "
+"find the title in the sidebar and in the top area in the ticket view. If the "
+"title is not very meaningful, you can change it by clicking on the title in "
+"a ticket view."
+msgstr ""

--- a/locale/fa/LC_MESSAGES/user-docs.po
+++ b/locale/fa/LC_MESSAGES/user-docs.po
@@ -7085,3 +7085,15 @@ msgid ""
 "docs:`system </index.html>` and :admin-docs:`administration manuals </index."
 "html>` available."
 msgstr ""
+
+#: ../basics/zammad-glossary.rst:618
+msgid "Bottom section:"
+msgstr ""
+
+#: ../basics/zammad-glossary.rst:732
+msgid ""
+"The title of a ticket is different based on the channel it came in. You can "
+"find the title in the sidebar and in the top area in the ticket view. If the "
+"title is not very meaningful, you can change it by clicking on the title in "
+"a ticket view."
+msgstr ""

--- a/locale/fr/LC_MESSAGES/user-docs.po
+++ b/locale/fr/LC_MESSAGES/user-docs.po
@@ -51,9 +51,6 @@ msgstr "Menu utilisateur"
 
 #: ../advanced/keyboard-shortcuts.rst:20
 #, fuzzy
-#| msgid ""
-#| "Alternately, bring it up with one of the shortcuts below (shortcut-"
-#| "ception!)"
 msgid "Alternatively, open it with one of the shortcuts below:"
 msgstr ""
 "Autrement, afficher la avec l'un des raccourcis suivants (raccourc-"
@@ -61,13 +58,11 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:22
 #, fuzzy
-#| msgid "``Ctrl`` + ``Shift`` + ``H`` (on Windows)"
 msgid "``ctrl`` + ``shift`` + ``h`` (on Linux and Windows)"
 msgstr "``Ctrl`` + ``Shift`` + ``H`` (sur Windows)"
 
 #: ../advanced/keyboard-shortcuts.rst:23
 #, fuzzy
-#| msgid "``Cmd`` + ``Ctrl`` + ``Shift`` + ``H`` (on macOS)"
 msgid "``cmd`` + ``ctrl`` + ``shift`` + ``h`` (on macOS)"
 msgstr "``Cmd`` + ``Ctrl`` + ``Shift`` + ``H`` (sur macOS)"
 
@@ -83,19 +78,16 @@ msgstr "Aide-mémoire des raccourcis clavier"
 
 #: ../advanced/keyboard-shortcuts.rst:33
 #, fuzzy
-#| msgid "Keyboard shortcut cheat sheet"
 msgid "The keyboard shortcut cheat sheet."
 msgstr "Aide-mémoire des raccourcis clavier"
 
 #: ../advanced/keyboard-shortcuts.rst:37
 #, fuzzy
-#| msgid "Keyboard Shortcuts"
 msgid "List of Available Keyboard Shortcuts"
 msgstr "Raccourcis clavier"
 
 #: ../advanced/keyboard-shortcuts.rst:40
 #, fuzzy
-#| msgid "organization"
 msgid "Navigation"
 msgstr "organisation"
 
@@ -125,7 +117,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:46
 #, fuzzy
-#| msgid "Search phrase"
 msgid "Show overviews"
 msgstr "Phrase de recherche"
 
@@ -143,7 +134,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:48
 #, fuzzy
-#| msgid "Notifications"
 msgid "Open notifications"
 msgstr "Notifications"
 
@@ -153,7 +143,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:49 ../extras/mobile-view.rst:119
 #, fuzzy
-#| msgid "Creating a Ticket"
 msgid "Create a new ticket"
 msgstr "Créer un ticket"
 
@@ -191,7 +180,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:54
 #, fuzzy
-#| msgid "``Cmd`` + ``Ctrl`` + ``Shift`` + ``H`` (on macOS)"
 msgid "``shift`` + ``ctrl`` + ``shift+tab``"
 msgstr "``Cmd`` + ``Ctrl`` + ``Shift`` + ``H`` (sur macOS)"
 
@@ -257,7 +245,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:66
 #, fuzzy
-#| msgid "Organizations"
 msgid "Translations"
 msgstr "Sociétés"
 
@@ -287,7 +274,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:86
 #, fuzzy
-#| msgid "Ticket Actions"
 msgid "Tickets"
 msgstr "Actions sur les tickets"
 
@@ -297,7 +283,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:91
 #, fuzzy
-#| msgid "Creating a Ticket"
 msgid "Create a new note article"
 msgstr "Créer un ticket"
 
@@ -327,7 +312,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:95
 #, fuzzy
-#| msgid "``Cmd`` + ``Ctrl`` + ``Shift`` + ``H`` (on macOS)"
 msgid "``shift`` + ``ctrl`` + ``←`` / ``→``"
 msgstr "``Cmd`` + ``Ctrl`` + ``Shift`` + ``H`` (sur macOS)"
 
@@ -377,7 +361,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:109
 #, fuzzy
-#| msgid "Press ``Cmd`` + ``I`` to enter Italics mode,"
 msgid "Press ``cmd`` + ``i`` to enter *italics* mode,"
 msgstr "Appuyez sur ``Cmd`` + ``I`` pour utiliser le mode Italique,"
 
@@ -387,7 +370,6 @@ msgstr "entrez votre texte souhaité, et"
 
 #: ../advanced/keyboard-shortcuts.rst:111
 #, fuzzy
-#| msgid "press ``Cmd`` + ``I`` again to return to normal text mode."
 msgid "press ``cmd`` + ``i`` again to return to normal text mode."
 msgstr ""
 "appuyez sur ``Cmd`` + ``I`` encore pour retourner en mode texte normal."
@@ -406,7 +388,6 @@ msgstr "cliquez et faites glisser avec la souris pour le sélectionner, et"
 
 #: ../advanced/keyboard-shortcuts.rst:117
 #, fuzzy
-#| msgid "press ``Cmd`` + ``I`` to italicize."
 msgid "press ``cmd`` + ``i`` to set the text in *italics*."
 msgstr "appuyez sur ``Cmd`` + ``I`` pour mettre en italique."
 
@@ -456,7 +437,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:128
 #, fuzzy
-#| msgid "``Ctrl`` + ``Shift`` + ``H`` (on Linux)"
 msgid "``ctrl`` + ``shift`` + ``v``"
 msgstr "``Ctrl`` + ``Shift`` + ``H`` (sur Linux)"
 
@@ -470,7 +450,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:129
 #, fuzzy
-#| msgid "Formatting Text"
 msgid "Remove formatting of text"
 msgstr "Formatage du texte"
 
@@ -560,10 +539,6 @@ msgstr ""
 
 #: ../advanced/macros.rst:10
 #, fuzzy
-#| msgid ""
-#| "You don’t – that’s the `administrator’s job <https://admin-docs.zammad."
-#| "org/en/latest/manage/macros.html>`_. If you have an idea for a macro "
-#| "you’d like to use, your Zammad admin can probably make it happen."
 msgid ""
 "Macros can be created by your :admin-docs:`administrator </manage/macros."
 "html>`. If you have an idea for a macro you'd like to use, your Zammad admin "
@@ -575,8 +550,6 @@ msgstr ""
 
 #: ../advanced/macros.rst:14
 #, fuzzy
-#| msgid ""
-#| "Macros can be applied in one of two ways: on a single ticket, or in bulk."
 msgid "Macros can be applied in two ways: on a single ticket, or in bulk."
 msgstr ""
 "Vous pouvez appliquer les macros de deux façons : sur un seul ticket ou sur "
@@ -588,9 +561,6 @@ msgstr "Sur un seul ticket"
 
 #: ../advanced/macros.rst:19
 #, fuzzy
-#| msgid ""
-#| "The simplest way to apply a macro is to select it from the **Update ᐱ** "
-#| "submenu in the Ticket View:"
 msgid ""
 "The simplest way to apply a macro is to select it from the **Update ^** "
 "submenu in the Ticket View:"
@@ -610,10 +580,6 @@ msgstr "💾 **Macro = Mise à jour**"
 
 #: ../advanced/macros.rst:29
 #, fuzzy
-#| msgid ""
-#| "If you’ve made changes to any other :ref:`settings on the ticket "
-#| "<ticket_settings>` (including typing up a reply to the customer), "
-#| "applying a macro will save them, too."
 msgid ""
 "If you've made changes to any other :ref:`settings on the ticket "
 "<ticket_settings>` (including typing up a reply to the customer), applying a "
@@ -625,10 +591,6 @@ msgstr ""
 
 #: ../advanced/macros.rst:34
 #, fuzzy
-#| msgid ""
-#| "⚠️ **But beware:** in the event of a conflict, the macro’s actions "
-#| "override any manual changes – including messages to the customer! When in "
-#| "doubt, apply your macro and your manual changes *separately.*"
 msgid ""
 "⚠️ **But beware:** in the event of a conflict, the macro's actions override "
 "any manual changes - including messages to the customer! When in doubt, "
@@ -706,10 +668,6 @@ msgstr "Recherche avancée"
 
 #: ../advanced/search.rst:4
 #, fuzzy
-#| msgid ""
-#| "With Zammad, you can limit your search to specific Information. This "
-#| "allows you to find e.g. Tickets with specific key words and states. Below "
-#| "information will help you to improve your search results."
 msgid ""
 "With Zammad, you can limit your search to specific attributes. This allows "
 "you to find e.g. tickets with specific key words and states. Below "
@@ -744,10 +702,6 @@ msgstr "Attributs disponibles"
 
 #: ../advanced/search.rst:28
 #, fuzzy
-#| msgid ""
-#| "For a more detailed list of available attributes please take a look into "
-#| "our `Zammad Admin-Documentation <https://docs.zammad.org/en/latest/"
-#| "install/elasticsearch/indexed-attributes.html>`_"
 msgid ""
 "For a more detailed list of available attributes please take a look into "
 "our :docs:`Zammad System Documentation </install/elasticsearch/indexed-"
@@ -933,7 +887,6 @@ msgstr ""
 
 #: ../advanced/search.rst:48
 #, fuzzy
-#| msgid "Search phrase"
 msgid "Combining search phrases"
 msgstr "Phrase de recherche"
 
@@ -1179,9 +1132,6 @@ msgstr ""
 
 #: ../advanced/suggested-workflows.rst:30
 #, fuzzy
-#| msgid ""
-#| "Reassign a ticket (via the *Group* and *Owner* settings) to let "
-#| "colleagues know you’re done with your part."
 msgid ""
 "Reassign a ticket (via the *Group* and *Owner* settings) to let colleagues "
 "know you're done with your part."
@@ -1203,12 +1153,6 @@ msgstr ""
 
 #: ../advanced/suggested-workflows.rst:39
 #, fuzzy
-#| msgid ""
-#| "Our sales rep can simply un-assign himself has the **owner** of the "
-#| "ticket and re-assign the ticket to the Customer Service **group**. *All "
-#| "customer service agents will be notified of the incoming ticket*, and the "
-#| "first available agent can assign herself to pick up where the sales rep "
-#| "left off."
 msgid ""
 "Our sales rep can simply un-assign himself as the **owner** of the ticket "
 "and re-assign the ticket to the Customer Service **group**. *All customer "
@@ -1392,9 +1336,6 @@ msgstr ""
 
 #: ../advanced/tabs.rst:9
 #, fuzzy
-#| msgid ""
-#| "You can freely switch between open tabs without losing your work – all "
-#| "unsaved changes are automatically backed up to the server."
 msgid ""
 "You can freely switch between open tabs without losing your work - all "
 "unsaved changes are automatically backed up to the server."
@@ -1416,7 +1357,6 @@ msgstr ""
 
 #: ../advanced/tabs.rst:18
 #, fuzzy
-#| msgid "What items open in a new “tab”?"
 msgid "**What items open in a new “tab”?**"
 msgstr "Quels éléments ouvrent un nouvel “onglet“?"
 
@@ -1465,7 +1405,6 @@ msgstr "**Fermé**"
 
 #: ../snippets/ticket-state-type-circles.rst:7
 #, fuzzy
-#| msgid "Merge"
 msgid "**Merged**"
 msgstr "Fusionner"
 
@@ -1587,11 +1526,6 @@ msgstr "Travailler avec les modules de texte"
 
 #: ../advanced/text-modules.rst:4
 #, fuzzy
-#| msgid ""
-#| "Zammad offers so-called text modules. Text modules will help you to "
-#| "improve your workflow, as you don't have to type your answer on every "
-#| "ticket by hand. You can simply choose a fitting text module and insert it "
-#| "into the E-Mail."
 msgid ""
 "Zammad offers so-called text modules. Text modules will help you to improve "
 "your workflow, as you don't have to type your answer on every ticket by "
@@ -1625,13 +1559,11 @@ msgstr ""
 
 #: ../advanced/text-modules.rst:21
 #, fuzzy
-#| msgid "Text modules on ticket creation"
 msgid "Text modules missing?"
 msgstr "Modules de texte lors de la création de ticket"
 
 #: ../advanced/text-modules.rst:23
 #, fuzzy
-#| msgid "**🤔 How come some text modules don’t always appear?**"
 msgid "You noticed that some text modules don't always appear?"
 msgstr ""
 "**🤔 Comment se fait-il que certains modules de texte n'apparaissent pas "
@@ -1639,10 +1571,6 @@ msgstr ""
 
 #: ../advanced/text-modules.rst:25
 #, fuzzy
-#| msgid ""
-#| "Text modules can be tied to **groups**: that is, they only become active "
-#| "once the ticket you’re working on has been assigned to the appropriate "
-#| "group."
 msgid ""
 "Text modules can be tied to **groups**: that is, they only become active "
 "once the ticket you're working on has been assigned to the appropriate group."
@@ -1665,9 +1593,6 @@ msgstr ""
 
 #: ../advanced/text-modules.rst:35
 #, fuzzy
-#| msgid ""
-#| "How do you which groups go with which text modules? Ask your "
-#| "administrator!"
 msgid ""
 "How do you know which groups go with which text modules? Ask your "
 "administrator!"
@@ -1796,7 +1721,6 @@ msgstr "Fusionner des tickets"
 
 #: ../advanced/ticket-actions/merge.rst:4
 #, fuzzy
-#| msgid "In such cases, you may want to **merge those tickets into one**."
 msgid ""
 "If you have two or more tickets about the same issue, you may want to merge "
 "those tickets into one."
@@ -1816,9 +1740,6 @@ msgstr ""
 
 #: ../advanced/ticket-actions/merge.rst:13
 #, fuzzy
-#| msgid ""
-#| "Merging a ticket migrates all messages and notes **out of the original** "
-#| "and into the selected one."
 msgid ""
 "Merging a ticket migrates all messages and notes of the ticket from where "
 "you select the merging into the selected one."
@@ -1837,7 +1758,6 @@ msgstr ""
 
 #: ../advanced/ticket-actions/merge.rst:28
 #, fuzzy
-#| msgid "Browse for Tickets"
 msgid "How to merge tickets?"
 msgstr "Parcourir les tickets"
 
@@ -1853,7 +1773,6 @@ msgstr ""
 
 #: ../advanced/ticket-actions/merge.rst:40
 #, fuzzy
-#| msgid "The edit customer dialog."
 msgid "Merge dialog"
 msgstr "La boîte d'édition du client."
 
@@ -1894,9 +1813,6 @@ msgstr ""
 
 #: ../advanced/ticket-actions/merge.rst:53
 #, fuzzy
-#| msgid ""
-#| "The original ticket is :doc:`linked <link>` to the new one, as seen in "
-#| "the ticket pane."
 msgid "The ticket is :doc:`linked <link>` to its \"parent\" ticket"
 msgstr ""
 "Le ticket original est :doc:`lié <link>` au nouveau, comme indiqué dans le "
@@ -1915,7 +1831,6 @@ msgstr ""
 
 #: ../advanced/ticket-actions/split.rst:8
 #, fuzzy
-#| msgid "To rename a ticket, simply click on the title and start typing."
 msgid ""
 "To split a ticket, simply click on the \"split\" button under the article "
 "you want to split off:"
@@ -1939,9 +1854,6 @@ msgstr ""
 
 #: ../advanced/ticket-actions/split.rst:23
 #, fuzzy
-#| msgid ""
-#| "When splitting a ticket, the target message is imported into the new "
-#| "ticket dialog. As usual, remember to select the **type** (call/email)."
 msgid ""
 "It is prefilled with the content of the existing article. Remember to select "
 "the type (call/email)."
@@ -1952,9 +1864,6 @@ msgstr ""
 
 #: ../advanced/ticket-actions/split.rst:26
 #, fuzzy
-#| msgid ""
-#| "The original ticket is :doc:`linked <link>` to the new one, as seen in "
-#| "the ticket pane."
 msgid ""
 "The original ticket is :doc:`linked <link>` to the new one, as you can see "
 "in the ticket side panel:"
@@ -1968,10 +1877,6 @@ msgstr "Modèles de ticket"
 
 #: ../advanced/ticket-templates.rst:6
 #, fuzzy
-#| msgid ""
-#| "If you find yourself creating lots of tickets with the same basic "
-#| "attributes, use **ticket templates** to fill them in next time with a "
-#| "single click."
 msgid ""
 "If you find yourself creating lots of tickets with the same basic "
 "attributes, use **ticket templates** to fill them in with a single click "
@@ -1987,7 +1892,6 @@ msgstr ""
 
 #: ../advanced/ticket-templates.rst:13
 #, fuzzy
-#| msgid "Use the ticket pane to load or create ticket templates."
 msgid "Use the ticket pane to load ticket templates."
 msgstr ""
 "Utilisez le panneau du ticket pour charger ou créer des modèles de ticket."
@@ -2059,16 +1963,11 @@ msgstr ""
 
 #: ../advanced/time-accounting.rst:None
 #, fuzzy
-#| msgid "Time Accounting"
 msgid "Time Accounting Dialog"
 msgstr "Comptabilité du temps"
 
 #: ../advanced/time-accounting.rst:11
 #, fuzzy
-#| msgid ""
-#| "If time accounting is enabled, this dialog will appear each time you "
-#| "update a ticket. Enter how much time you spent on it (in minutes, or "
-#| "whichever unit of time all your other colleagues are using)."
 msgid ""
 "If the time accounting is enabled, this dialog will appear each time you "
 "update a ticket. Enter how much time you spent on it."
@@ -2098,13 +1997,11 @@ msgstr ""
 
 #: ../advanced/time-accounting.rst:None
 #, fuzzy
-#| msgid "Time Accounting"
 msgid "Time Accounting Unit"
 msgstr "Comptabilité du temps"
 
 #: ../advanced/time-accounting.rst:31
 #, fuzzy
-#| msgid "Time Accounting"
 msgid "Activity Types"
 msgstr "Comptabilité du temps"
 
@@ -2117,7 +2014,6 @@ msgstr ""
 
 #: ../advanced/time-accounting.rst:None
 #, fuzzy
-#| msgid "Time Accounting"
 msgid "Time Accounting Activity Type"
 msgstr "Comptabilité du temps"
 
@@ -2142,7 +2038,6 @@ msgstr ""
 
 #: ../advanced/time-accounting.rst:57
 #, fuzzy
-#| msgid "Screencast showing how to run a macro within a ticket view."
 msgid "Screenshot showing accounted times in ticket pane"
 msgstr ""
 "Screencast montre comment exécuter une macro lors de la visualisation d'un "
@@ -2166,8 +2061,6 @@ msgstr "Trouver des tickets"
 
 #: ../basics/find-ticket.rst:4
 #, fuzzy
-#| msgid ""
-#| "If you plan to work on tickets, you’d better know how to find ’em first."
 msgid ""
 "If you plan to work on tickets, you'd better know how to find them first."
 msgstr ""
@@ -2201,9 +2094,6 @@ msgstr ""
 
 #: ../basics/find-ticket/browse.rst:12
 #, fuzzy
-#| msgid ""
-#| "📥 Think of overviews as **inboxes**, each with a different filter for "
-#| "the tickets it displays."
 msgid ""
 "Think of overviews as **inboxes**, each with a different filter for the "
 "tickets it displays."
@@ -2284,7 +2174,6 @@ msgstr "Recherche de tickets"
 
 #: ../basics/find-ticket/search.rst:4
 #, fuzzy
-#| msgid "Looking for an archived ticket? Use the **search bar**."
 msgid "Looking for an a specific ticket? Use the **search bar**:"
 msgstr "Vous recherchez un ticket archivé? Utilisez la **barre de recherche**."
 
@@ -2296,9 +2185,6 @@ msgstr ""
 
 #: ../basics/find-ticket/search.rst:12
 #, fuzzy
-#| msgid ""
-#| "It’s not just for tickets! Results cover 💬 **chat logs**, 👨 "
-#| "**customers**, and 🏢 **organizations**, too."
 msgid ""
 "It's not just for tickets! Results cover 💬 **chat logs**, 👨 **customers**, "
 "and 🏢 **organizations**, too."
@@ -2351,7 +2237,6 @@ msgstr "Répondre aux tickets"
 
 #: ../basics/service-ticket.rst:4
 #, fuzzy
-#| msgid "This is where you’ll spend the vast majority of your time in Zammad."
 msgid "This is where you'll spend the vast majority of your time in Zammad."
 msgstr ""
 "C'est ici que vous passerez la plus grande majorité de votre temps sur "
@@ -2359,9 +2244,6 @@ msgstr ""
 
 #: ../basics/service-ticket.rst:6
 #, fuzzy
-#| msgid ""
-#| "Once you get the hang of the tasks below, there’s really not much more to "
-#| "it."
 msgid ""
 "Once you get the hang of the tasks below, there's really not much more to it."
 msgstr ""
@@ -2374,10 +2256,6 @@ msgstr "Créer un ticket"
 
 #: ../basics/service-ticket/create.rst:4
 #, fuzzy
-#| msgid ""
-#| "Zammad does its best to create tickets automatically when new customer "
-#| "issues come your way. But sometimes, there’s just no way for Zammad to "
-#| "know when an issue arrives – like when a customer calls on the phone."
 msgid ""
 "Zammad does its best to create tickets automatically when new customer "
 "issues come your way. But sometimes, there's just no way for Zammad to know "
@@ -2439,7 +2317,6 @@ msgstr "Remplir le formulaire"
 
 #: ../basics/service-ticket/create.rst:28
 #, fuzzy
-#| msgid "Here’s a quick run-down of each input field in the New Ticket form:"
 msgid "Here's a quick run-down of each input field in the New Ticket form:"
 msgstr ""
 "Voici un rapide passage en revue de chaque champ du formulaire de nouveau "
@@ -2481,7 +2358,6 @@ msgstr ""
 
 #: ../basics/service-ticket/create.rst:46
 #, fuzzy
-#| msgid "Autocomplete can’t find customers by name."
 msgid "Autocomplete can't find customers by name."
 msgstr "L'auto-complétement ne peut trouver de clients par leur nom."
 
@@ -2610,10 +2486,6 @@ msgstr ""
 
 #: ../basics/service-ticket/follow-up.rst:19
 #, fuzzy
-#| msgid ""
-#| "Tickets are threads of messages & notes about a customer service issue. :"
-#| "doc:`⚙️ Manage a ticket’s settings <settings>` in the **ticket pane** on "
-#| "the right."
 msgid ""
 "Tickets are threads of messages & notes about a customer service issue. :doc:"
 "`⚙️ Manage ticket settings <settings>` in the **ticket pane** on the right."
@@ -2624,9 +2496,6 @@ msgstr ""
 
 #: ../basics/service-ticket/follow-up.rst:23
 #, fuzzy
-#| msgid ""
-#| "📇 Any time you open a ticket, a new entry will appear in your :doc:`tab "
-#| "list</advanced/tabs>` in the main menu."
 msgid ""
 "Any time you open a ticket, a new entry will appear in your :doc:`tab list</"
 "advanced/tabs>` in the main menu."
@@ -2673,9 +2542,6 @@ msgstr ""
 
 #: ../basics/service-ticket/follow-up.rst:47
 #, fuzzy
-#| msgid ""
-#| "⏩ You can also **forward messages**, just as you would in any email "
-#| "client (attachments are included automatically)."
 msgid ""
 "You can also **forward messages**, just as you would in any email client "
 "(attachments are included automatically). This way, you can share "
@@ -2701,7 +2567,6 @@ msgstr "Ajouter de nouveaux messages/notes"
 
 #: ../basics/service-ticket/follow-up.rst:60
 #, fuzzy
-#| msgid "Click on the text field at the end of the thread to add a follow-up."
 msgid "Click on the text field at the end of the thread to add a follow-up:"
 msgstr "Cliquez sur le champ texte à la fin du fil pour ajouter un suivi."
 
@@ -2885,7 +2750,6 @@ msgstr ""
 
 #: ../basics/service-ticket/settings.rst:4
 #, fuzzy
-#| msgid "Use the **ticket pane** to manage a ticket’s settings:"
 msgid "Use the **ticket pane** to manage a ticket's settings:"
 msgstr "Utilisez le **panneau ticket** pour gérer les paramètres d'un ticket:"
 
@@ -2923,9 +2787,6 @@ msgstr "Surligner le texte du ticket"
 
 #: ../basics/service-ticket/settings.rst:39
 #, fuzzy
-#| msgid ""
-#| "Use the highlighter tool in the upper-righthand corner to mark up "
-#| "important text. (Your highlights are **not** visible to other agents.)"
 msgid ""
 "Use the highlighter tool in the upper-righthand corner to mark up important "
 "text. (Your highlights are visible to other agents.)"
@@ -2948,7 +2809,6 @@ msgstr ""
 
 #: ../basics/service-ticket/settings.rst:50
 #, fuzzy
-#| msgid "Ticket Actions"
 msgid "Further ticket actions"
 msgstr "Actions sur les tickets"
 
@@ -3015,10 +2875,6 @@ msgstr "Quoi?"
 
 #: ../basics/service-ticket/settings/group.rst:11
 #, fuzzy
-#| msgid ""
-#| "Suppose your organization uses Zammad for both sales and customer "
-#| "support. You’ve got ten different agents spread across two teams, "
-#| "handling dozens of tickets a day."
 msgid ""
 "Suppose your organization uses Zammad for both sales and customer support. "
 "You've got ten different agents spread across two teams, handling dozens of "
@@ -3030,14 +2886,6 @@ msgstr ""
 
 #: ../basics/service-ticket/settings/group.rst:15
 #, fuzzy
-#| msgid ""
-#| "Without groups, all ten agents can see (and respond to) every single "
-#| "ticket that comes in, regardless of which department it’s for. This isn’t "
-#| "problematic *per se,* but it does lead to a lot of unnecessary clutter in "
-#| "the :doc:`overviews menu </basics/find-ticket>`. (It can be much worse "
-#| "when, for example, a customer service rep sees tickets meant for your HR "
-#| "department, and finds out how much their colleagues in sales are making! "
-#| "💸💸💸)"
 msgid ""
 "Without groups, all ten agents can see (and respond to) every single ticket "
 "that comes in, regardless of which department it's for. This isn't "
@@ -3057,9 +2905,6 @@ msgstr ""
 
 #: ../basics/service-ticket/settings/group.rst:25
 #, fuzzy
-#| msgid ""
-#| "If, instead, each agent were assigned to an appropriate group, then "
-#| "they’d only ever see the tickets that belong to their own group."
 msgid ""
 "If, instead, each agent were assigned to an appropriate group, then they'd "
 "only ever see the tickets that belong to their own group."
@@ -3073,9 +2918,6 @@ msgstr ""
 
 #: ../basics/service-ticket/settings/group.rst:31
 #, fuzzy
-#| msgid ""
-#| "You don’t – that’s the `administrator’s job <https://admin-docs.zammad."
-#| "org/en/latest/manage-groups.html>`_."
 msgid ""
 "So how do I manage which team I'm on? You don't - that's the :admin-docs:"
 "`administrator's job </manage/groups/index.html>`."
@@ -3085,9 +2927,6 @@ msgstr ""
 
 #: ../basics/service-ticket/settings/group.rst:34
 #, fuzzy
-#| msgid ""
-#| "However, you can *check* which teams you’re on in the Notifications "
-#| "section of your :doc:`user settings </extras/profile-and-settings>`:"
 msgid ""
 "However, you can *check* which teams you're on in the Notifications section "
 "of your :doc:`user settings </extras/profile-and-settings>`:"
@@ -3110,11 +2949,6 @@ msgstr "Alors où dois-je intervenir?"
 
 #: ../basics/service-ticket/settings/group.rst:48
 #, fuzzy
-#| msgid ""
-#| "If you belong to more than one group, you may re-assign a ticket from one "
-#| "of your groups to another. In general, though, you won’t need to do this "
-#| "unless you’re an admin, or an admin has discussed the procedure with you "
-#| "beforehand."
 msgid ""
 "If you belong to more than one group, you may re-assign a ticket from one of "
 "your groups to another. In general, though, you won't need to do this unless "
@@ -3132,9 +2966,6 @@ msgstr "Propriétaire"
 
 #: ../basics/service-ticket/settings/owner.rst:4
 #, fuzzy
-#| msgid ""
-#| "A ticket’s **owner** is simply *the agent that is currently responsible "
-#| "for it*."
 msgid ""
 "A ticket's **owner** is simply *the agent that is currently responsible for "
 "it*."
@@ -3148,10 +2979,6 @@ msgstr "A qui appartient la tâche d'assigner les tickets?"
 
 #: ../basics/service-ticket/settings/owner.rst:10
 #, fuzzy
-#| msgid ""
-#| "It depends on your organization’s workflow, but in most cases, **you will "
-#| "assign tickets to yourself** when you choose an issue to work on from the "
-#| "pool of new tickets."
 msgid ""
 "It depends on your organization's workflow, but in most cases, **you will "
 "assign tickets to yourself** when you choose an issue to work on from the "
@@ -3163,9 +2990,6 @@ msgstr ""
 
 #: ../basics/service-ticket/settings/owner.rst:16
 #, fuzzy
-#| msgid ""
-#| "In principle, any agent may assign a ticket to any other, as long as both "
-#| "have the required privileges for the ticket’s :doc:`group <group>`."
 msgid ""
 "In principle, any agent may assign a ticket to any other, as long as both "
 "have the required privileges for the ticket's :doc:`group </basics/service-"
@@ -3302,18 +3126,11 @@ msgstr ""
 
 #: ../basics/service-ticket/settings/state.rst:30
 #, fuzzy
-#| msgid "What’s the difference between “new” and “open”?"
 msgid "What's the difference between “new” and “open”?"
 msgstr "Quelle est la différence entre “nouveau” et “ouvert”?"
 
 #: ../basics/service-ticket/settings/state.rst:32
 #, fuzzy
-#| msgid ""
-#| "States do more than just indicate progress: Zammad has a fine-grained "
-#| "time tracking feature (so-called “\\ `service-level agreements <https://"
-#| "admin-docs.zammad.org/en/latest/manage-slas.html>`_\\ ”, or SLAs) that "
-#| "uses state information to measure how long it takes for customers to get "
-#| "a response on a new ticket or get their issues resolved entirely."
 msgid ""
 "States do more than just indicate progress: Zammad has a fine-grained time "
 "tracking feature (so-called “:admin-docs:`service-level agreements </manage/"
@@ -3330,9 +3147,6 @@ msgstr ""
 
 #: ../basics/service-ticket/settings/state.rst:38
 #, fuzzy
-#| msgid ""
-#| "On a *new* ticket, the customer still hasn’t received her first response "
-#| "on the issue."
 msgid ""
 "On a *new* ticket, the customer still hasn't received her first response on "
 "the issue."
@@ -3342,9 +3156,6 @@ msgstr ""
 
 #: ../basics/service-ticket/settings/state.rst:41
 #, fuzzy
-#| msgid ""
-#| "On an *open* ticket, the customer has received an initial response, but "
-#| "the issue still hasn’t been resolved."
 msgid ""
 "On an *open* ticket, the customer has received an initial response, but the "
 "issue still hasn't been resolved."
@@ -3362,10 +3173,6 @@ msgstr ""
 
 #: ../basics/service-ticket/settings/state.rst:47
 #, fuzzy
-#| msgid ""
-#| "So, for instance, a ticket may be marked *pending reminder* if it’s "
-#| "waiting on feedback from a third-party supplier who’s out of town until "
-#| "next week."
 msgid ""
 "So, for instance, a ticket may be marked *pending reminder* if it's waiting "
 "on feedback from a third-party supplier who's out of town until next week."
@@ -3581,7 +3388,6 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:48
 #, fuzzy
-#| msgid "article.from"
 msgid "Article"
 msgstr "article.from"
 
@@ -3760,7 +3566,6 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:142
 #, fuzzy
-#| msgid "Suggested Workflows"
 msgid "Core Workflows"
 msgstr "Flux de travail suggérés"
 
@@ -3830,7 +3635,6 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:172
 #, fuzzy
-#| msgid "Ticket attributes"
 msgid "Custom Object Attributes"
 msgstr "Attributs du ticket"
 
@@ -3903,7 +3707,6 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:227
 #, fuzzy
-#| msgid "Omnisearch"
 msgid "Elasticsearch"
 msgstr "Omnisearch"
 
@@ -4116,7 +3919,6 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:338
 #, fuzzy
-#| msgid "Group"
 msgid "Groups"
 msgstr "Groupe"
 
@@ -4297,7 +4099,6 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:441
 #, fuzzy
-#| msgid "Macros"
 msgid "Macro"
 msgstr "Macros"
 
@@ -4633,13 +4434,11 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:610
 #, fuzzy
-#| msgid "Search phrase"
 msgid "Search bar"
 msgstr "Phrase de recherche"
 
 #: ../basics/zammad-glossary.rst:611
 #, fuzzy
-#| msgid "Notifications"
 msgid "Notification section"
 msgstr "Notifications"
 
@@ -4649,7 +4448,6 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:615
 #, fuzzy
-#| msgid "Customer"
 msgid "Customer Chat"
 msgstr "Client"
 
@@ -4659,7 +4457,6 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:617
 #, fuzzy
-#| msgid "Browse for Tickets"
 msgid "One or more open tickets"
 msgstr "Parcourir les tickets"
 
@@ -4669,13 +4466,11 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:622
 #, fuzzy
-#| msgid "Ticket Settings"
 msgid "Admin settings"
 msgstr "Paramètres du ticket"
 
 #: ../basics/zammad-glossary.rst:623
 #, fuzzy
-#| msgid "Text modules on ticket creation"
 msgid "Button for ticket creation"
 msgstr "Modules de texte lors de la création de ticket"
 
@@ -4741,7 +4536,6 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:663
 #, fuzzy
-#| msgid "Splitting Tickets"
 msgid "Splitting tickets"
 msgstr "Scinder des tickets"
 
@@ -4858,7 +4652,6 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:729
 #, fuzzy
-#| msgid "Ticket Templates"
 msgid "(Ticket) Template"
 msgstr "Modèles de ticket"
 
@@ -4883,7 +4676,6 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:741
 #, fuzzy
-#| msgid "Ticket Actions"
 msgid "Ticket hook"
 msgstr "Actions sur les tickets"
 
@@ -4913,7 +4705,6 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:757
 #, fuzzy
-#| msgid "Users"
 msgid "User"
 msgstr "Utilisateurs"
 
@@ -4998,9 +4789,6 @@ msgstr ""
 
 #: ../extras/caller-log.rst:18
 #, fuzzy
-#| msgid ""
-#| "🏢 The caller log shows all incoming and outgoing calls **for the entire "
-#| "team**."
 msgid ""
 "🏢 The caller log shows all incoming and outgoing calls **for the entire "
 "instance**. The number of entries shown depends on the configuration your "
@@ -5018,7 +4806,6 @@ msgstr ""
 
 #: ../extras/caller-log.rst:34
 #, fuzzy
-#| msgid "New tickets"
 msgid "New Ticket dialog"
 msgstr "Nouveaux tickets"
 
@@ -5095,10 +4882,6 @@ msgstr ""
 
 #: ../extras/caller-log.rst:64
 #, fuzzy
-#| msgid ""
-#| "👤 Click on unrecognized numbers in the caller log to **create a new "
-#| "customer and ticket**. (Unrecognized phone numbers cannot be added to "
-#| "existing customers in this way.)"
 msgid ""
 "👤 Click on unrecognized numbers to **create a new customer** or maybe "
 "entries to **update an existing customer**."
@@ -5239,9 +5022,6 @@ msgstr ""
 
 #: ../extras/chat.rst:49
 #, fuzzy
-#| msgid ""
-#| "⌨️ Live chat supports `text modules <https://admin-docs.zammad.org/en/"
-#| "latest/manage-text-modules.html>`_."
 msgid ""
 "⌨️ Live chat supports :admin-docs:`text modules </manage-text-modules.html>`."
 msgstr ""
@@ -5250,9 +5030,6 @@ msgstr ""
 
 #: ../extras/chat.rst:50
 #, fuzzy
-#| msgid ""
-#| "📝 Chats can be **renamed** or **tagged**, and record technical details "
-#| "about the customer’s connection."
 msgid ""
 "📝 Chats can be **renamed** or **tagged**, and record technical details "
 "about the customer's connection."
@@ -5309,7 +5086,6 @@ msgstr "Clients"
 
 #: ../extras/customers.rst:4
 #, fuzzy
-#| msgid "Use the **ticket pane** to manage customer profiles."
 msgid "Use the **ticket pane** to view and manage customer profiles."
 msgstr "Utilisez le **panneau ticket** pour gérer les profils client."
 
@@ -5319,7 +5095,6 @@ msgstr ""
 
 #: ../extras/customers.rst:13
 #, fuzzy
-#| msgid "Click the 👨 tab in the ticket pane to see the customer’s profile."
 msgid "Click the 👨 tab in the ticket pane to see the customer's profile."
 msgstr ""
 "Cliquez sur l'onglet 👨 dans le panneau ticket pour voir le profil du client."
@@ -5336,9 +5111,6 @@ msgstr ""
 
 #: ../extras/customers.rst:23
 #, fuzzy
-#| msgid ""
-#| "Hover over the **open/closed** labels to see a summary of the customer’s "
-#| "other tickets."
 msgid ""
 "Hover over the **open/closed** labels to see a summary of the customer's "
 "other tickets."
@@ -5352,7 +5124,6 @@ msgstr "Éditer un client"
 
 #: ../extras/customers.rst:29
 #, fuzzy
-#| msgid "To edit the customer’s profile, use the **customer submenu**:"
 msgid ""
 "To edit the customer's profile, use the **customer submenu** and select "
 "\"Edit Customer\":"
@@ -5369,7 +5140,6 @@ msgstr ""
 
 #: ../extras/customers.rst:46
 #, fuzzy
-#| msgid "The edit customer dialog."
 msgid "Customer edit dialog"
 msgstr "La boîte d'édition du client."
 
@@ -5399,7 +5169,6 @@ msgstr ""
 
 #: ../extras/customers.rst:0
 #, fuzzy
-#| msgid "Organizations"
 msgid "Secondary Organizations"
 msgstr "Sociétés"
 
@@ -5415,11 +5184,6 @@ msgstr "VIP"
 
 #: ../extras/customers.rst:63
 #, fuzzy
-#| msgid ""
-#| "Like :doc:`ticket priority </basics/service-ticket/settings/priority>`, "
-#| "**VIP status** doesn’t actually do anything out-of-the-box, but an admin "
-#| "*can* set up automated system hooks based on this value, or use it as a "
-#| "filter for :doc:`custom overviews </basics/find-ticket/browse>`."
 msgid ""
 "Like :doc:`ticket priority </basics/service-ticket/settings/priority>`, "
 "**VIP status** doesn't actually do anything out-of-the-box, but an admin "
@@ -5434,9 +5198,6 @@ msgstr ""
 
 #: ../extras/customers.rst:68
 #, fuzzy
-#| msgid ""
-#| "**Ask your administrator** about how she’d like you to use this attribute "
-#| "(or just leave it alone)."
 msgid ""
 "**Ask your administrator** about how she'd like you to use this attribute "
 "(or just leave it alone)."
@@ -5477,7 +5238,6 @@ msgstr "Légende"
 
 #: ../extras/dashboard.rst:18
 #, fuzzy
-#| msgid "**1. Waiting Time Today**"
 msgid "**1. ∅ Waiting Time Today**"
 msgstr "**1. Temps d'attente aujourd'hui**"
 
@@ -5528,7 +5288,6 @@ msgstr ""
 
 #: ../extras/dashboard.rst:30
 #, fuzzy
-#| msgid "**5. Your Tickets in Process**"
 msgid "**5. My Tickets in Process**"
 msgstr "**5. Vos tickets en cours**"
 
@@ -5669,7 +5428,6 @@ msgstr ""
 
 #: ../extras/i-doit-track-company-property.rst:23
 #, fuzzy
-#| msgid "Use the **ticket pane** to manage a ticket’s settings:"
 msgid ""
 "Use the 🖨 **printer** tab to view or manage a ticket's assets from i-doit."
 msgstr "Utilisez le **panneau ticket** pour gérer les paramètres d'un ticket:"
@@ -5980,9 +5738,6 @@ msgstr ""
 
 #: ../extras/knowledge-base.rst:130
 #, fuzzy
-#| msgid ""
-#| "📁 If you relocate a category using the **Parent** menu, all of its "
-#| "articles and sub-categories will be relocated with it."
 msgid ""
 "You can relocate a category using the **Parent** menu. Doing so, all of its "
 "articles and sub-categories will be relocated with it."
@@ -5992,9 +5747,6 @@ msgstr ""
 
 #: ../extras/knowledge-base.rst:133
 #, fuzzy
-#| msgid ""
-#| "🗑️ Categories can only be deleted once **all of their articles and sub-"
-#| "categories** have been deleted or relocated."
 msgid ""
 "You can delete categories by clicking on the 🗑️ **Delete** button. Categories "
 "can only be deleted once **all of their articles and sub-categories** have "
@@ -6140,10 +5892,6 @@ msgstr ""
 
 #: ../extras/knowledge-base.rst:206
 #, fuzzy
-#| msgid ""
-#| "🙈 Set the **visibility** of an answer to control who can see an article, "
-#| "or schedule it to be published at a later date. Articles are **color-"
-#| "coded** according to their visibility:"
 msgid ""
 "Set the **visibility** of an answer to control who can see an article, or "
 "schedule it to be published at a later date. Articles are **color-coded** "
@@ -6253,7 +6001,6 @@ msgstr ""
 
 #: ../extras/mobile-view.rst:39
 #, fuzzy
-#| msgid "Search phrase"
 msgid "Search & Overview"
 msgstr "Phrase de recherche"
 
@@ -6263,25 +6010,21 @@ msgstr ""
 
 #: ../extras/mobile-view.rst:47
 #, fuzzy
-#| msgid "Search for Tickets"
 msgid "Search Results"
 msgstr "Recherche de tickets"
 
 #: ../extras/mobile-view.rst:0
 #, fuzzy
-#| msgid "open a ticket overview;"
 msgid "Mobile View Ticket Overview"
 msgstr "afficher l'aperçu d'un ticket ;"
 
 #: ../extras/mobile-view.rst:55
 #, fuzzy
-#| msgid "open a ticket overview;"
 msgid "Ticket Overview"
 msgstr "afficher l'aperçu d'un ticket ;"
 
 #: ../extras/mobile-view.rst:61
 #, fuzzy
-#| msgid "Ticket Settings"
 msgid "Ticket Details"
 msgstr "Paramètres du ticket"
 
@@ -6291,7 +6034,6 @@ msgstr ""
 
 #: ../extras/mobile-view.rst:69
 #, fuzzy
-#| msgid "Ticket Settings"
 msgid "Ticket Detail View"
 msgstr "Paramètres du ticket"
 
@@ -6301,19 +6043,16 @@ msgstr ""
 
 #: ../extras/mobile-view.rst:77
 #, fuzzy
-#| msgid "Ticket Actions"
 msgid "Ticket Information"
 msgstr "Actions sur les tickets"
 
 #: ../extras/mobile-view.rst:83
 #, fuzzy
-#| msgid "Notifications"
 msgid "Notifications & Account"
 msgstr "Notifications"
 
 #: ../extras/mobile-view.rst:0
 #, fuzzy
-#| msgid "Notifications"
 msgid "Mobile View Notifications"
 msgstr "Notifications"
 
@@ -6344,13 +6083,11 @@ msgstr ""
 
 #: ../extras/mobile-view.rst:117
 #, fuzzy
-#| msgid "open a ticket overview;"
 msgid "Manage & use your ticket overviews"
 msgstr "afficher l'aperçu d'un ticket ;"
 
 #: ../extras/mobile-view.rst:118
 #, fuzzy
-#| msgid "Search for Tickets"
 msgid "Search for existing records"
 msgstr "Recherche de tickets"
 
@@ -6360,19 +6097,16 @@ msgstr ""
 
 #: ../extras/mobile-view.rst:121
 #, fuzzy
-#| msgid "Ticket attributes"
 msgid "Modify ticket attributes"
 msgstr "Attributs du ticket"
 
 #: ../extras/mobile-view.rst:122
 #, fuzzy
-#| msgid "Ticket attributes"
 msgid "Modify customer attributes"
 msgstr "Attributs du ticket"
 
 #: ../extras/mobile-view.rst:123
 #, fuzzy
-#| msgid "Organization Profiles"
 msgid "Modify organization attributes"
 msgstr "Profils de société"
 
@@ -6398,7 +6132,6 @@ msgstr ""
 
 #: ../extras/mobile-view.rst:133
 #, fuzzy
-#| msgid "Notifications"
 msgid "Limitations"
 msgstr "Notifications"
 
@@ -6410,7 +6143,6 @@ msgstr ""
 
 #: ../extras/mobile-view.rst:138
 #, fuzzy
-#| msgid "Time Accounting"
 msgid "Ticket Article Time Accounting"
 msgstr "Comptabilité du temps"
 
@@ -6424,13 +6156,11 @@ msgstr ""
 
 #: ../extras/mobile-view.rst:141
 #, fuzzy
-#| msgid "Ticket Actions"
 msgid "Ticket Macros"
 msgstr "Actions sur les tickets"
 
 #: ../extras/mobile-view.rst:142
 #, fuzzy
-#| msgid "History"
 msgid "Ticket History"
 msgstr "Historique"
 
@@ -6463,7 +6193,6 @@ msgstr ""
 
 #: ../extras/mobile-view.rst:156
 #, fuzzy
-#| msgid "Token Access"
 msgid "Access"
 msgstr "Jeton d'accès"
 
@@ -6514,11 +6243,6 @@ msgstr ""
 
 #: ../extras/organizations.rst:4
 #, fuzzy
-#| msgid ""
-#| "Tickets track communication between individuals, but oftentimes, your "
-#| "company’s real client is **another company** (or **organization**). "
-#| "Customers can be grouped into organizations to monitor their activity as "
-#| "a whole."
 msgid ""
 "Tickets track communication between individuals, but often your company's "
 "real client is **another company** (or **organization**). Customers can be "
@@ -6535,7 +6259,6 @@ msgstr "Profils de société"
 
 #: ../extras/organizations.rst:12
 #, fuzzy
-#| msgid "Use the **ticket pane** to manage organization profiles."
 msgid "Use the **ticket pane** to view and manage organization profiles."
 msgstr "Utilisez le **panneau ticket** pour gérer les profiles de sociétés."
 
@@ -6545,8 +6268,6 @@ msgstr ""
 
 #: ../extras/organizations.rst:18
 #, fuzzy
-#| msgid ""
-#| "Click the 👪 tab in the ticket pane to see the organization’s profile."
 msgid "Click the 👪 tab in the ticket pane to see the organization's profile."
 msgstr ""
 "Cliquez sur l'onget 👪 dans le panneau ticket pour voir le profil de la "
@@ -6554,8 +6275,6 @@ msgstr ""
 
 #: ../extras/organizations.rst:20
 #, fuzzy
-#| msgid ""
-#| "To edit the organization’s profile, use the **organization submenu**:"
 msgid "To edit the organization's profile, use the **organization submenu**:"
 msgstr ""
 "Pour éditer le profil de la société, utilisez le **sous-menu société**:"
@@ -6572,7 +6291,6 @@ msgstr ""
 
 #: ../extras/organizations.rst:35
 #, fuzzy
-#| msgid "Organization Stats"
 msgid "Organization edit dialog"
 msgstr "Stats de société"
 
@@ -6606,9 +6324,6 @@ msgstr "“Quel âge à le plus vieux ticket de cette société?”"
 
 #: ../extras/organizations.rst:51
 #, fuzzy
-#| msgid ""
-#| "Click the 🏢 button in the ticket pane to see a detailed breakdown of the "
-#| "organization’s stats."
 msgid ""
 "Click the 🏢 button in the ticket pane to see a detailed breakdown of the "
 "organization's stats."
@@ -6622,9 +6337,6 @@ msgstr "Profil & Paramètres"
 
 #: ../extras/profile-and-settings.rst:4
 #, fuzzy
-#| msgid ""
-#| "Click on your avatar at the bottom of the main menu to access your "
-#| "**profile and settings**."
 msgid ""
 "Click on your avatar or initials at the bottom of the main menu to access "
 "your **profile and settings**."
@@ -6642,7 +6354,6 @@ msgstr ""
 
 #: ../extras/profile-and-settings.rst:17
 #, fuzzy
-#| msgid "User submenu"
 msgid "User Menu"
 msgstr "Menu utilisateur"
 
@@ -6682,15 +6393,11 @@ msgstr ""
 
 #: ../extras/profile-and-settings.rst:36
 #, fuzzy
-#| msgid "Keyboard Shortcuts"
 msgid "Keyboard shortcuts"
 msgstr "Raccourcis clavier"
 
 #: ../extras/profile-and-settings.rst:36
 #, fuzzy
-#| msgid ""
-#| "Use the built-in :doc:`keyboard shortcuts </advanced/keyboard-shortcuts>` "
-#| "to apply rich text formatting."
 msgid ""
 ":doc:`Opens the keyboard shortcut section </advanced/keyboard-shortcuts>`."
 msgstr ""
@@ -6699,7 +6406,6 @@ msgstr ""
 
 #: ../extras/profile-and-settings.rst:41
 #, fuzzy
-#| msgid "Profile Settings"
 msgid "Profile"
 msgstr "Paramètres de profil"
 
@@ -6780,19 +6486,16 @@ msgstr "Définir la langue d'affichage du système."
 
 #: ../extras/profile-and-settings.rst:82
 #, fuzzy
-#| msgid "Upload an avatar."
 msgid "Upload an avatar image."
 msgstr "Téléverser un avatar."
 
 #: ../extras/profile-and-settings.rst:0
 #, fuzzy
-#| msgid "Password"
 msgid "Password & Auth"
 msgstr "Mot de passe"
 
 #: ../extras/profile-and-settings.rst:86
 #, fuzzy
-#| msgid "Change your login password (may be disabled by system admin)."
 msgid ""
 "Change your login password and manage your two-factor authentication methods "
 "(both may be disabled by system admin)."
@@ -6809,9 +6512,6 @@ msgstr ""
 
 #: ../extras/profile-and-settings.rst:97
 #, fuzzy
-#| msgid ""
-#| "Select where, when, and for which groups you want to receive "
-#| "notifications, or choose a new notification sound."
 msgid ""
 "Select where, when, and for which groups you want to receive notifications, "
 "or choose a new notification sound. Notifications are available to agents "
@@ -6838,17 +6538,11 @@ msgstr ""
 
 #: ../extras/profile-and-settings.rst:130
 #, fuzzy
-#| msgid "Group"
 msgid "Limit Groups"
 msgstr "Groupe"
 
 #: ../extras/profile-and-settings.rst:117
 #, fuzzy
-#| msgid ""
-#| "By default, you will receive notifications for all tickets on every group "
-#| "you belong to—even for tickets that are assigned to other agents. Use the "
-#| "**Limit Groups** box to disable such notifications on a per-group basis. "
-#| "(You will continue to receive notifications for your own tickets.)"
 msgid ""
 "By default, you will receive notifications for all tickets in every group "
 "you belong to - even for tickets that are assigned to other agents. Use the "
@@ -6887,9 +6581,6 @@ msgstr "Absent du bureau"
 
 #: ../extras/profile-and-settings.rst:139
 #, fuzzy
-#| msgid ""
-#| "Schedule out-of-office periods in advance, and designate a substitute to "
-#| "handle your tickets while you’re gone."
 msgid ""
 "Schedule absence periods in advance, and designate a substitute to handle "
 "your tickets while you're gone."
@@ -6909,9 +6600,6 @@ msgstr ""
 
 #: ../extras/profile-and-settings.rst:146
 #, fuzzy
-#| msgid ""
-#| "🔔 You **will** continue to receive notifications while you are out-of-"
-#| "office!"
 msgid "You will reveive notifications while you are absent."
 msgstr ""
 "🔔 Vous **continuerez** à recevoir des notifications pendant que vous êtes "
@@ -6954,9 +6642,6 @@ msgstr "Calendrier"
 
 #: ../extras/profile-and-settings.rst:171
 #, fuzzy
-#| msgid ""
-#| "Add your ticket deadlines to your own favorite calendar app with the ICAL "
-#| "link listed at this settings panel."
 msgid ""
 "Add your ticket deadlines to your own favorite calendar app with the ICAL "
 "link listed at this setting's panel."
@@ -6970,9 +6655,6 @@ msgstr "Périphériques"
 
 #: ../extras/profile-and-settings.rst:176
 #, fuzzy
-#| msgid ""
-#| "See a list of all devices logged in to your Zammad account (and revoke "
-#| "access, if necessary)."
 msgid ""
 "See a list of all devices logged into your Zammad account (and revoke "
 "access, if necessary)."
@@ -6986,9 +6668,6 @@ msgstr "Jeton d'accès"
 
 #: ../extras/profile-and-settings.rst:181
 #, fuzzy
-#| msgid ""
-#| "Generate personal access tokens for third-party applications to use the "
-#| "Zammad API."
 msgid ""
 "Generate personal access tokens for third party applications to use the "
 "Zammad API."
@@ -7012,9 +6691,6 @@ msgstr "Comptes liés"
 
 #: ../extras/profile-and-settings.rst:191
 #, fuzzy
-#| msgid ""
-#| "See a list of third-party services (*e.g.,* Facebook or Twitter) linked "
-#| "to your Zammad account."
 msgid ""
 "See a list of third party services (*e.g.,* Facebook or Twitter) linked to "
 "your Zammad account."
@@ -7440,7 +7116,6 @@ msgstr ""
 
 #: ../extras/shared-drafts.rst:54
 #, fuzzy
-#| msgid "New tickets"
 msgid "New Ticket dialogue"
 msgstr "Nouveaux tickets"
 
@@ -7459,7 +7134,6 @@ msgstr ""
 
 #: ../extras/shared-drafts.rst:64
 #, fuzzy
-#| msgid "Existing tickets"
 msgid "Existing tickets (Ticket zoom)"
 msgstr "Tickets existants"
 
@@ -7501,13 +7175,11 @@ msgstr ""
 
 #: ../extras/shared-drafts.rst:97
 #, fuzzy
-#| msgid "New tickets"
 msgid "New ticket"
 msgstr "Nouveaux tickets"
 
 #: ../extras/shared-drafts.rst:87
 #, fuzzy
-#| msgid "Adding New Messages/Notes"
 msgid "Adding new drafts"
 msgstr "Ajouter de nouveaux messages/notes"
 
@@ -7549,7 +7221,6 @@ msgstr ""
 
 #: ../extras/shared-drafts.rst:109
 #, fuzzy
-#| msgid "Existing tickets"
 msgid "Existing ticket"
 msgstr "Tickets existants"
 
@@ -7999,7 +7670,6 @@ msgstr ""
 #: ../extras/two-factor-authentication/security-keys-setup.rst:50
 #: ../extras/two-factor-authentication/security-keys-setup.rst:None
 #, fuzzy
-#| msgid "Editing Categories"
 msgid "Editing Security Keys"
 msgstr "Éditer des catégories"
 
@@ -8080,8 +7750,20 @@ msgid ""
 "html>` available."
 msgstr ""
 
+#: ../basics/zammad-glossary.rst:618
 #, fuzzy
-#~| msgid "State"
+msgid "Bottom section:"
+msgstr "Notifications"
+
+#: ../basics/zammad-glossary.rst:732
+msgid ""
+"The title of a ticket is different based on the channel it came in. You can "
+"find the title in the sidebar and in the top area in the ticket view. If the "
+"title is not very meaningful, you can change it by clicking on the title in "
+"a ticket view."
+msgstr ""
+
+#, fuzzy
 #~ msgid "Status"
 #~ msgstr "État"
 
@@ -8190,9 +7872,6 @@ msgstr ""
 #~ "**🤔 Huh? Je ne vois pas de boîte de dialogue “Comptabilité du temps“...**"
 
 #, fuzzy
-#~| msgid ""
-#~| "This way, you can share correspondences with people who don’t have "
-#~| "Zammad (like a third-party supplier)."
 #~ msgid ""
 #~ "This way, you can share correspondences with people who don't have Zammad "
 #~ "(like a third-party supplier)."
@@ -8211,7 +7890,6 @@ msgstr ""
 #~ "message."
 
 #, fuzzy
-#~| msgid "**🙅 I’m working here!**"
 #~ msgid "**🙅 I'm working here!**"
 #~ msgstr "**🙅 Je travaille ici!**"
 
@@ -8232,7 +7910,6 @@ msgstr ""
 #~ msgstr "**🤔 Huh? Je ne vois pas “Discussion client“ dans le menu...**"
 
 #, fuzzy
-#~| msgid "**🤔 Huh? I don’t see an “Edit” button...**"
 #~ msgid "**🤔 Huh? I don't see a 🖨 printer tab...**"
 #~ msgstr "**🤔 Huh? Je ne vois pas de bouton “Éditer”...**"
 
@@ -8267,7 +7944,6 @@ msgstr ""
 #~ "langue sélectionnée?**"
 
 #, fuzzy
-#~| msgid "**🤔 Huh? I don’t see an “Edit” button...**"
 #~ msgid "**🤔 Huh? I don’t see an “RSS” button...**"
 #~ msgstr "**🤔 Huh? Je ne vois pas de bouton “Éditer”...**"
 
@@ -8275,22 +7951,17 @@ msgstr ""
 #~ msgstr "Les notifications internes ne peuvent pas être désactivées."
 
 #, fuzzy
-#~| msgid ""
-#~| "🔔 You **will** continue to receive notifications while you are out-of-"
-#~| "office!"
 #~ msgid "(You will continue to receive notifications for your own tickets.)"
 #~ msgstr ""
 #~ "🔔 Vous **continuerez** à recevoir des notifications pendant que vous "
 #~ "êtes absent du bureau!"
 
 #, fuzzy
-#~| msgid "**🤔 Huh? I don’t see an “Edit” button...**"
 #~ msgid ""
 #~ "**🤔 Huh? I don't see “Sign” or “Encrypt” options in the ticket view...**"
 #~ msgstr "**🤔 Huh? Je ne vois pas de bouton “Éditer”...**"
 
 #, fuzzy
-#~| msgid "**🤔 Huh? I don’t see an “Edit” button...**"
 #~ msgid "**🤔 Huh? I don't see “Share Draft” option...**"
 #~ msgstr "**🤔 Huh? Je ne vois pas de bouton “Éditer”...**"
 

--- a/locale/fr_CA/LC_MESSAGES/user-docs.po
+++ b/locale/fr_CA/LC_MESSAGES/user-docs.po
@@ -25,9 +25,6 @@ msgstr "Raccourcis clavier"
 
 #: ../advanced/keyboard-shortcuts.rst:6
 #, fuzzy
-#| msgid ""
-#| "Zammad supports a wide array of keyboard shortcuts to expedite your "
-#| "workflow as an expert user."
 msgid ""
 "Zammad supports a wide array of keyboard shortcuts to expedite your workflow "
 "as an expert user. But don't be afraid, you don't have to remember all of "
@@ -55,9 +52,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:20
 #, fuzzy
-#| msgid ""
-#| "Alternately, bring it up with one of the shortcuts below (shortcut-"
-#| "ception!)"
 msgid "Alternatively, open it with one of the shortcuts below:"
 msgstr ""
 "Alternativement, affichez-le avec l'un des raccourcis ci-dessous "
@@ -65,13 +59,11 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:22
 #, fuzzy
-#| msgid "``Ctrl`` + ``Shift`` + ``H`` (on Windows)"
 msgid "``ctrl`` + ``shift`` + ``h`` (on Linux and Windows)"
 msgstr "``Ctrl`` + ``Majuscule`` + ``H`` (sous Windows)"
 
 #: ../advanced/keyboard-shortcuts.rst:23
 #, fuzzy
-#| msgid "``Cmd`` + ``Ctrl`` + ``Shift`` + ``H`` (on macOS)"
 msgid "``cmd`` + ``ctrl`` + ``shift`` + ``h`` (on macOS)"
 msgstr "``Cmd`` + ``Ctrl`` + ``Majuscule`` + ``H`` (sous macOS)"
 
@@ -87,19 +79,16 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:33
 #, fuzzy
-#| msgid "Keyboard Shortcuts"
 msgid "The keyboard shortcut cheat sheet."
 msgstr "Raccourcis clavier"
 
 #: ../advanced/keyboard-shortcuts.rst:37
 #, fuzzy
-#| msgid "Keyboard Shortcuts"
 msgid "List of Available Keyboard Shortcuts"
 msgstr "Raccourcis clavier"
 
 #: ../advanced/keyboard-shortcuts.rst:40
 #, fuzzy
-#| msgid "Organizations"
 msgid "Navigation"
 msgstr "Organisations"
 
@@ -129,7 +118,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:46
 #, fuzzy
-#| msgid "Search phrase"
 msgid "Show overviews"
 msgstr "Expression de recherche"
 
@@ -155,7 +143,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:49 ../extras/mobile-view.rst:119
 #, fuzzy
-#| msgid "New tickets"
 msgid "Create a new ticket"
 msgstr "Nouveaux billets"
 
@@ -193,7 +180,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:54
 #, fuzzy
-#| msgid "``Cmd`` + ``Ctrl`` + ``Shift`` + ``H`` (on macOS)"
 msgid "``shift`` + ``ctrl`` + ``shift+tab``"
 msgstr "``Cmd`` + ``Ctrl`` + ``Majuscule`` + ``H`` (sous macOS)"
 
@@ -259,7 +245,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:66
 #, fuzzy
-#| msgid "Organizations"
 msgid "Translations"
 msgstr "Organisations"
 
@@ -289,7 +274,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:86
 #, fuzzy
-#| msgid "Ticket Actions"
 msgid "Tickets"
 msgstr "Actions de billets"
 
@@ -299,7 +283,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:91
 #, fuzzy
-#| msgid "New tickets"
 msgid "Create a new note article"
 msgstr "Nouveaux billets"
 
@@ -329,7 +312,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:95
 #, fuzzy
-#| msgid "``Cmd`` + ``Ctrl`` + ``Shift`` + ``H`` (on macOS)"
 msgid "``shift`` + ``ctrl`` + ``←`` / ``→``"
 msgstr "``Cmd`` + ``Ctrl`` + ``Majuscule`` + ``H`` (sous macOS)"
 
@@ -379,7 +361,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:109
 #, fuzzy
-#| msgid "Press ``Cmd`` + ``I`` to enter Italics mode,"
 msgid "Press ``cmd`` + ``i`` to enter *italics* mode,"
 msgstr "Appuyez sur ``Cmd`` + ``I`` pour passer en mode Italique,"
 
@@ -389,7 +370,6 @@ msgstr "entrez le texte désiré et"
 
 #: ../advanced/keyboard-shortcuts.rst:111
 #, fuzzy
-#| msgid "press ``Cmd`` + ``I`` again to return to normal text mode."
 msgid "press ``cmd`` + ``i`` again to return to normal text mode."
 msgstr ""
 "appuyez à nouveau sur ``Cmd`` + ``I`` pour revenir au mode texte normal."
@@ -408,7 +388,6 @@ msgstr "cliquez et glisser avec la souris pour le sélectionner et"
 
 #: ../advanced/keyboard-shortcuts.rst:117
 #, fuzzy
-#| msgid "press ``Cmd`` + ``I`` to italicize."
 msgid "press ``cmd`` + ``i`` to set the text in *italics*."
 msgstr "appuyez sur ``Cmd`` + ``I`` pour mettre en italique."
 
@@ -458,7 +437,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:128
 #, fuzzy
-#| msgid "``Ctrl`` + ``Shift`` + ``H`` (on Linux)"
 msgid "``ctrl`` + ``shift`` + ``v``"
 msgstr "``Ctrl`` + ``Majuscule`` + ``H`` (sous Linux)"
 
@@ -472,7 +450,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:129
 #, fuzzy
-#| msgid "Formatting Text"
 msgid "Remove formatting of text"
 msgstr "Formater du texte"
 
@@ -865,7 +842,6 @@ msgstr ""
 
 #: ../advanced/search.rst:48
 #, fuzzy
-#| msgid "Search phrase"
 msgid "Combining search phrases"
 msgstr "Expression de recherche"
 
@@ -1111,9 +1087,6 @@ msgstr ""
 
 #: ../advanced/suggested-workflows.rst:30
 #, fuzzy
-#| msgid ""
-#| "Reassign a ticket (via the *Group* and *Owner* settings) to let "
-#| "colleagues know you’re done with your part."
 msgid ""
 "Reassign a ticket (via the *Group* and *Owner* settings) to let colleagues "
 "know you're done with your part."
@@ -1135,12 +1108,6 @@ msgstr ""
 
 #: ../advanced/suggested-workflows.rst:39
 #, fuzzy
-#| msgid ""
-#| "Our sales rep can simply un-assign himself has the **owner** of the "
-#| "ticket and re-assign the ticket to the Customer Service **group**. *All "
-#| "customer service agents will be notified of the incoming ticket*, and the "
-#| "first available agent can assign herself to pick up where the sales rep "
-#| "left off."
 msgid ""
 "Our sales rep can simply un-assign himself as the **owner** of the ticket "
 "and re-assign the ticket to the Customer Service **group**. *All customer "
@@ -1324,9 +1291,6 @@ msgstr ""
 
 #: ../advanced/tabs.rst:9
 #, fuzzy
-#| msgid ""
-#| "You can freely switch between open tabs without losing your work – all "
-#| "unsaved changes are automatically backed up to the server."
 msgid ""
 "You can freely switch between open tabs without losing your work - all "
 "unsaved changes are automatically backed up to the server."
@@ -1348,7 +1312,6 @@ msgstr ""
 
 #: ../advanced/tabs.rst:18
 #, fuzzy
-#| msgid "What items open in a new “tab”?"
 msgid "**What items open in a new “tab”?**"
 msgstr "Quels éléments s'ouvrent dans un nouvel \"onglet\" ?"
 
@@ -1395,7 +1358,6 @@ msgstr "**Fermés**"
 
 #: ../snippets/ticket-state-type-circles.rst:7
 #, fuzzy
-#| msgid "**Closed**"
 msgid "**Merged**"
 msgstr "**Fermés**"
 
@@ -1516,11 +1478,6 @@ msgstr "Travailler avec les modules de texte"
 
 #: ../advanced/text-modules.rst:4
 #, fuzzy
-#| msgid ""
-#| "Zammad offers so-called text modules. Text modules will help you to "
-#| "improve your workflow, as you don't have to type your answer on every "
-#| "ticket by hand. You can simply choose a fitting text module and insert it "
-#| "into the E-Mail."
 msgid ""
 "Zammad offers so-called text modules. Text modules will help you to improve "
 "your workflow, as you don't have to type your answer on every ticket by "
@@ -1553,13 +1510,11 @@ msgstr ""
 
 #: ../advanced/text-modules.rst:21
 #, fuzzy
-#| msgid "Text modules on ticket creation"
 msgid "Text modules missing?"
 msgstr "Modules de texte et la création de billets"
 
 #: ../advanced/text-modules.rst:23
 #, fuzzy
-#| msgid "**🤔 How come some text modules don’t always appear?**"
 msgid "You noticed that some text modules don't always appear?"
 msgstr ""
 "**🤔 Comment se fait-il que certains modules de texte n'apparaissent pas "
@@ -1567,10 +1522,6 @@ msgstr ""
 
 #: ../advanced/text-modules.rst:25
 #, fuzzy
-#| msgid ""
-#| "Text modules can be tied to **groups**: that is, they only become active "
-#| "once the ticket you’re working on has been assigned to the appropriate "
-#| "group."
 msgid ""
 "Text modules can be tied to **groups**: that is, they only become active "
 "once the ticket you're working on has been assigned to the appropriate group."
@@ -1593,9 +1544,6 @@ msgstr ""
 
 #: ../advanced/text-modules.rst:35
 #, fuzzy
-#| msgid ""
-#| "How do you which groups go with which text modules? Ask your "
-#| "administrator!"
 msgid ""
 "How do you know which groups go with which text modules? Ask your "
 "administrator!"
@@ -1724,7 +1672,6 @@ msgstr "Fusion de billets"
 
 #: ../advanced/ticket-actions/merge.rst:4
 #, fuzzy
-#| msgid "In such cases, you may want to **merge those tickets into one**."
 msgid ""
 "If you have two or more tickets about the same issue, you may want to merge "
 "those tickets into one."
@@ -1746,9 +1693,6 @@ msgstr ""
 
 #: ../advanced/ticket-actions/merge.rst:13
 #, fuzzy
-#| msgid ""
-#| "Merging a ticket migrates all messages and notes **out of the original** "
-#| "and into the selected one."
 msgid ""
 "Merging a ticket migrates all messages and notes of the ticket from where "
 "you select the merging into the selected one."
@@ -1767,7 +1711,6 @@ msgstr ""
 
 #: ../advanced/ticket-actions/merge.rst:28
 #, fuzzy
-#| msgid "Browse for Tickets"
 msgid "How to merge tickets?"
 msgstr "Recherche de billets"
 
@@ -1783,7 +1726,6 @@ msgstr ""
 
 #: ../advanced/ticket-actions/merge.rst:40
 #, fuzzy
-#| msgid "New tickets"
 msgid "Merge dialog"
 msgstr "Nouveaux billets"
 
@@ -1824,9 +1766,6 @@ msgstr ""
 
 #: ../advanced/ticket-actions/merge.rst:53
 #, fuzzy
-#| msgid ""
-#| "The original ticket is :doc:`linked <link>` to the new one, as seen in "
-#| "the ticket pane."
 msgid "The ticket is :doc:`linked <link>` to its \"parent\" ticket"
 msgstr ""
 "Le billet d'origine est :doc:`linked ` au nouveau, comme vu dans le panneau "
@@ -1865,9 +1804,6 @@ msgstr ""
 
 #: ../advanced/ticket-actions/split.rst:23
 #, fuzzy
-#| msgid ""
-#| "When splitting a ticket, the target message is imported into the new "
-#| "ticket dialog. As usual, remember to select the **type** (call/email)."
 msgid ""
 "It is prefilled with the content of the existing article. Remember to select "
 "the type (call/email)."
@@ -1878,9 +1814,6 @@ msgstr ""
 
 #: ../advanced/ticket-actions/split.rst:26
 #, fuzzy
-#| msgid ""
-#| "The original ticket is :doc:`linked <link>` to the new one, as seen in "
-#| "the ticket pane."
 msgid ""
 "The original ticket is :doc:`linked <link>` to the new one, as you can see "
 "in the ticket side panel:"
@@ -1894,10 +1827,6 @@ msgstr "Modèles de billet"
 
 #: ../advanced/ticket-templates.rst:6
 #, fuzzy
-#| msgid ""
-#| "If you find yourself creating lots of tickets with the same basic "
-#| "attributes, use **ticket templates** to fill them in next time with a "
-#| "single click."
 msgid ""
 "If you find yourself creating lots of tickets with the same basic "
 "attributes, use **ticket templates** to fill them in with a single click "
@@ -1912,7 +1841,6 @@ msgstr ""
 
 #: ../advanced/ticket-templates.rst:13
 #, fuzzy
-#| msgid "Use the ticket pane to load or create ticket templates."
 msgid "Use the ticket pane to load ticket templates."
 msgstr ""
 "Utilisez le panneau des billets pour charger ou créer des modèles de billets."
@@ -1984,16 +1912,11 @@ msgstr ""
 
 #: ../advanced/time-accounting.rst:None
 #, fuzzy
-#| msgid "Time Accounting"
 msgid "Time Accounting Dialog"
 msgstr "Comptabilité horaire"
 
 #: ../advanced/time-accounting.rst:11
 #, fuzzy
-#| msgid ""
-#| "If time accounting is enabled, this dialog will appear each time you "
-#| "update a ticket. Enter how much time you spent on it (in minutes, or "
-#| "whichever unit of time all your other colleagues are using)."
 msgid ""
 "If the time accounting is enabled, this dialog will appear each time you "
 "update a ticket. Enter how much time you spent on it."
@@ -2023,13 +1946,11 @@ msgstr ""
 
 #: ../advanced/time-accounting.rst:None
 #, fuzzy
-#| msgid "Time Accounting"
 msgid "Time Accounting Unit"
 msgstr "Comptabilité horaire"
 
 #: ../advanced/time-accounting.rst:31
 #, fuzzy
-#| msgid "Time Accounting"
 msgid "Activity Types"
 msgstr "Comptabilité horaire"
 
@@ -2042,7 +1963,6 @@ msgstr ""
 
 #: ../advanced/time-accounting.rst:None
 #, fuzzy
-#| msgid "Time Accounting"
 msgid "Time Accounting Activity Type"
 msgstr "Comptabilité horaire"
 
@@ -2087,8 +2007,6 @@ msgstr "Trouver des billets"
 
 #: ../basics/find-ticket.rst:4
 #, fuzzy
-#| msgid ""
-#| "If you plan to work on tickets, you’d better know how to find ’em first."
 msgid ""
 "If you plan to work on tickets, you'd better know how to find them first."
 msgstr ""
@@ -2122,9 +2040,6 @@ msgstr ""
 
 #: ../basics/find-ticket/browse.rst:12
 #, fuzzy
-#| msgid ""
-#| "📥 Think of overviews as **inboxes**, each with a different filter for "
-#| "the tickets it displays."
 msgid ""
 "Think of overviews as **inboxes**, each with a different filter for the "
 "tickets it displays."
@@ -2691,7 +2606,6 @@ msgstr ""
 
 #: ../basics/service-ticket/settings.rst:4
 #, fuzzy
-#| msgid "Use the ticket pane to load or create ticket templates."
 msgid "Use the **ticket pane** to manage a ticket's settings:"
 msgstr ""
 "Utilisez le panneau des billets pour charger ou créer des modèles de billets."
@@ -2742,7 +2656,6 @@ msgstr ""
 
 #: ../basics/service-ticket/settings.rst:50
 #, fuzzy
-#| msgid "Ticket Actions"
 msgid "Further ticket actions"
 msgstr "Actions de billets"
 
@@ -3207,7 +3120,6 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:48
 #, fuzzy
-#| msgid "article.from"
 msgid "Article"
 msgstr "article.from"
 
@@ -3386,7 +3298,6 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:142
 #, fuzzy
-#| msgid "Suggested Workflows"
 msgid "Core Workflows"
 msgstr "Flux de travail suggéré"
 
@@ -3456,7 +3367,6 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:172
 #, fuzzy
-#| msgid "Ticket attributes"
 msgid "Custom Object Attributes"
 msgstr "Attributs d'un billet"
 
@@ -3529,7 +3439,6 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:227
 #, fuzzy
-#| msgid "Omnisearch"
 msgid "Elasticsearch"
 msgstr "Omnisearch"
 
@@ -4255,7 +4164,6 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:610
 #, fuzzy
-#| msgid "Search phrase"
 msgid "Search bar"
 msgstr "Expression de recherche"
 
@@ -4277,7 +4185,6 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:617
 #, fuzzy
-#| msgid "Browse for Tickets"
 msgid "One or more open tickets"
 msgstr "Recherche de billets"
 
@@ -4291,7 +4198,6 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:623
 #, fuzzy
-#| msgid "Text modules on ticket creation"
 msgid "Button for ticket creation"
 msgstr "Modules de texte et la création de billets"
 
@@ -4357,7 +4263,6 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:663
 #, fuzzy
-#| msgid "Splitting Tickets"
 msgid "Splitting tickets"
 msgstr "Fractionnement des billets"
 
@@ -4474,7 +4379,6 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:729
 #, fuzzy
-#| msgid "Ticket Templates"
 msgid "(Ticket) Template"
 msgstr "Modèles de billet"
 
@@ -4499,7 +4403,6 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:741
 #, fuzzy
-#| msgid "Ticket Actions"
 msgid "Ticket hook"
 msgstr "Actions de billets"
 
@@ -4529,7 +4432,6 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:757
 #, fuzzy
-#| msgid "Users"
 msgid "User"
 msgstr "Utilisateurs"
 
@@ -4626,7 +4528,6 @@ msgstr ""
 
 #: ../extras/caller-log.rst:34
 #, fuzzy
-#| msgid "New tickets"
 msgid "New Ticket dialog"
 msgstr "Nouveaux billets"
 
@@ -4876,7 +4777,6 @@ msgstr ""
 
 #: ../extras/customers.rst:4
 #, fuzzy
-#| msgid "Use the ticket pane to load or create ticket templates."
 msgid "Use the **ticket pane** to view and manage customer profiles."
 msgstr ""
 "Utilisez le panneau des billets pour charger ou créer des modèles de billets."
@@ -4949,7 +4849,6 @@ msgstr ""
 
 #: ../extras/customers.rst:0
 #, fuzzy
-#| msgid "Organizations"
 msgid "Secondary Organizations"
 msgstr "Organisations"
 
@@ -5723,7 +5622,6 @@ msgstr ""
 
 #: ../extras/mobile-view.rst:39
 #, fuzzy
-#| msgid "Search phrase"
 msgid "Search & Overview"
 msgstr "Expression de recherche"
 
@@ -5741,13 +5639,11 @@ msgstr ""
 
 #: ../extras/mobile-view.rst:55
 #, fuzzy
-#| msgid "Ticket attributes"
 msgid "Ticket Overview"
 msgstr "Attributs d'un billet"
 
 #: ../extras/mobile-view.rst:61
 #, fuzzy
-#| msgid "Ticket Actions"
 msgid "Ticket Details"
 msgstr "Actions de billets"
 
@@ -5765,7 +5661,6 @@ msgstr ""
 
 #: ../extras/mobile-view.rst:77
 #, fuzzy
-#| msgid "Ticket Actions"
 msgid "Ticket Information"
 msgstr "Actions de billets"
 
@@ -5808,7 +5703,6 @@ msgstr ""
 
 #: ../extras/mobile-view.rst:118
 #, fuzzy
-#| msgid "Search for a Ticketnumber"
 msgid "Search for existing records"
 msgstr "Rechercher un numéro de billet"
 
@@ -5818,19 +5712,16 @@ msgstr ""
 
 #: ../extras/mobile-view.rst:121
 #, fuzzy
-#| msgid "Ticket attributes"
 msgid "Modify ticket attributes"
 msgstr "Attributs d'un billet"
 
 #: ../extras/mobile-view.rst:122
 #, fuzzy
-#| msgid "Ticket attributes"
 msgid "Modify customer attributes"
 msgstr "Attributs d'un billet"
 
 #: ../extras/mobile-view.rst:123
 #, fuzzy
-#| msgid "Organizations"
 msgid "Modify organization attributes"
 msgstr "Organisations"
 
@@ -5866,7 +5757,6 @@ msgstr ""
 
 #: ../extras/mobile-view.rst:138
 #, fuzzy
-#| msgid "Time Accounting"
 msgid "Ticket Article Time Accounting"
 msgstr "Comptabilité horaire"
 
@@ -5880,13 +5770,11 @@ msgstr ""
 
 #: ../extras/mobile-view.rst:141
 #, fuzzy
-#| msgid "Ticket Actions"
 msgid "Ticket Macros"
 msgstr "Actions de billets"
 
 #: ../extras/mobile-view.rst:142
 #, fuzzy
-#| msgid "Ticket Actions"
 msgid "Ticket History"
 msgstr "Actions de billets"
 
@@ -5979,7 +5867,6 @@ msgstr ""
 
 #: ../extras/organizations.rst:12
 #, fuzzy
-#| msgid "Use the ticket pane to load or create ticket templates."
 msgid "Use the **ticket pane** to view and manage organization profiles."
 msgstr ""
 "Utilisez le panneau des billets pour charger ou créer des modèles de billets."
@@ -6006,7 +5893,6 @@ msgstr ""
 
 #: ../extras/organizations.rst:35
 #, fuzzy
-#| msgid "Organizations"
 msgid "Organization edit dialog"
 msgstr "Organisations"
 
@@ -6050,9 +5936,6 @@ msgstr ""
 
 #: ../extras/profile-and-settings.rst:4
 #, fuzzy
-#| msgid ""
-#| "Click on your avatar at the bottom of the main menu to access the "
-#| "**keyboard shortcuts cheat sheet**."
 msgid ""
 "Click on your avatar or initials at the bottom of the main menu to access "
 "your **profile and settings**."
@@ -6068,7 +5951,6 @@ msgstr ""
 
 #: ../extras/profile-and-settings.rst:17
 #, fuzzy
-#| msgid "Users"
 msgid "User Menu"
 msgstr "Utilisateurs"
 
@@ -6108,7 +5990,6 @@ msgstr ""
 
 #: ../extras/profile-and-settings.rst:36
 #, fuzzy
-#| msgid "Keyboard Shortcuts"
 msgid "Keyboard shortcuts"
 msgstr "Raccourcis clavier"
 
@@ -6786,7 +6667,6 @@ msgstr ""
 
 #: ../extras/shared-drafts.rst:54
 #, fuzzy
-#| msgid "New tickets"
 msgid "New Ticket dialogue"
 msgstr "Nouveaux billets"
 
@@ -6805,7 +6685,6 @@ msgstr ""
 
 #: ../extras/shared-drafts.rst:64
 #, fuzzy
-#| msgid "Existing tickets"
 msgid "Existing tickets (Ticket zoom)"
 msgstr "Billets existants"
 
@@ -6847,7 +6726,6 @@ msgstr ""
 
 #: ../extras/shared-drafts.rst:97
 #, fuzzy
-#| msgid "New tickets"
 msgid "New ticket"
 msgstr "Nouveaux billets"
 
@@ -6893,7 +6771,6 @@ msgstr ""
 
 #: ../extras/shared-drafts.rst:109
 #, fuzzy
-#| msgid "Existing tickets"
 msgid "Existing ticket"
 msgstr "Billets existants"
 
@@ -7422,6 +7299,18 @@ msgid ""
 "html>` available."
 msgstr ""
 
+#: ../basics/zammad-glossary.rst:618
+msgid "Bottom section:"
+msgstr ""
+
+#: ../basics/zammad-glossary.rst:732
+msgid ""
+"The title of a ticket is different based on the channel it came in. You can "
+"find the title in the sidebar and in the top area in the ticket view. If the "
+"title is not very meaningful, you can change it by clicking on the title in "
+"a ticket view."
+msgstr ""
+
 #~ msgid ""
 #~ "Unlike ticket settings (which are *attributes that can be modified*), "
 #~ "**actions** are *operations that can be performed* on a ticket, usually "
@@ -7516,26 +7405,22 @@ msgstr ""
 #~ "** 🤔 Hein? Je ne vois pas de boîte de dialogue \"Comptabilité horaire\"**"
 
 #, fuzzy
-#~| msgid "**🤔 Huh? I don’t see a “Time Accounting” dialog...**"
 #~ msgid "**🤔 Huh? I don't see a 🖨 printer tab...**"
 #~ msgstr ""
 #~ "** 🤔 Hein? Je ne vois pas de boîte de dialogue \"Comptabilité horaire\"**"
 
 #, fuzzy
-#~| msgid "**🤔 Huh? I don’t see a “Time Accounting” dialog...**"
 #~ msgid "**🤔 Huh? I don’t see an “RSS” button...**"
 #~ msgstr ""
 #~ "** 🤔 Hein? Je ne vois pas de boîte de dialogue \"Comptabilité horaire\"**"
 
 #, fuzzy
-#~| msgid "**🤔 Huh? I don’t see a “Time Accounting” dialog...**"
 #~ msgid ""
 #~ "**🤔 Huh? I don't see “Sign” or “Encrypt” options in the ticket view...**"
 #~ msgstr ""
 #~ "** 🤔 Hein? Je ne vois pas de boîte de dialogue \"Comptabilité horaire\"**"
 
 #, fuzzy
-#~| msgid "**🤔 Huh? I don’t see a “Time Accounting” dialog...**"
 #~ msgid "**🤔 Huh? I don't see “Share Draft” option...**"
 #~ msgstr ""
 #~ "** 🤔 Hein? Je ne vois pas de boîte de dialogue \"Comptabilité horaire\"**"

--- a/locale/hr/LC_MESSAGES/user-docs.po
+++ b/locale/hr/LC_MESSAGES/user-docs.po
@@ -26,9 +26,6 @@ msgstr "Tipkovnički prečaci"
 
 #: ../advanced/keyboard-shortcuts.rst:6
 #, fuzzy
-#| msgid ""
-#| "Zammad supports a wide array of keyboard shortcuts to expedite your "
-#| "workflow as an expert user."
 msgid ""
 "Zammad supports a wide array of keyboard shortcuts to expedite your workflow "
 "as an expert user. But don't be afraid, you don't have to remember all of "
@@ -56,9 +53,6 @@ msgstr "Korisnički podizbornik"
 
 #: ../advanced/keyboard-shortcuts.rst:20
 #, fuzzy
-#| msgid ""
-#| "Alternately, bring it up with one of the shortcuts below (shortcut-"
-#| "ception!)"
 msgid "Alternatively, open it with one of the shortcuts below:"
 msgstr ""
 "Alternativa za pristupanje tipkovničkim prečacima je otvoriti ih putem neke "
@@ -66,13 +60,11 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:22
 #, fuzzy
-#| msgid "``Ctrl`` + ``Shift`` + ``H`` (on Windows)"
 msgid "``ctrl`` + ``shift`` + ``h`` (on Linux and Windows)"
 msgstr "``Ctrl`` + ``Shift`` + ``H`` (na Windowsima)"
 
 #: ../advanced/keyboard-shortcuts.rst:23
 #, fuzzy
-#| msgid "``Cmd`` + ``Ctrl`` + ``Shift`` + ``H`` (on macOS)"
 msgid "``cmd`` + ``ctrl`` + ``shift`` + ``h`` (on macOS)"
 msgstr "``Cmd`` + ``Ctrl`` + ``Shift`` + ``H`` (na macOS-u)"
 
@@ -88,19 +80,16 @@ msgstr "Šalabahter za tipkovničke prečace"
 
 #: ../advanced/keyboard-shortcuts.rst:33
 #, fuzzy
-#| msgid "Keyboard shortcut cheat sheet"
 msgid "The keyboard shortcut cheat sheet."
 msgstr "Šalabahter za tipkovničke prečace"
 
 #: ../advanced/keyboard-shortcuts.rst:37
 #, fuzzy
-#| msgid "Keyboard Shortcuts"
 msgid "List of Available Keyboard Shortcuts"
 msgstr "Tipkovnički prečaci"
 
 #: ../advanced/keyboard-shortcuts.rst:40
 #, fuzzy
-#| msgid "organization"
 msgid "Navigation"
 msgstr "organizacija"
 
@@ -190,7 +179,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:54
 #, fuzzy
-#| msgid "``Cmd`` + ``Ctrl`` + ``Shift`` + ``H`` (on macOS)"
 msgid "``shift`` + ``ctrl`` + ``shift+tab``"
 msgstr "``Cmd`` + ``Ctrl`` + ``Shift`` + ``H`` (na macOS-u)"
 
@@ -256,7 +244,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:66
 #, fuzzy
-#| msgid "organization"
 msgid "Translations"
 msgstr "organizacija"
 
@@ -286,7 +273,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:86
 #, fuzzy
-#| msgid "Macros"
 msgid "Tickets"
 msgstr "Makro-naredbe"
 
@@ -324,7 +310,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:95
 #, fuzzy
-#| msgid "``Cmd`` + ``Ctrl`` + ``Shift`` + ``H`` (on macOS)"
 msgid "``shift`` + ``ctrl`` + ``←`` / ``→``"
 msgstr "``Cmd`` + ``Ctrl`` + ``Shift`` + ``H`` (na macOS-u)"
 
@@ -374,7 +359,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:109
 #, fuzzy
-#| msgid "Press ``Cmd`` + ``I`` to enter Italics mode,"
 msgid "Press ``cmd`` + ``i`` to enter *italics* mode,"
 msgstr "Pritisnite `Cmd`` + ``I`` kako bi pisali kurzivom,"
 
@@ -384,7 +368,6 @@ msgstr "unesite željeni tekst i"
 
 #: ../advanced/keyboard-shortcuts.rst:111
 #, fuzzy
-#| msgid "press ``Cmd`` + ``I`` again to return to normal text mode."
 msgid "press ``cmd`` + ``i`` again to return to normal text mode."
 msgstr ""
 "pritisnite ``Cmd`` + ``I``kako biste ponovno pisali standardnim fontom."
@@ -405,7 +388,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:117
 #, fuzzy
-#| msgid "press ``Cmd`` + ``I`` to italicize."
 msgid "press ``cmd`` + ``i`` to set the text in *italics*."
 msgstr "pritisnite ``Cmd`` + ``I``kako biste pisali kurzivom."
 
@@ -455,7 +437,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:128
 #, fuzzy
-#| msgid "``Ctrl`` + ``Shift`` + ``H`` (on Linux)"
 msgid "``ctrl`` + ``shift`` + ``v``"
 msgstr "``Ctrl`` + ``Shift`` + ``H`` (na Linuxu)"
 
@@ -469,7 +450,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:129
 #, fuzzy
-#| msgid "Formatting Text"
 msgid "Remove formatting of text"
 msgstr "Oblikovanje teksta"
 
@@ -559,10 +539,6 @@ msgstr ""
 
 #: ../advanced/macros.rst:10
 #, fuzzy
-#| msgid ""
-#| "You don’t – that’s the `administrator’s job <https://admin-docs.zammad."
-#| "org/en/latest/manage/macros.html>`_. If you have an idea for a macro "
-#| "you’d like to use, your Zammad admin can probably make it happen."
 msgid ""
 "Macros can be created by your :admin-docs:`administrator </manage/macros."
 "html>`. If you have an idea for a macro you'd like to use, your Zammad admin "
@@ -575,8 +551,6 @@ msgstr ""
 
 #: ../advanced/macros.rst:14
 #, fuzzy
-#| msgid ""
-#| "Macros can be applied in one of two ways: on a single ticket, or in bulk."
 msgid "Macros can be applied in two ways: on a single ticket, or in bulk."
 msgstr ""
 "Makro-naredbe se mogu primijeniti na dva načina: na jedan zaseban ticket ili "
@@ -588,9 +562,6 @@ msgstr "na jednom ticketu"
 
 #: ../advanced/macros.rst:19
 #, fuzzy
-#| msgid ""
-#| "The simplest way to apply a macro is to select it from the **Update ᐱ** "
-#| "submenu in the Ticket View:"
 msgid ""
 "The simplest way to apply a macro is to select it from the **Update ^** "
 "submenu in the Ticket View:"
@@ -608,10 +579,6 @@ msgstr "💾 **Makro-naredba = Ažuriranje**"
 
 #: ../advanced/macros.rst:29
 #, fuzzy
-#| msgid ""
-#| "If you’ve made changes to any other :ref:`settings on the ticket "
-#| "<ticket_settings>` (including typing up a reply to the customer), "
-#| "applying a macro will save them, too."
 msgid ""
 "If you've made changes to any other :ref:`settings on the ticket "
 "<ticket_settings>` (including typing up a reply to the customer), applying a "
@@ -623,10 +590,6 @@ msgstr ""
 
 #: ../advanced/macros.rst:34
 #, fuzzy
-#| msgid ""
-#| "⚠️ **But beware:** in the event of a conflict, the macro’s actions "
-#| "override any manual changes – including messages to the customer! When in "
-#| "doubt, apply your macro and your manual changes *separately.*"
 msgid ""
 "⚠️ **But beware:** in the event of a conflict, the macro's actions override "
 "any manual changes - including messages to the customer! When in doubt, "
@@ -705,10 +668,6 @@ msgstr "Proširena pretraga"
 
 #: ../advanced/search.rst:4
 #, fuzzy
-#| msgid ""
-#| "With Zammad, you can limit your search to specific Information. This "
-#| "allows you to find e.g. Tickets with specific key words and states. Below "
-#| "information will help you to improve your search results."
 msgid ""
 "With Zammad, you can limit your search to specific attributes. This allows "
 "you to find e.g. tickets with specific key words and states. Below "
@@ -732,9 +691,6 @@ msgstr "ili::"
 
 #: ../advanced/search.rst:18
 #, fuzzy
-#| msgid ""
-#| "If you want to run a more complex search you can use conditions with "
-#| "``()`` and ``AND``/``OR`` options::"
 msgid ""
 "If you want to run a more complex search, you can use conditions with ``()`` "
 "and ``AND``/``OR`` options::"
@@ -748,10 +704,6 @@ msgstr "Dostupni atributi"
 
 #: ../advanced/search.rst:28
 #, fuzzy
-#| msgid ""
-#| "For a more detailed list of available attributes please take a look into "
-#| "our `Zammad Admin-Documentation <https://docs.zammad.org/en/latest/"
-#| "install/elasticsearch/indexed-attributes.html>`_"
 msgid ""
 "For a more detailed list of available attributes please take a look into "
 "our :docs:`Zammad System Documentation </install/elasticsearch/indexed-"
@@ -940,7 +892,6 @@ msgstr ""
 
 #: ../advanced/search.rst:48
 #, fuzzy
-#| msgid "**Combining search phrases**"
 msgid "Combining search phrases"
 msgstr "**Kombiniranje fraza za pretraživanje**"
 
@@ -1751,7 +1702,6 @@ msgstr ""
 
 #: ../advanced/ticket-actions/merge.rst:40
 #, fuzzy
-#| msgid "Macros"
 msgid "Merge dialog"
 msgstr "Makro-naredbe"
 
@@ -1986,7 +1936,6 @@ msgstr ""
 
 #: ../advanced/time-accounting.rst:57
 #, fuzzy
-#| msgid "Screencast showing how to run a macro within a ticket view."
 msgid "Screenshot showing accounted times in ticket pane"
 msgstr "Screencast pokazuje kako izvršiti makro-naredbu u ticketu."
 
@@ -4375,7 +4324,6 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:741
 #, fuzzy
-#| msgid "Macros"
 msgid "Ticket hook"
 msgstr "Makro-naredbe"
 
@@ -4500,7 +4448,6 @@ msgstr ""
 
 #: ../extras/caller-log.rst:34
 #, fuzzy
-#| msgid "Macros"
 msgid "New Ticket dialog"
 msgstr "Makro-naredbe"
 
@@ -4820,7 +4767,6 @@ msgstr ""
 
 #: ../extras/customers.rst:0
 #, fuzzy
-#| msgid "organization"
 msgid "Secondary Organizations"
 msgstr "organizacija"
 
@@ -5606,13 +5552,11 @@ msgstr ""
 
 #: ../extras/mobile-view.rst:0
 #, fuzzy
-#| msgid "open a ticket overview;"
 msgid "Mobile View Ticket Overview"
 msgstr "otvorite Preglede;"
 
 #: ../extras/mobile-view.rst:55
 #, fuzzy
-#| msgid "open a ticket overview;"
 msgid "Ticket Overview"
 msgstr "otvorite Preglede;"
 
@@ -5671,13 +5615,11 @@ msgstr ""
 
 #: ../extras/mobile-view.rst:117
 #, fuzzy
-#| msgid "open a ticket overview;"
 msgid "Manage & use your ticket overviews"
 msgstr "otvorite Preglede;"
 
 #: ../extras/mobile-view.rst:118
 #, fuzzy
-#| msgid "Search for a Ticketnumber"
 msgid "Search for existing records"
 msgstr "Pretraga po broju ticketa"
 
@@ -5695,7 +5637,6 @@ msgstr ""
 
 #: ../extras/mobile-view.rst:123
 #, fuzzy
-#| msgid "organization"
 msgid "Modify organization attributes"
 msgstr "organizacija"
 
@@ -5743,7 +5684,6 @@ msgstr ""
 
 #: ../extras/mobile-view.rst:141
 #, fuzzy
-#| msgid "Macros"
 msgid "Ticket Macros"
 msgstr "Makro-naredbe"
 
@@ -5864,7 +5804,6 @@ msgstr ""
 
 #: ../extras/organizations.rst:35
 #, fuzzy
-#| msgid "organization"
 msgid "Organization edit dialog"
 msgstr "organizacija"
 
@@ -5908,9 +5847,6 @@ msgstr ""
 
 #: ../extras/profile-and-settings.rst:4
 #, fuzzy
-#| msgid ""
-#| "Click on your avatar at the bottom of the main menu to access the "
-#| "**keyboard shortcuts cheat sheet**."
 msgid ""
 "Click on your avatar or initials at the bottom of the main menu to access "
 "your **profile and settings**."
@@ -5926,7 +5862,6 @@ msgstr ""
 
 #: ../extras/profile-and-settings.rst:17
 #, fuzzy
-#| msgid "User submenu"
 msgid "User Menu"
 msgstr "Korisnički podizbornik"
 
@@ -5966,7 +5901,6 @@ msgstr ""
 
 #: ../extras/profile-and-settings.rst:36
 #, fuzzy
-#| msgid "Keyboard Shortcuts"
 msgid "Keyboard shortcuts"
 msgstr "Tipkovnički prečaci"
 
@@ -7270,6 +7204,18 @@ msgid ""
 "You are currently reading the Zammad user documentation. There are also :"
 "docs:`system </index.html>` and :admin-docs:`administration manuals </index."
 "html>` available."
+msgstr ""
+
+#: ../basics/zammad-glossary.rst:618
+msgid "Bottom section:"
+msgstr ""
+
+#: ../basics/zammad-glossary.rst:732
+msgid ""
+"The title of a ticket is different based on the channel it came in. You can "
+"find the title in the sidebar and in the top area in the ticket view. If the "
+"title is not very meaningful, you can change it by clicking on the title in "
+"a ticket view."
 msgstr ""
 
 #~ msgid "🤔 **How do I make macros?**"

--- a/locale/hu/LC_MESSAGES/user-docs.po
+++ b/locale/hu/LC_MESSAGES/user-docs.po
@@ -7085,3 +7085,15 @@ msgid ""
 "docs:`system </index.html>` and :admin-docs:`administration manuals </index."
 "html>` available."
 msgstr ""
+
+#: ../basics/zammad-glossary.rst:618
+msgid "Bottom section:"
+msgstr ""
+
+#: ../basics/zammad-glossary.rst:732
+msgid ""
+"The title of a ticket is different based on the channel it came in. You can "
+"find the title in the sidebar and in the top area in the ticket view. If the "
+"title is not very meaningful, you can change it by clicking on the title in "
+"a ticket view."
+msgstr ""

--- a/locale/it/LC_MESSAGES/user-docs.po
+++ b/locale/it/LC_MESSAGES/user-docs.po
@@ -25,9 +25,6 @@ msgstr "Scorciatoie da tastiera"
 
 #: ../advanced/keyboard-shortcuts.rst:6
 #, fuzzy
-#| msgid ""
-#| "Zammad supports a wide array of keyboard shortcuts to expedite your "
-#| "workflow as an expert user."
 msgid ""
 "Zammad supports a wide array of keyboard shortcuts to expedite your workflow "
 "as an expert user. But don't be afraid, you don't have to remember all of "
@@ -55,21 +52,16 @@ msgstr "Sottomenù utente"
 
 #: ../advanced/keyboard-shortcuts.rst:20
 #, fuzzy
-#| msgid ""
-#| "Alternately, bring it up with one of the shortcuts below (shortcut-"
-#| "ception!)"
 msgid "Alternatively, open it with one of the shortcuts below:"
 msgstr "In alternativa, richiamalo con una delle scorciatoie qui sotto"
 
 #: ../advanced/keyboard-shortcuts.rst:22
 #, fuzzy
-#| msgid "``Ctrl`` + ``Shift`` + ``H`` (on Windows)"
 msgid "``ctrl`` + ``shift`` + ``h`` (on Linux and Windows)"
 msgstr "``Ctrl`` + ``Shift`` + ``H`` (su Windows)"
 
 #: ../advanced/keyboard-shortcuts.rst:23
 #, fuzzy
-#| msgid "``Cmd`` + ``Ctrl`` + ``Shift`` + ``H`` (on macOS)"
 msgid "``cmd`` + ``ctrl`` + ``shift`` + ``h`` (on macOS)"
 msgstr "``Cmd`` + ``Ctrl`` + ``Shift`` + ``H`` (su macOS)"
 
@@ -85,13 +77,11 @@ msgstr "Specchietto riassuntivo delle scorciatoie da tastiera"
 
 #: ../advanced/keyboard-shortcuts.rst:33
 #, fuzzy
-#| msgid "Keyboard shortcut cheat sheet"
 msgid "The keyboard shortcut cheat sheet."
 msgstr "Specchietto riassuntivo delle scorciatoie da tastiera"
 
 #: ../advanced/keyboard-shortcuts.rst:37
 #, fuzzy
-#| msgid "Keyboard Shortcuts"
 msgid "List of Available Keyboard Shortcuts"
 msgstr "Scorciatoie da tastiera"
 
@@ -125,7 +115,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:46
 #, fuzzy
-#| msgid "Sample view of Overviews"
 msgid "Show overviews"
 msgstr "Visualizzazione d'esempio delle Panoramiche"
 
@@ -151,7 +140,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:49 ../extras/mobile-view.rst:119
 #, fuzzy
-#| msgid "Creating a Ticket"
 msgid "Create a new ticket"
 msgstr "Creare un ticket"
 
@@ -189,7 +177,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:54
 #, fuzzy
-#| msgid "``Cmd`` + ``Ctrl`` + ``Shift`` + ``H`` (on macOS)"
 msgid "``shift`` + ``ctrl`` + ``shift+tab``"
 msgstr "``Cmd`` + ``Ctrl`` + ``Shift`` + ``H`` (su macOS)"
 
@@ -283,7 +270,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:86
 #, fuzzy
-#| msgid "Macros"
 msgid "Tickets"
 msgstr "Macros"
 
@@ -293,7 +279,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:91
 #, fuzzy
-#| msgid "Creating a Ticket"
 msgid "Create a new note article"
 msgstr "Creare un ticket"
 
@@ -323,7 +308,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:95
 #, fuzzy
-#| msgid "``Cmd`` + ``Ctrl`` + ``Shift`` + ``H`` (on macOS)"
 msgid "``shift`` + ``ctrl`` + ``←`` / ``→``"
 msgstr "``Cmd`` + ``Ctrl`` + ``Shift`` + ``H`` (su macOS)"
 
@@ -373,7 +357,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:109
 #, fuzzy
-#| msgid "Press ``Cmd`` + ``I`` to enter Italics mode,"
 msgid "Press ``cmd`` + ``i`` to enter *italics* mode,"
 msgstr "Premi ``Cmd`` + ``I`` per andare in modalità Corsivo,"
 
@@ -383,7 +366,6 @@ msgstr "inserisci il tuo testo, e"
 
 #: ../advanced/keyboard-shortcuts.rst:111
 #, fuzzy
-#| msgid "press ``Cmd`` + ``I`` again to return to normal text mode."
 msgid "press ``cmd`` + ``i`` again to return to normal text mode."
 msgstr ""
 "premi ``Cmd`` + ``I`` di nuovo per tornare alla modalità di testo normale."
@@ -402,7 +384,6 @@ msgstr "clicca e trascina col mouse per selezionare, e"
 
 #: ../advanced/keyboard-shortcuts.rst:117
 #, fuzzy
-#| msgid "press ``Cmd`` + ``I`` to italicize."
 msgid "press ``cmd`` + ``i`` to set the text in *italics*."
 msgstr "premi ``Cmd`` + ``I`` per il corsivo."
 
@@ -452,7 +433,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:128
 #, fuzzy
-#| msgid "``Ctrl`` + ``Shift`` + ``H`` (on Linux)"
 msgid "``ctrl`` + ``shift`` + ``v``"
 msgstr "``Ctrl`` + ``Shift`` + ``H`` (su Linux)"
 
@@ -466,7 +446,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:129
 #, fuzzy
-#| msgid "Formatting Text"
 msgid "Remove formatting of text"
 msgstr "Formattazione del testo"
 
@@ -556,10 +535,6 @@ msgstr ""
 
 #: ../advanced/macros.rst:10
 #, fuzzy
-#| msgid ""
-#| "You don’t – that’s the `administrator’s job <https://admin-docs.zammad."
-#| "org/en/latest/manage/macros.html>`_. If you have an idea for a macro "
-#| "you’d like to use, your Zammad admin can probably make it happen."
 msgid ""
 "Macros can be created by your :admin-docs:`administrator </manage/macros."
 "html>`. If you have an idea for a macro you'd like to use, your Zammad admin "
@@ -572,8 +547,6 @@ msgstr ""
 
 #: ../advanced/macros.rst:14
 #, fuzzy
-#| msgid ""
-#| "Macros can be applied in one of two ways: on a single ticket, or in bulk."
 msgid "Macros can be applied in two ways: on a single ticket, or in bulk."
 msgstr ""
 "Le macro possono essere applicate in uno di questi due modi: su un singolo "
@@ -585,9 +558,6 @@ msgstr "In un singolo ticket"
 
 #: ../advanced/macros.rst:19
 #, fuzzy
-#| msgid ""
-#| "The simplest way to apply a macro is to select it from the **Update ᐱ** "
-#| "submenu in the Ticket View:"
 msgid ""
 "The simplest way to apply a macro is to select it from the **Update ^** "
 "submenu in the Ticket View:"
@@ -605,10 +575,6 @@ msgstr "💾 **Macro = Aggiorna**"
 
 #: ../advanced/macros.rst:29
 #, fuzzy
-#| msgid ""
-#| "If you’ve made changes to any other :ref:`settings on the ticket "
-#| "<ticket_settings>` (including typing up a reply to the customer), "
-#| "applying a macro will save them, too."
 msgid ""
 "If you've made changes to any other :ref:`settings on the ticket "
 "<ticket_settings>` (including typing up a reply to the customer), applying a "
@@ -1107,9 +1073,6 @@ msgstr ""
 
 #: ../advanced/suggested-workflows.rst:30
 #, fuzzy
-#| msgid ""
-#| "Reassign a ticket (via the *Group* and *Owner* settings) to let "
-#| "colleagues know you’re done with your part."
 msgid ""
 "Reassign a ticket (via the *Group* and *Owner* settings) to let colleagues "
 "know you're done with your part."
@@ -1365,7 +1328,6 @@ msgstr "**Chiusi**"
 
 #: ../snippets/ticket-state-type-circles.rst:7
 #, fuzzy
-#| msgid "Merge"
 msgid "**Merged**"
 msgstr "Unisci"
 
@@ -1684,7 +1646,6 @@ msgstr ""
 
 #: ../advanced/ticket-actions/merge.rst:28
 #, fuzzy
-#| msgid "Browse for Tickets"
 msgid "How to merge tickets?"
 msgstr "Navigazione dei Ticket"
 
@@ -1698,7 +1659,6 @@ msgstr ""
 
 #: ../advanced/ticket-actions/merge.rst:40
 #, fuzzy
-#| msgid "Macros"
 msgid "Merge dialog"
 msgstr "Macros"
 
@@ -1754,7 +1714,6 @@ msgstr ""
 
 #: ../advanced/ticket-actions/split.rst:8
 #, fuzzy
-#| msgid "To rename a ticket, simply click on the title and start typing."
 msgid ""
 "To split a ticket, simply click on the \"split\" button under the article "
 "you want to split off:"
@@ -1801,13 +1760,11 @@ msgstr ""
 
 #: ../advanced/ticket-templates.rst:13
 #, fuzzy
-#| msgid "Ticket template dialog"
 msgid "Ticket template selection in new ticket dialog"
 msgstr "Finestra Template ticket"
 
 #: ../advanced/ticket-templates.rst:13
 #, fuzzy
-#| msgid "Use the **ticket pane** to manage a ticket’s settings:"
 msgid "Use the ticket pane to load ticket templates."
 msgstr ""
 "Tramite il **pannello ticket** puoi gestire le impostazioni di un ticket:"
@@ -1879,16 +1836,11 @@ msgstr ""
 
 #: ../advanced/time-accounting.rst:None
 #, fuzzy
-#| msgid "Time accounting dialog"
 msgid "Time Accounting Dialog"
 msgstr "Finestra di dialogo per la Gestione del tempo"
 
 #: ../advanced/time-accounting.rst:11
 #, fuzzy
-#| msgid ""
-#| "If time accounting is enabled, this dialog will appear each time you "
-#| "update a ticket. Enter how much time you spent on it (in minutes, or "
-#| "whichever unit of time all your other colleagues are using)."
 msgid ""
 "If the time accounting is enabled, this dialog will appear each time you "
 "update a ticket. Enter how much time you spent on it."
@@ -1924,13 +1876,11 @@ msgstr ""
 
 #: ../advanced/time-accounting.rst:None
 #, fuzzy
-#| msgid "Time Accounting"
 msgid "Time Accounting Unit"
 msgstr "Gestione del tempo"
 
 #: ../advanced/time-accounting.rst:31
 #, fuzzy
-#| msgid "Time Accounting"
 msgid "Activity Types"
 msgstr "Gestione del tempo"
 
@@ -1943,7 +1893,6 @@ msgstr ""
 
 #: ../advanced/time-accounting.rst:None
 #, fuzzy
-#| msgid "Time Accounting"
 msgid "Time Accounting Activity Type"
 msgstr "Gestione del tempo"
 
@@ -1968,7 +1917,6 @@ msgstr ""
 
 #: ../advanced/time-accounting.rst:57
 #, fuzzy
-#| msgid "Screencast showing how to run a macro within a ticket view."
 msgid "Screenshot showing accounted times in ticket pane"
 msgstr "Screencast che mostra come eseguire una macro dalla vista ticket."
 
@@ -1990,8 +1938,6 @@ msgstr "Trovare i Ticket"
 
 #: ../basics/find-ticket.rst:4
 #, fuzzy
-#| msgid ""
-#| "If you plan to work on tickets, you’d better know how to find ’em first."
 msgid ""
 "If you plan to work on tickets, you'd better know how to find them first."
 msgstr "Per lavorare sui ticket, può essere necessario trovarli."
@@ -2020,9 +1966,6 @@ msgstr "Clicca **Panoramiche** nel menù principale per visualizzare i ticket."
 
 #: ../basics/find-ticket/browse.rst:12
 #, fuzzy
-#| msgid ""
-#| "📥 Think of overviews as **inboxes**, each with a different filter for "
-#| "the tickets it displays."
 msgid ""
 "Think of overviews as **inboxes**, each with a different filter for the "
 "tickets it displays."
@@ -2104,7 +2047,6 @@ msgstr "Cercare i ticket"
 
 #: ../basics/find-ticket/search.rst:4
 #, fuzzy
-#| msgid "Looking for an archived ticket? Use the **search bar**."
 msgid "Looking for an a specific ticket? Use the **search bar**:"
 msgstr "Stai cercando un ticket archiviato? Usa la **barra di ricerca**."
 
@@ -2114,9 +2056,6 @@ msgstr "I risultati appaiono mentre scrivi."
 
 #: ../basics/find-ticket/search.rst:12
 #, fuzzy
-#| msgid ""
-#| "It’s not just for tickets! Results cover 💬 **chat logs**, 👨 "
-#| "**customers**, and 🏢 **organizations**, too."
 msgid ""
 "It's not just for tickets! Results cover 💬 **chat logs**, 👨 **customers**, "
 "and 🏢 **organizations**, too."
@@ -2171,15 +2110,11 @@ msgstr "Gestione dei ticket"
 
 #: ../basics/service-ticket.rst:4
 #, fuzzy
-#| msgid "This is where you’ll spend the vast majority of your time in Zammad."
 msgid "This is where you'll spend the vast majority of your time in Zammad."
 msgstr "Questa è la sezione che userai più di frequente in Zammad."
 
 #: ../basics/service-ticket.rst:6
 #, fuzzy
-#| msgid ""
-#| "Once you get the hang of the tasks below, there’s really not much more to "
-#| "it."
 msgid ""
 "Once you get the hang of the tasks below, there's really not much more to it."
 msgstr ""
@@ -2192,10 +2127,6 @@ msgstr "Creare un ticket"
 
 #: ../basics/service-ticket/create.rst:4
 #, fuzzy
-#| msgid ""
-#| "Zammad does its best to create tickets automatically when new customer "
-#| "issues come your way. But sometimes, there’s just no way for Zammad to "
-#| "know when an issue arrives – like when a customer calls on the phone."
 msgid ""
 "Zammad does its best to create tickets automatically when new customer "
 "issues come your way. But sometimes, there's just no way for Zammad to know "
@@ -2257,7 +2188,6 @@ msgstr "Riempire il modulo"
 
 #: ../basics/service-ticket/create.rst:28
 #, fuzzy
-#| msgid "Here’s a quick run-down of each input field in the New Ticket form:"
 msgid "Here's a quick run-down of each input field in the New Ticket form:"
 msgstr ""
 "Ecco una panoramica veloce di ogni campo del modulo di creazione ticket:"
@@ -2298,7 +2228,6 @@ msgstr ""
 
 #: ../basics/service-ticket/create.rst:46
 #, fuzzy
-#| msgid "Autocomplete can’t find customers by name."
 msgid "Autocomplete can't find customers by name."
 msgstr ""
 "L'autocompletamento non è in grado di trovare i clienti in base al loro nome."
@@ -2428,10 +2357,6 @@ msgstr ""
 
 #: ../basics/service-ticket/follow-up.rst:19
 #, fuzzy
-#| msgid ""
-#| "Tickets are threads of messages & notes about a customer service issue. :"
-#| "doc:`⚙️ Manage a ticket’s settings <settings>` in the **ticket pane** on "
-#| "the right."
 msgid ""
 "Tickets are threads of messages & notes about a customer service issue. :doc:"
 "`⚙️ Manage ticket settings <settings>` in the **ticket pane** on the right."
@@ -2442,9 +2367,6 @@ msgstr ""
 
 #: ../basics/service-ticket/follow-up.rst:23
 #, fuzzy
-#| msgid ""
-#| "📇 Any time you open a ticket, a new entry will appear in your :doc:`tab "
-#| "list</advanced/tabs>` in the main menu."
 msgid ""
 "Any time you open a ticket, a new entry will appear in your :doc:`tab list</"
 "advanced/tabs>` in the main menu."
@@ -2491,9 +2413,6 @@ msgstr ""
 
 #: ../basics/service-ticket/follow-up.rst:47
 #, fuzzy
-#| msgid ""
-#| "⏩ You can also **forward messages**, just as you would in any email "
-#| "client (attachments are included automatically)."
 msgid ""
 "You can also **forward messages**, just as you would in any email client "
 "(attachments are included automatically). This way, you can share "
@@ -2518,7 +2437,6 @@ msgstr "Aggiungere nuovi messaggi/note"
 
 #: ../basics/service-ticket/follow-up.rst:60
 #, fuzzy
-#| msgid "Click on the text field at the end of the thread to add a follow-up."
 msgid "Click on the text field at the end of the thread to add a follow-up:"
 msgstr ""
 "Clicca sul campo di testo alla fine del thread per aggiungere una risposta."
@@ -2709,7 +2627,6 @@ msgstr ""
 
 #: ../basics/service-ticket/settings.rst:4
 #, fuzzy
-#| msgid "Use the **ticket pane** to manage a ticket’s settings:"
 msgid "Use the **ticket pane** to manage a ticket's settings:"
 msgstr ""
 "Tramite il **pannello ticket** puoi gestire le impostazioni di un ticket:"
@@ -2748,9 +2665,6 @@ msgstr "Evidenziare del testo del ticket"
 
 #: ../basics/service-ticket/settings.rst:39
 #, fuzzy
-#| msgid ""
-#| "Use the highlighter tool in the upper-righthand corner to mark up "
-#| "important text. (Your highlights are **not** visible to other agents.)"
 msgid ""
 "Use the highlighter tool in the upper-righthand corner to mark up important "
 "text. (Your highlights are visible to other agents.)"
@@ -2838,10 +2752,6 @@ msgstr "Cosa?"
 
 #: ../basics/service-ticket/settings/group.rst:11
 #, fuzzy
-#| msgid ""
-#| "Suppose your organization uses Zammad for both sales and customer "
-#| "support. You’ve got ten different agents spread across two teams, "
-#| "handling dozens of tickets a day."
 msgid ""
 "Suppose your organization uses Zammad for both sales and customer support. "
 "You've got ten different agents spread across two teams, handling dozens of "
@@ -2853,14 +2763,6 @@ msgstr ""
 
 #: ../basics/service-ticket/settings/group.rst:15
 #, fuzzy
-#| msgid ""
-#| "Without groups, all ten agents can see (and respond to) every single "
-#| "ticket that comes in, regardless of which department it’s for. This isn’t "
-#| "problematic *per se,* but it does lead to a lot of unnecessary clutter in "
-#| "the :doc:`overviews menu </basics/find-ticket>`. (It can be much worse "
-#| "when, for example, a customer service rep sees tickets meant for your HR "
-#| "department, and finds out how much their colleagues in sales are making! "
-#| "💸💸💸)"
 msgid ""
 "Without groups, all ten agents can see (and respond to) every single ticket "
 "that comes in, regardless of which department it's for. This isn't "
@@ -2880,9 +2782,6 @@ msgstr ""
 
 #: ../basics/service-ticket/settings/group.rst:25
 #, fuzzy
-#| msgid ""
-#| "If, instead, each agent were assigned to an appropriate group, then "
-#| "they’d only ever see the tickets that belong to their own group."
 msgid ""
 "If, instead, each agent were assigned to an appropriate group, then they'd "
 "only ever see the tickets that belong to their own group."
@@ -2896,9 +2795,6 @@ msgstr ""
 
 #: ../basics/service-ticket/settings/group.rst:31
 #, fuzzy
-#| msgid ""
-#| "You don’t – that’s the `administrator’s job <https://admin-docs.zammad."
-#| "org/en/latest/manage-groups.html>`_."
 msgid ""
 "So how do I manage which team I'm on? You don't - that's the :admin-docs:"
 "`administrator's job </manage/groups/index.html>`."
@@ -2908,9 +2804,6 @@ msgstr ""
 
 #: ../basics/service-ticket/settings/group.rst:34
 #, fuzzy
-#| msgid ""
-#| "However, you can *check* which teams you’re on in the Notifications "
-#| "section of your :doc:`user settings </extras/profile-and-settings>`:"
 msgid ""
 "However, you can *check* which teams you're on in the Notifications section "
 "of your :doc:`user settings </extras/profile-and-settings>`:"
@@ -2932,11 +2825,6 @@ msgstr "Allora, dove posso entrare?"
 
 #: ../basics/service-ticket/settings/group.rst:48
 #, fuzzy
-#| msgid ""
-#| "If you belong to more than one group, you may re-assign a ticket from one "
-#| "of your groups to another. In general, though, you won’t need to do this "
-#| "unless you’re an admin, or an admin has discussed the procedure with you "
-#| "beforehand."
 msgid ""
 "If you belong to more than one group, you may re-assign a ticket from one of "
 "your groups to another. In general, though, you won't need to do this unless "
@@ -2954,9 +2842,6 @@ msgstr "Proprietario"
 
 #: ../basics/service-ticket/settings/owner.rst:4
 #, fuzzy
-#| msgid ""
-#| "A ticket’s **owner** is simply *the agent that is currently responsible "
-#| "for it*."
 msgid ""
 "A ticket's **owner** is simply *the agent that is currently responsible for "
 "it*."
@@ -2968,10 +2853,6 @@ msgstr "Chi deve assegnare i ticket?"
 
 #: ../basics/service-ticket/settings/owner.rst:10
 #, fuzzy
-#| msgid ""
-#| "It depends on your organization’s workflow, but in most cases, **you will "
-#| "assign tickets to yourself** when you choose an issue to work on from the "
-#| "pool of new tickets."
 msgid ""
 "It depends on your organization's workflow, but in most cases, **you will "
 "assign tickets to yourself** when you choose an issue to work on from the "
@@ -2983,9 +2864,6 @@ msgstr ""
 
 #: ../basics/service-ticket/settings/owner.rst:16
 #, fuzzy
-#| msgid ""
-#| "In principle, any agent may assign a ticket to any other, as long as both "
-#| "have the required privileges for the ticket’s :doc:`group <group>`."
 msgid ""
 "In principle, any agent may assign a ticket to any other, as long as both "
 "have the required privileges for the ticket's :doc:`group </basics/service-"
@@ -3052,9 +2930,6 @@ msgstr ""
 
 #: ../basics/service-ticket/settings/priority.rst:25
 #, fuzzy
-#| msgid ""
-#| "Priority can also be used as a ticket filter when creating `custom "
-#| "overviews`_."
 msgid ""
 "Priority can also be used as a ticket filter when creating :admin-docs:"
 "`custom overviews </manage/overviews.html>`."
@@ -3125,18 +3000,11 @@ msgstr ""
 
 #: ../basics/service-ticket/settings/state.rst:30
 #, fuzzy
-#| msgid "What’s the difference between “new” and “open”?"
 msgid "What's the difference between “new” and “open”?"
 msgstr "Che differenza c'è fra \"nuovo\" ed \"aperto\"?"
 
 #: ../basics/service-ticket/settings/state.rst:32
 #, fuzzy
-#| msgid ""
-#| "States do more than just indicate progress: Zammad has a fine-grained "
-#| "time tracking feature (so-called “\\ `service-level agreements <https://"
-#| "admin-docs.zammad.org/en/latest/manage-slas.html>`_\\ ”, or SLAs) that "
-#| "uses state information to measure how long it takes for customers to get "
-#| "a response on a new ticket or get their issues resolved entirely."
 msgid ""
 "States do more than just indicate progress: Zammad has a fine-grained time "
 "tracking feature (so-called “:admin-docs:`service-level agreements </manage/"
@@ -3153,9 +3021,6 @@ msgstr ""
 
 #: ../basics/service-ticket/settings/state.rst:38
 #, fuzzy
-#| msgid ""
-#| "On a *new* ticket, the customer still hasn’t received her first response "
-#| "on the issue."
 msgid ""
 "On a *new* ticket, the customer still hasn't received her first response on "
 "the issue."
@@ -3165,9 +3030,6 @@ msgstr ""
 
 #: ../basics/service-ticket/settings/state.rst:41
 #, fuzzy
-#| msgid ""
-#| "On an *open* ticket, the customer has received an initial response, but "
-#| "the issue still hasn’t been resolved."
 msgid ""
 "On an *open* ticket, the customer has received an initial response, but the "
 "issue still hasn't been resolved."
@@ -3185,10 +3047,6 @@ msgstr ""
 
 #: ../basics/service-ticket/settings/state.rst:47
 #, fuzzy
-#| msgid ""
-#| "So, for instance, a ticket may be marked *pending reminder* if it’s "
-#| "waiting on feedback from a third-party supplier who’s out of town until "
-#| "next week."
 msgid ""
 "So, for instance, a ticket may be marked *pending reminder* if it's waiting "
 "on feedback from a third-party supplier who's out of town until next week."
@@ -4455,7 +4313,6 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:615
 #, fuzzy
-#| msgid "Customer"
 msgid "Customer Chat"
 msgstr "Cliente"
 
@@ -4465,7 +4322,6 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:617
 #, fuzzy
-#| msgid "Browse for Tickets"
 msgid "One or more open tickets"
 msgstr "Navigazione dei Ticket"
 
@@ -4475,7 +4331,6 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:622
 #, fuzzy
-#| msgid "Ticket Settings"
 msgid "Admin settings"
 msgstr "Impostazioni del ticket"
 
@@ -4684,7 +4539,6 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:741
 #, fuzzy
-#| msgid "Macros"
 msgid "Ticket hook"
 msgstr "Macros"
 
@@ -4779,11 +4633,6 @@ msgstr "Visualizza e gestisci il registro chiamate dal pannello **telefono**."
 
 #: ../extras/caller-log.rst:6
 #, fuzzy
-#| msgid ""
-#| "This feature is **optional**; if you don’t see it in the main menu, that "
-#| "means your administrator hasn’t enabled it yet. Administrators can learn "
-#| "more `here <https://admin-docs.zammad.org/en/latest/system-integrations."
-#| "html#integrations-for-phone-systems>`_."
 msgid ""
 "This feature is **optional**; if you don't see it in the main menu, that "
 "means your administrator hasn't enabled it yet. Administrators can learn "
@@ -4825,7 +4674,6 @@ msgstr ""
 
 #: ../extras/caller-log.rst:34
 #, fuzzy
-#| msgid "Macros"
 msgid "New Ticket dialog"
 msgstr "Macros"
 
@@ -5087,7 +4935,6 @@ msgstr ""
 
 #: ../extras/customers.rst:4
 #, fuzzy
-#| msgid "Use the **ticket pane** to manage a ticket’s settings:"
 msgid "Use the **ticket pane** to view and manage customer profiles."
 msgstr ""
 "Tramite il **pannello ticket** puoi gestire le impostazioni di un ticket:"
@@ -5290,11 +5137,6 @@ msgstr ""
 
 #: ../extras/github-gitlab-integration.rst:7
 #, fuzzy
-#| msgid ""
-#| "This feature is **optional**; if you don’t see it in the main menu, that "
-#| "means your administrator hasn’t enabled it yet. Administrators can learn "
-#| "more `here <https://admin-docs.zammad.org/en/latest/system-integrations."
-#| "html#integrations-for-phone-systems>`_."
 msgid ""
 "This feature is **optional**; if you don't see it in the ticket pane, that "
 "means your administrator hasn't enabled it yet. Administrators can learn "
@@ -5406,7 +5248,6 @@ msgstr ""
 
 #: ../extras/i-doit-track-company-property.rst:23
 #, fuzzy
-#| msgid "Use the **ticket pane** to manage a ticket’s settings:"
 msgid ""
 "Use the 🖨 **printer** tab to view or manage a ticket's assets from i-doit."
 msgstr ""
@@ -5966,25 +5807,21 @@ msgstr ""
 
 #: ../extras/mobile-view.rst:47
 #, fuzzy
-#| msgid "Search for Tickets"
 msgid "Search Results"
 msgstr "Cercare i ticket"
 
 #: ../extras/mobile-view.rst:0
 #, fuzzy
-#| msgid "open a ticket overview;"
 msgid "Mobile View Ticket Overview"
 msgstr "apri una panoramica dei ticket;"
 
 #: ../extras/mobile-view.rst:55
 #, fuzzy
-#| msgid "open a ticket overview;"
 msgid "Ticket Overview"
 msgstr "apri una panoramica dei ticket;"
 
 #: ../extras/mobile-view.rst:61
 #, fuzzy
-#| msgid "Ticket Settings"
 msgid "Ticket Details"
 msgstr "Impostazioni del ticket"
 
@@ -5994,7 +5831,6 @@ msgstr ""
 
 #: ../extras/mobile-view.rst:69
 #, fuzzy
-#| msgid "Ticket Settings"
 msgid "Ticket Detail View"
 msgstr "Impostazioni del ticket"
 
@@ -6004,7 +5840,6 @@ msgstr ""
 
 #: ../extras/mobile-view.rst:77
 #, fuzzy
-#| msgid "Ticket Settings"
 msgid "Ticket Information"
 msgstr "Impostazioni del ticket"
 
@@ -6018,7 +5853,6 @@ msgstr ""
 
 #: ../extras/mobile-view.rst:0
 #, fuzzy
-#| msgid "Sample view of Overviews"
 msgid "Mobile View Account Overview"
 msgstr "Visualizzazione d'esempio delle Panoramiche"
 
@@ -6045,13 +5879,11 @@ msgstr ""
 
 #: ../extras/mobile-view.rst:117
 #, fuzzy
-#| msgid "open a ticket overview;"
 msgid "Manage & use your ticket overviews"
 msgstr "apri una panoramica dei ticket;"
 
 #: ../extras/mobile-view.rst:118
 #, fuzzy
-#| msgid "Search for Tickets"
 msgid "Search for existing records"
 msgstr "Cercare i ticket"
 
@@ -6103,7 +5935,6 @@ msgstr ""
 
 #: ../extras/mobile-view.rst:138
 #, fuzzy
-#| msgid "Time Accounting"
 msgid "Ticket Article Time Accounting"
 msgstr "Gestione del tempo"
 
@@ -6117,13 +5948,11 @@ msgstr ""
 
 #: ../extras/mobile-view.rst:141
 #, fuzzy
-#| msgid "Macros"
 msgid "Ticket Macros"
 msgstr "Macros"
 
 #: ../extras/mobile-view.rst:142
 #, fuzzy
-#| msgid "History"
 msgid "Ticket History"
 msgstr "Cronologia"
 
@@ -6216,7 +6045,6 @@ msgstr ""
 
 #: ../extras/organizations.rst:12
 #, fuzzy
-#| msgid "Use the **ticket pane** to manage a ticket’s settings:"
 msgid "Use the **ticket pane** to view and manage organization profiles."
 msgstr ""
 "Tramite il **pannello ticket** puoi gestire le impostazioni di un ticket:"
@@ -6285,9 +6113,6 @@ msgstr ""
 
 #: ../extras/profile-and-settings.rst:4
 #, fuzzy
-#| msgid ""
-#| "Click on your avatar at the bottom of the main menu to access the "
-#| "**keyboard shortcuts cheat sheet**."
 msgid ""
 "Click on your avatar or initials at the bottom of the main menu to access "
 "your **profile and settings**."
@@ -6303,7 +6128,6 @@ msgstr ""
 
 #: ../extras/profile-and-settings.rst:17
 #, fuzzy
-#| msgid "User submenu"
 msgid "User Menu"
 msgstr "Sottomenù utente"
 
@@ -6343,15 +6167,11 @@ msgstr ""
 
 #: ../extras/profile-and-settings.rst:36
 #, fuzzy
-#| msgid "Keyboard Shortcuts"
 msgid "Keyboard shortcuts"
 msgstr "Scorciatoie da tastiera"
 
 #: ../extras/profile-and-settings.rst:36
 #, fuzzy
-#| msgid ""
-#| "Use the built-in :doc:`keyboard shortcuts </advanced/keyboard-shortcuts>` "
-#| "to apply rich text formatting."
 msgid ""
 ":doc:`Opens the keyboard shortcut section </advanced/keyboard-shortcuts>`."
 msgstr ""
@@ -6530,8 +6350,6 @@ msgstr ""
 
 #: ../extras/profile-and-settings.rst:146
 #, fuzzy
-#| msgid ""
-#| "Enable the **Phone** panel to receive notifications for incoming calls."
 msgid "You will reveive notifications while you are absent."
 msgstr ""
 "Abilita il pannello **Telefono** per ricevere notifiche di chiamate in "
@@ -7666,7 +7484,6 @@ msgstr "Extra"
 
 #: ../index.rst:2
 #, fuzzy
-#| msgid "Zammad Agent Documentation"
 msgid "Zammad User Documentation"
 msgstr "Documentazione dell'operatore Zammad"
 
@@ -7675,6 +7492,18 @@ msgid ""
 "You are currently reading the Zammad user documentation. There are also :"
 "docs:`system </index.html>` and :admin-docs:`administration manuals </index."
 "html>` available."
+msgstr ""
+
+#: ../basics/zammad-glossary.rst:618
+msgid "Bottom section:"
+msgstr ""
+
+#: ../basics/zammad-glossary.rst:732
+msgid ""
+"The title of a ticket is different based on the channel it came in. You can "
+"find the title in the sidebar and in the top area in the ticket view. If the "
+"title is not very meaningful, you can change it by clicking on the title in "
+"a ticket view."
 msgstr ""
 
 #, fuzzy
@@ -7688,9 +7517,6 @@ msgstr ""
 #~ msgstr "**🤔 Uhm? Non vedo la finestra “Gestione del tempo”...**"
 
 #, fuzzy
-#~| msgid ""
-#~| "This way, you can share correspondences with people who don’t have "
-#~| "Zammad (like a third-party supplier)."
 #~ msgid ""
 #~ "This way, you can share correspondences with people who don't have Zammad "
 #~ "(like a third-party supplier)."
@@ -7706,7 +7532,6 @@ msgstr ""
 #~ msgstr "Clicca il pulsante 🔒 per modificare la visibilità di un messaggio."
 
 #, fuzzy
-#~| msgid "**🙅 I’m working here!**"
 #~ msgid "**🙅 I'm working here!**"
 #~ msgstr "**🙅 Ci sto lavorando io!**"
 

--- a/locale/nl/LC_MESSAGES/user-docs.po
+++ b/locale/nl/LC_MESSAGES/user-docs.po
@@ -7085,3 +7085,15 @@ msgid ""
 "docs:`system </index.html>` and :admin-docs:`administration manuals </index."
 "html>` available."
 msgstr ""
+
+#: ../basics/zammad-glossary.rst:618
+msgid "Bottom section:"
+msgstr ""
+
+#: ../basics/zammad-glossary.rst:732
+msgid ""
+"The title of a ticket is different based on the channel it came in. You can "
+"find the title in the sidebar and in the top area in the ticket view. If the "
+"title is not very meaningful, you can change it by clicking on the title in "
+"a ticket view."
+msgstr ""

--- a/locale/pl/LC_MESSAGES/user-docs.po
+++ b/locale/pl/LC_MESSAGES/user-docs.po
@@ -26,9 +26,6 @@ msgstr "Skróty klawiszowe"
 
 #: ../advanced/keyboard-shortcuts.rst:6
 #, fuzzy
-#| msgid ""
-#| "Zammad supports a wide array of keyboard shortcuts to expedite your "
-#| "workflow as an expert user."
 msgid ""
 "Zammad supports a wide array of keyboard shortcuts to expedite your workflow "
 "as an expert user. But don't be afraid, you don't have to remember all of "
@@ -81,19 +78,16 @@ msgstr "Ściąga ze skrótów klawiszowych"
 
 #: ../advanced/keyboard-shortcuts.rst:33
 #, fuzzy
-#| msgid "Keyboard shortcut cheat sheet"
 msgid "The keyboard shortcut cheat sheet."
 msgstr "Ściąga ze skrótów klawiszowych"
 
 #: ../advanced/keyboard-shortcuts.rst:37
 #, fuzzy
-#| msgid "Keyboard Shortcuts"
 msgid "List of Available Keyboard Shortcuts"
 msgstr "Skróty klawiszowe"
 
 #: ../advanced/keyboard-shortcuts.rst:40
 #, fuzzy
-#| msgid "organization"
 msgid "Navigation"
 msgstr "organizacja"
 
@@ -248,7 +242,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:66
 #, fuzzy
-#| msgid "organization"
 msgid "Translations"
 msgstr "organizacja"
 
@@ -583,10 +576,6 @@ msgstr ""
 
 #: ../advanced/macros.rst:29
 #, fuzzy
-#| msgid ""
-#| "If you’ve made changes to any other :ref:`settings on the ticket "
-#| "<ticket_settings>` (including typing up a reply to the customer), "
-#| "applying a macro will save them, too."
 msgid ""
 "If you've made changes to any other :ref:`settings on the ticket "
 "<ticket_settings>` (including typing up a reply to the customer), applying a "
@@ -598,10 +587,6 @@ msgstr ""
 
 #: ../advanced/macros.rst:34
 #, fuzzy
-#| msgid ""
-#| "⚠️ **But beware:** in the event of a conflict, the macro’s actions "
-#| "override any manual changes – including messages to the customer! When in "
-#| "doubt, apply your macro and your manual changes *separately.*"
 msgid ""
 "⚠️ **But beware:** in the event of a conflict, the macro's actions override "
 "any manual changes - including messages to the customer! When in doubt, "
@@ -682,10 +667,6 @@ msgstr "Wyszukiwanie zaawansowane"
 
 #: ../advanced/search.rst:4
 #, fuzzy
-#| msgid ""
-#| "With Zammad, you can limit your search to specific Information. This "
-#| "allows you to find e.g. Tickets with specific key words and states. Below "
-#| "information will help you to improve your search results."
 msgid ""
 "With Zammad, you can limit your search to specific attributes. This allows "
 "you to find e.g. tickets with specific key words and states. Below "
@@ -929,7 +910,6 @@ msgstr ""
 
 #: ../advanced/search.rst:48
 #, fuzzy
-#| msgid "**Combining search phrases**"
 msgid "Combining search phrases"
 msgstr "**Łączenie fraz wyszukiwania**"
 
@@ -3068,13 +3048,6 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:22
 #, fuzzy
-#| msgid ""
-#| "An admin(istrator) is a user in Zammad who has special rights. Admins can "
-#| "configure user accesses, time recording settings, templates, and text "
-#| "modules and, on a higher level, integrations, reporting, etc. So if "
-#| "you're looking to make a change within your Zammad and you find that it "
-#| "doesn't work, find an admin in your organization and ask them – chances "
-#| "are, they can help."
 msgid ""
 "An admin(istrator) is a user in Zammad who has special rights. Admins can "
 "configure user accesses, time recording settings, templates, and text "
@@ -4170,7 +4143,6 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:610
 #, fuzzy
-#| msgid "Search phrase"
 msgid "Search bar"
 msgstr "Szukana fraza"
 
@@ -5877,7 +5849,6 @@ msgstr ""
 
 #: ../extras/organizations.rst:35
 #, fuzzy
-#| msgid "organization"
 msgid "Organization edit dialog"
 msgstr "organizacja"
 
@@ -5921,9 +5892,6 @@ msgstr ""
 
 #: ../extras/profile-and-settings.rst:4
 #, fuzzy
-#| msgid ""
-#| "Click on your avatar at the bottom of the main menu to access the "
-#| "**keyboard shortcuts cheat sheet**."
 msgid ""
 "Click on your avatar or initials at the bottom of the main menu to access "
 "your **profile and settings**."
@@ -7280,6 +7248,18 @@ msgid ""
 "You are currently reading the Zammad user documentation. There are also :"
 "docs:`system </index.html>` and :admin-docs:`administration manuals </index."
 "html>` available."
+msgstr ""
+
+#: ../basics/zammad-glossary.rst:618
+msgid "Bottom section:"
+msgstr ""
+
+#: ../basics/zammad-glossary.rst:732
+msgid ""
+"The title of a ticket is different based on the channel it came in. You can "
+"find the title in the sidebar and in the top area in the ticket view. If the "
+"title is not very meaningful, you can change it by clicking on the title in "
+"a ticket view."
 msgstr ""
 
 #, fuzzy

--- a/locale/pt_BR/LC_MESSAGES/user-docs.po
+++ b/locale/pt_BR/LC_MESSAGES/user-docs.po
@@ -25,9 +25,6 @@ msgstr "Atalhos de teclado"
 
 #: ../advanced/keyboard-shortcuts.rst:6
 #, fuzzy
-#| msgid ""
-#| "Zammad supports a wide array of keyboard shortcuts to expedite your "
-#| "workflow as an expert user."
 msgid ""
 "Zammad supports a wide array of keyboard shortcuts to expedite your workflow "
 "as an expert user. But don't be afraid, you don't have to remember all of "
@@ -55,21 +52,16 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:20
 #, fuzzy
-#| msgid ""
-#| "Alternately, bring it up with one of the shortcuts below (shortcut-"
-#| "ception!)"
 msgid "Alternatively, open it with one of the shortcuts below:"
 msgstr "Alternativamente, você pode usar um dos atalhos abaixo (muito fácil!)"
 
 #: ../advanced/keyboard-shortcuts.rst:22
 #, fuzzy
-#| msgid "``Ctrl`` + ``Shift`` + ``H`` (on Windows)"
 msgid "``ctrl`` + ``shift`` + ``h`` (on Linux and Windows)"
 msgstr "\"Ctrl\" + \"Shift\" + \"H\" (no Windows)"
 
 #: ../advanced/keyboard-shortcuts.rst:23
 #, fuzzy
-#| msgid "``Cmd`` + ``Ctrl`` + ``Shift`` + ``H`` (on macOS)"
 msgid "``cmd`` + ``ctrl`` + ``shift`` + ``h`` (on macOS)"
 msgstr "\"Cmd\" + \"Ctrl\" + \"Shift\" + \"H\" (no macOS)"
 
@@ -85,19 +77,16 @@ msgstr "Planilha com Atalhos do teclado"
 
 #: ../advanced/keyboard-shortcuts.rst:33
 #, fuzzy
-#| msgid "Keyboard shortcut cheat sheet"
 msgid "The keyboard shortcut cheat sheet."
 msgstr "Planilha com Atalhos do teclado"
 
 #: ../advanced/keyboard-shortcuts.rst:37
 #, fuzzy
-#| msgid "Keyboard Shortcuts"
 msgid "List of Available Keyboard Shortcuts"
 msgstr "Atalhos de teclado"
 
 #: ../advanced/keyboard-shortcuts.rst:40
 #, fuzzy
-#| msgid "Organization"
 msgid "Navigation"
 msgstr "Organização"
 
@@ -127,7 +116,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:46
 #, fuzzy
-#| msgid "Search phrase"
 msgid "Show overviews"
 msgstr "Frase pesquisada"
 
@@ -145,7 +133,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:48
 #, fuzzy
-#| msgid "Notifications"
 msgid "Open notifications"
 msgstr "Notificações"
 
@@ -155,7 +142,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:49 ../extras/mobile-view.rst:119
 #, fuzzy
-#| msgid "Creating a Ticket"
 msgid "Create a new ticket"
 msgstr "Criando chamados"
 
@@ -193,7 +179,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:54
 #, fuzzy
-#| msgid "``Cmd`` + ``Ctrl`` + ``Shift`` + ``H`` (on macOS)"
 msgid "``shift`` + ``ctrl`` + ``shift+tab``"
 msgstr "\"Cmd\" + \"Ctrl\" + \"Shift\" + \"H\" (no macOS)"
 
@@ -259,7 +244,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:66
 #, fuzzy
-#| msgid "Organizations"
 msgid "Translations"
 msgstr "Organizações"
 
@@ -289,7 +273,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:86
 #, fuzzy
-#| msgid "Ticket Actions"
 msgid "Tickets"
 msgstr "Ações dos Chamados"
 
@@ -299,7 +282,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:91
 #, fuzzy
-#| msgid "Creating a Ticket"
 msgid "Create a new note article"
 msgstr "Criando chamados"
 
@@ -329,7 +311,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:95
 #, fuzzy
-#| msgid "``Cmd`` + ``Ctrl`` + ``Shift`` + ``H`` (on macOS)"
 msgid "``shift`` + ``ctrl`` + ``←`` / ``→``"
 msgstr "\"Cmd\" + \"Ctrl\" + \"Shift\" + \"H\" (no macOS)"
 
@@ -379,7 +360,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:109
 #, fuzzy
-#| msgid "Press ``Cmd`` + ``I`` to enter Italics mode,"
 msgid "Press ``cmd`` + ``i`` to enter *italics* mode,"
 msgstr "Pressione \"Cmd\" + \"I\" para habilitar o modo itálico,"
 
@@ -389,7 +369,6 @@ msgstr "digite o seu texto desejado, e"
 
 #: ../advanced/keyboard-shortcuts.rst:111
 #, fuzzy
-#| msgid "press ``Cmd`` + ``I`` again to return to normal text mode."
 msgid "press ``cmd`` + ``i`` again to return to normal text mode."
 msgstr "pressione``Cmd`` + ``I`` novamente para desabilitar o modo itálico."
 
@@ -407,7 +386,6 @@ msgstr "clique e arraste com o mouse para selecionar o texto, e"
 
 #: ../advanced/keyboard-shortcuts.rst:117
 #, fuzzy
-#| msgid "press ``Cmd`` + ``I`` to italicize."
 msgid "press ``cmd`` + ``i`` to set the text in *italics*."
 msgstr "pressione \"Cmd\" + \"I\" para formatar como itálico."
 
@@ -457,7 +435,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:128
 #, fuzzy
-#| msgid "``Ctrl`` + ``Shift`` + ``H`` (on Linux)"
 msgid "``ctrl`` + ``shift`` + ``v``"
 msgstr "\"Ctrl\" + \"Shift\" + \"H\" (no Linux)"
 
@@ -471,7 +448,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:129
 #, fuzzy
-#| msgid "Formatting Text"
 msgid "Remove formatting of text"
 msgstr "Formatando texto"
 
@@ -537,7 +513,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:137
 #, fuzzy
-#| msgid "Remove an issue"
 msgid "Remove any hyperlink"
 msgstr "Remova um problema"
 
@@ -867,7 +842,6 @@ msgstr ""
 
 #: ../advanced/search.rst:48
 #, fuzzy
-#| msgid "Search phrase"
 msgid "Combining search phrases"
 msgstr "Frase pesquisada"
 
@@ -1124,9 +1098,6 @@ msgstr ""
 
 #: ../advanced/suggested-workflows.rst:30
 #, fuzzy
-#| msgid ""
-#| "Reassign a ticket (via the *Group* and *Owner* settings) to let "
-#| "colleagues know you’re done with your part."
 msgid ""
 "Reassign a ticket (via the *Group* and *Owner* settings) to let colleagues "
 "know you're done with your part."
@@ -1148,12 +1119,6 @@ msgstr ""
 
 #: ../advanced/suggested-workflows.rst:39
 #, fuzzy
-#| msgid ""
-#| "Our sales rep can simply un-assign himself has the **owner** of the "
-#| "ticket and re-assign the ticket to the Customer Service **group**. *All "
-#| "customer service agents will be notified of the incoming ticket*, and the "
-#| "first available agent can assign herself to pick up where the sales rep "
-#| "left off."
 msgid ""
 "Our sales rep can simply un-assign himself as the **owner** of the ticket "
 "and re-assign the ticket to the Customer Service **group**. *All customer "
@@ -1337,9 +1302,6 @@ msgstr ""
 
 #: ../advanced/tabs.rst:9
 #, fuzzy
-#| msgid ""
-#| "You can freely switch between open tabs without losing your work – all "
-#| "unsaved changes are automatically backed up to the server."
 msgid ""
 "You can freely switch between open tabs without losing your work - all "
 "unsaved changes are automatically backed up to the server."
@@ -1360,7 +1322,6 @@ msgstr ""
 
 #: ../advanced/tabs.rst:18
 #, fuzzy
-#| msgid "What items open in a new “tab”?"
 msgid "**What items open in a new “tab”?**"
 msgstr "Quais itens aparecem em uma nova \"aba\"?"
 
@@ -1409,7 +1370,6 @@ msgstr "**Fechado**"
 
 #: ../snippets/ticket-state-type-circles.rst:7
 #, fuzzy
-#| msgid "Merge"
 msgid "**Merged**"
 msgstr "Mesclar"
 
@@ -1558,7 +1518,6 @@ msgstr ""
 
 #: ../advanced/text-modules.rst:21
 #, fuzzy
-#| msgid "Text modules on ticket creation"
 msgid "Text modules missing?"
 msgstr "Módulos de texto na criação de chamado"
 
@@ -1708,7 +1667,6 @@ msgstr "Mesclando chamados"
 
 #: ../advanced/ticket-actions/merge.rst:4
 #, fuzzy
-#| msgid "In such cases, you may want to **merge those tickets into one**."
 msgid ""
 "If you have two or more tickets about the same issue, you may want to merge "
 "those tickets into one."
@@ -1730,9 +1688,6 @@ msgstr ""
 
 #: ../advanced/ticket-actions/merge.rst:13
 #, fuzzy
-#| msgid ""
-#| "Merging a ticket migrates all messages and notes **out of the original** "
-#| "and into the selected one."
 msgid ""
 "Merging a ticket migrates all messages and notes of the ticket from where "
 "you select the merging into the selected one."
@@ -1751,7 +1706,6 @@ msgstr ""
 
 #: ../advanced/ticket-actions/merge.rst:28
 #, fuzzy
-#| msgid "Browse for Tickets"
 msgid "How to merge tickets?"
 msgstr "Navegar pelos chamados"
 
@@ -1767,7 +1721,6 @@ msgstr ""
 
 #: ../advanced/ticket-actions/merge.rst:40
 #, fuzzy
-#| msgid "The edit customer dialog."
 msgid "Merge dialog"
 msgstr "A janela de edição de cliente."
 
@@ -1808,9 +1761,6 @@ msgstr ""
 
 #: ../advanced/ticket-actions/merge.rst:53
 #, fuzzy
-#| msgid ""
-#| "The original ticket is :doc:`linked <link>` to the new one, as seen in "
-#| "the ticket pane."
 msgid "The ticket is :doc:`linked <link>` to its \"parent\" ticket"
 msgstr ""
 "O chamado original é :doc:`associado <link>` ao novo, como visto no painel "
@@ -1829,7 +1779,6 @@ msgstr ""
 
 #: ../advanced/ticket-actions/split.rst:8
 #, fuzzy
-#| msgid "To rename a ticket, simply click on the title and start typing."
 msgid ""
 "To split a ticket, simply click on the \"split\" button under the article "
 "you want to split off:"
@@ -1852,9 +1801,6 @@ msgstr ""
 
 #: ../advanced/ticket-actions/split.rst:23
 #, fuzzy
-#| msgid ""
-#| "When splitting a ticket, the target message is imported into the new "
-#| "ticket dialog. As usual, remember to select the **type** (call/email)."
 msgid ""
 "It is prefilled with the content of the existing article. Remember to select "
 "the type (call/email)."
@@ -1865,9 +1811,6 @@ msgstr ""
 
 #: ../advanced/ticket-actions/split.rst:26
 #, fuzzy
-#| msgid ""
-#| "The original ticket is :doc:`linked <link>` to the new one, as seen in "
-#| "the ticket pane."
 msgid ""
 "The original ticket is :doc:`linked <link>` to the new one, as you can see "
 "in the ticket side panel:"
@@ -1881,10 +1824,6 @@ msgstr "Modelos de chamados"
 
 #: ../advanced/ticket-templates.rst:6
 #, fuzzy
-#| msgid ""
-#| "If you find yourself creating lots of tickets with the same basic "
-#| "attributes, use **ticket templates** to fill them in next time with a "
-#| "single click."
 msgid ""
 "If you find yourself creating lots of tickets with the same basic "
 "attributes, use **ticket templates** to fill them in with a single click "
@@ -1900,7 +1839,6 @@ msgstr ""
 
 #: ../advanced/ticket-templates.rst:13
 #, fuzzy
-#| msgid "Use the ticket pane to load or create ticket templates."
 msgid "Use the ticket pane to load ticket templates."
 msgstr ""
 "Utilize o painel do chamado para carregar ou criar um modelo de chamado."
@@ -1972,16 +1910,11 @@ msgstr ""
 
 #: ../advanced/time-accounting.rst:None
 #, fuzzy
-#| msgid "Time Accounting"
 msgid "Time Accounting Dialog"
 msgstr "Gestão de Tempo"
 
 #: ../advanced/time-accounting.rst:11
 #, fuzzy
-#| msgid ""
-#| "If time accounting is enabled, this dialog will appear each time you "
-#| "update a ticket. Enter how much time you spent on it (in minutes, or "
-#| "whichever unit of time all your other colleagues are using)."
 msgid ""
 "If the time accounting is enabled, this dialog will appear each time you "
 "update a ticket. Enter how much time you spent on it."
@@ -2015,13 +1948,11 @@ msgstr ""
 
 #: ../advanced/time-accounting.rst:None
 #, fuzzy
-#| msgid "Time Accounting"
 msgid "Time Accounting Unit"
 msgstr "Gestão de Tempo"
 
 #: ../advanced/time-accounting.rst:31
 #, fuzzy
-#| msgid "Time Accounting"
 msgid "Activity Types"
 msgstr "Gestão de Tempo"
 
@@ -2034,7 +1965,6 @@ msgstr ""
 
 #: ../advanced/time-accounting.rst:None
 #, fuzzy
-#| msgid "Time Accounting"
 msgid "Time Accounting Activity Type"
 msgstr "Gestão de Tempo"
 
@@ -2079,8 +2009,6 @@ msgstr "Encontrando chamados"
 
 #: ../basics/find-ticket.rst:4
 #, fuzzy
-#| msgid ""
-#| "If you plan to work on tickets, you’d better know how to find ’em first."
 msgid ""
 "If you plan to work on tickets, you'd better know how to find them first."
 msgstr ""
@@ -2113,9 +2041,6 @@ msgstr "Clique na aba **Visões** no menu para procurar por chamados."
 
 #: ../basics/find-ticket/browse.rst:12
 #, fuzzy
-#| msgid ""
-#| "📥 Think of overviews as **inboxes**, each with a different filter for "
-#| "the tickets it displays."
 msgid ""
 "Think of overviews as **inboxes**, each with a different filter for the "
 "tickets it displays."
@@ -2195,7 +2120,6 @@ msgstr "Pesquisar por chamados"
 
 #: ../basics/find-ticket/search.rst:4
 #, fuzzy
-#| msgid "Looking for an archived ticket? Use the **search bar**."
 msgid "Looking for an a specific ticket? Use the **search bar**:"
 msgstr "Procurando por um chamado arquivado? Utilize a **barra de pesquisa**."
 
@@ -2207,9 +2131,6 @@ msgstr ""
 
 #: ../basics/find-ticket/search.rst:12
 #, fuzzy
-#| msgid ""
-#| "It’s not just for tickets! Results cover 💬 **chat logs**, 👨 "
-#| "**customers**, and 🏢 **organizations**, too."
 msgid ""
 "It's not just for tickets! Results cover 💬 **chat logs**, 👨 **customers**, "
 "and 🏢 **organizations**, too."
@@ -2264,15 +2185,11 @@ msgstr "Manipulando chamados"
 
 #: ../basics/service-ticket.rst:4
 #, fuzzy
-#| msgid "This is where you’ll spend the vast majority of your time in Zammad."
 msgid "This is where you'll spend the vast majority of your time in Zammad."
 msgstr "Aqui é onde você gastará a maior parte do seu tempo no Zammad."
 
 #: ../basics/service-ticket.rst:6
 #, fuzzy
-#| msgid ""
-#| "Once you get the hang of the tasks below, there’s really not much more to "
-#| "it."
 msgid ""
 "Once you get the hang of the tasks below, there's really not much more to it."
 msgstr ""
@@ -2285,10 +2202,6 @@ msgstr "Criando chamados"
 
 #: ../basics/service-ticket/create.rst:4
 #, fuzzy
-#| msgid ""
-#| "Zammad does its best to create tickets automatically when new customer "
-#| "issues come your way. But sometimes, there’s just no way for Zammad to "
-#| "know when an issue arrives – like when a customer calls on the phone."
 msgid ""
 "Zammad does its best to create tickets automatically when new customer "
 "issues come your way. But sometimes, there's just no way for Zammad to know "
@@ -2356,7 +2269,6 @@ msgstr "Preenchendo o formulário"
 
 #: ../basics/service-ticket/create.rst:28
 #, fuzzy
-#| msgid "Here’s a quick run-down of each input field in the New Ticket form:"
 msgid "Here's a quick run-down of each input field in the New Ticket form:"
 msgstr ""
 "Abaixo, uma explicação rápida de cada campo de entrada no formulário de "
@@ -2398,7 +2310,6 @@ msgstr ""
 
 #: ../basics/service-ticket/create.rst:46
 #, fuzzy
-#| msgid "Autocomplete can’t find customers by name."
 msgid "Autocomplete can't find customers by name."
 msgstr "A busca não pode encontrar um cliente pelo nome."
 
@@ -2526,10 +2437,6 @@ msgstr ""
 
 #: ../basics/service-ticket/follow-up.rst:19
 #, fuzzy
-#| msgid ""
-#| "Tickets are threads of messages & notes about a customer service issue. :"
-#| "doc:`⚙️ Manage a ticket’s settings <settings>` in the **ticket pane** on "
-#| "the right."
 msgid ""
 "Tickets are threads of messages & notes about a customer service issue. :doc:"
 "`⚙️ Manage ticket settings <settings>` in the **ticket pane** on the right."
@@ -2540,9 +2447,6 @@ msgstr ""
 
 #: ../basics/service-ticket/follow-up.rst:23
 #, fuzzy
-#| msgid ""
-#| "📇 Any time you open a ticket, a new entry will appear in your :doc:`tab "
-#| "list</advanced/tabs>` in the main menu."
 msgid ""
 "Any time you open a ticket, a new entry will appear in your :doc:`tab list</"
 "advanced/tabs>` in the main menu."
@@ -2588,9 +2492,6 @@ msgstr ""
 
 #: ../basics/service-ticket/follow-up.rst:47
 #, fuzzy
-#| msgid ""
-#| "⏩ You can also **forward messages**, just as you would in any email "
-#| "client (attachments are included automatically)."
 msgid ""
 "You can also **forward messages**, just as you would in any email client "
 "(attachments are included automatically). This way, you can share "
@@ -2615,7 +2516,6 @@ msgstr "Adicionando novas mensagens / notas"
 
 #: ../basics/service-ticket/follow-up.rst:60
 #, fuzzy
-#| msgid "Click on the text field at the end of the thread to add a follow-up."
 msgid "Click on the text field at the end of the thread to add a follow-up:"
 msgstr ""
 "Clique no campo de texto no final do fluxo de mensagem para adicionar uma "
@@ -2806,7 +2706,6 @@ msgstr ""
 
 #: ../basics/service-ticket/settings.rst:4
 #, fuzzy
-#| msgid "Use the **ticket pane** to manage a ticket’s settings:"
 msgid "Use the **ticket pane** to manage a ticket's settings:"
 msgstr ""
 "Utilize o **painel do chamado** para gerenciar as configurações do chamado:"
@@ -2844,9 +2743,6 @@ msgstr "Destacar o texto de um chamado"
 
 #: ../basics/service-ticket/settings.rst:39
 #, fuzzy
-#| msgid ""
-#| "Use the highlighter tool in the upper-righthand corner to mark up "
-#| "important text. (Your highlights are **not** visible to other agents.)"
 msgid ""
 "Use the highlighter tool in the upper-righthand corner to mark up important "
 "text. (Your highlights are visible to other agents.)"
@@ -2868,7 +2764,6 @@ msgstr ""
 
 #: ../basics/service-ticket/settings.rst:50
 #, fuzzy
-#| msgid "Ticket Actions"
 msgid "Further ticket actions"
 msgstr "Ações dos Chamados"
 
@@ -2934,10 +2829,6 @@ msgstr "O que?"
 
 #: ../basics/service-ticket/settings/group.rst:11
 #, fuzzy
-#| msgid ""
-#| "Suppose your organization uses Zammad for both sales and customer "
-#| "support. You’ve got ten different agents spread across two teams, "
-#| "handling dozens of tickets a day."
 msgid ""
 "Suppose your organization uses Zammad for both sales and customer support. "
 "You've got ten different agents spread across two teams, handling dozens of "
@@ -2949,14 +2840,6 @@ msgstr ""
 
 #: ../basics/service-ticket/settings/group.rst:15
 #, fuzzy
-#| msgid ""
-#| "Without groups, all ten agents can see (and respond to) every single "
-#| "ticket that comes in, regardless of which department it’s for. This isn’t "
-#| "problematic *per se,* but it does lead to a lot of unnecessary clutter in "
-#| "the :doc:`overviews menu </basics/find-ticket>`. (It can be much worse "
-#| "when, for example, a customer service rep sees tickets meant for your HR "
-#| "department, and finds out how much their colleagues in sales are making! "
-#| "💸💸💸)"
 msgid ""
 "Without groups, all ten agents can see (and respond to) every single ticket "
 "that comes in, regardless of which department it's for. This isn't "
@@ -2976,9 +2859,6 @@ msgstr ""
 
 #: ../basics/service-ticket/settings/group.rst:25
 #, fuzzy
-#| msgid ""
-#| "If, instead, each agent were assigned to an appropriate group, then "
-#| "they’d only ever see the tickets that belong to their own group."
 msgid ""
 "If, instead, each agent were assigned to an appropriate group, then they'd "
 "only ever see the tickets that belong to their own group."
@@ -2992,9 +2872,6 @@ msgstr ""
 
 #: ../basics/service-ticket/settings/group.rst:31
 #, fuzzy
-#| msgid ""
-#| "You don’t – that’s the `administrator’s job <https://admin-docs.zammad."
-#| "org/en/latest/manage-groups.html>`_."
 msgid ""
 "So how do I manage which team I'm on? You don't - that's the :admin-docs:"
 "`administrator's job </manage/groups/index.html>`."
@@ -3004,9 +2881,6 @@ msgstr ""
 
 #: ../basics/service-ticket/settings/group.rst:34
 #, fuzzy
-#| msgid ""
-#| "However, you can *check* which teams you’re on in the Notifications "
-#| "section of your :doc:`user settings </extras/profile-and-settings>`:"
 msgid ""
 "However, you can *check* which teams you're on in the Notifications section "
 "of your :doc:`user settings </extras/profile-and-settings>`:"
@@ -3029,11 +2903,6 @@ msgstr "Então, onde eu entro?"
 
 #: ../basics/service-ticket/settings/group.rst:48
 #, fuzzy
-#| msgid ""
-#| "If you belong to more than one group, you may re-assign a ticket from one "
-#| "of your groups to another. In general, though, you won’t need to do this "
-#| "unless you’re an admin, or an admin has discussed the procedure with you "
-#| "beforehand."
 msgid ""
 "If you belong to more than one group, you may re-assign a ticket from one of "
 "your groups to another. In general, though, you won't need to do this unless "
@@ -3051,9 +2920,6 @@ msgstr "Proprietário"
 
 #: ../basics/service-ticket/settings/owner.rst:4
 #, fuzzy
-#| msgid ""
-#| "A ticket’s **owner** is simply *the agent that is currently responsible "
-#| "for it*."
 msgid ""
 "A ticket's **owner** is simply *the agent that is currently responsible for "
 "it*."
@@ -3067,10 +2933,6 @@ msgstr "De quem é a tarefa de atribuir chamados?"
 
 #: ../basics/service-ticket/settings/owner.rst:10
 #, fuzzy
-#| msgid ""
-#| "It depends on your organization’s workflow, but in most cases, **you will "
-#| "assign tickets to yourself** when you choose an issue to work on from the "
-#| "pool of new tickets."
 msgid ""
 "It depends on your organization's workflow, but in most cases, **you will "
 "assign tickets to yourself** when you choose an issue to work on from the "
@@ -3082,9 +2944,6 @@ msgstr ""
 
 #: ../basics/service-ticket/settings/owner.rst:16
 #, fuzzy
-#| msgid ""
-#| "In principle, any agent may assign a ticket to any other, as long as both "
-#| "have the required privileges for the ticket’s :doc:`group <group>`."
 msgid ""
 "In principle, any agent may assign a ticket to any other, as long as both "
 "have the required privileges for the ticket's :doc:`group </basics/service-"
@@ -3221,18 +3080,11 @@ msgstr ""
 
 #: ../basics/service-ticket/settings/state.rst:30
 #, fuzzy
-#| msgid "What’s the difference between “new” and “open”?"
 msgid "What's the difference between “new” and “open”?"
 msgstr "Qual a diferença entre *novo* e *aberto*?"
 
 #: ../basics/service-ticket/settings/state.rst:32
 #, fuzzy
-#| msgid ""
-#| "States do more than just indicate progress: Zammad has a fine-grained "
-#| "time tracking feature (so-called “\\ `service-level agreements <https://"
-#| "admin-docs.zammad.org/en/latest/manage-slas.html>`_\\ ”, or SLAs) that "
-#| "uses state information to measure how long it takes for customers to get "
-#| "a response on a new ticket or get their issues resolved entirely."
 msgid ""
 "States do more than just indicate progress: Zammad has a fine-grained time "
 "tracking feature (so-called “:admin-docs:`service-level agreements </manage/"
@@ -3249,9 +3101,6 @@ msgstr ""
 
 #: ../basics/service-ticket/settings/state.rst:38
 #, fuzzy
-#| msgid ""
-#| "On a *new* ticket, the customer still hasn’t received her first response "
-#| "on the issue."
 msgid ""
 "On a *new* ticket, the customer still hasn't received her first response on "
 "the issue."
@@ -3261,9 +3110,6 @@ msgstr ""
 
 #: ../basics/service-ticket/settings/state.rst:41
 #, fuzzy
-#| msgid ""
-#| "On an *open* ticket, the customer has received an initial response, but "
-#| "the issue still hasn’t been resolved."
 msgid ""
 "On an *open* ticket, the customer has received an initial response, but the "
 "issue still hasn't been resolved."
@@ -3281,10 +3127,6 @@ msgstr ""
 
 #: ../basics/service-ticket/settings/state.rst:47
 #, fuzzy
-#| msgid ""
-#| "So, for instance, a ticket may be marked *pending reminder* if it’s "
-#| "waiting on feedback from a third-party supplier who’s out of town until "
-#| "next week."
 msgid ""
 "So, for instance, a ticket may be marked *pending reminder* if it's waiting "
 "on feedback from a third-party supplier who's out of town until next week."
@@ -3741,7 +3583,6 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:172
 #, fuzzy
-#| msgid "Ticket attributes"
 msgid "Custom Object Attributes"
 msgstr "Atributos do ticket"
 
@@ -4541,13 +4382,11 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:610
 #, fuzzy
-#| msgid "Search phrase"
 msgid "Search bar"
 msgstr "Frase pesquisada"
 
 #: ../basics/zammad-glossary.rst:611
 #, fuzzy
-#| msgid "Notifications"
 msgid "Notification section"
 msgstr "Notificações"
 
@@ -4557,7 +4396,6 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:615
 #, fuzzy
-#| msgid "Customer"
 msgid "Customer Chat"
 msgstr "Cliente"
 
@@ -4567,7 +4405,6 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:617
 #, fuzzy
-#| msgid "Browse for Tickets"
 msgid "One or more open tickets"
 msgstr "Navegar pelos chamados"
 
@@ -4577,13 +4414,11 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:622
 #, fuzzy
-#| msgid "Ticket Settings"
 msgid "Admin settings"
 msgstr "Configurações dos chamados"
 
 #: ../basics/zammad-glossary.rst:623
 #, fuzzy
-#| msgid "Text modules on ticket creation"
 msgid "Button for ticket creation"
 msgstr "Módulos de texto na criação de chamado"
 
@@ -4649,7 +4484,6 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:663
 #, fuzzy
-#| msgid "Splitting Tickets"
 msgid "Splitting tickets"
 msgstr "Dividindo chamados"
 
@@ -4790,7 +4624,6 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:741
 #, fuzzy
-#| msgid "Ticket Actions"
 msgid "Ticket hook"
 msgstr "Ações dos Chamados"
 
@@ -4885,11 +4718,6 @@ msgstr "Veja e gerencie os registros de ligações a partir da aba **Telefone**.
 
 #: ../extras/caller-log.rst:6
 #, fuzzy
-#| msgid ""
-#| "This feature is **optional**; if you don’t see it in the main menu, that "
-#| "means your administrator hasn’t enabled it yet. Administrators can learn "
-#| "more `here <https://admin-docs.zammad.org/en/latest/system-integrations."
-#| "html#integrations-for-phone-systems>`_."
 msgid ""
 "This feature is **optional**; if you don't see it in the main menu, that "
 "means your administrator hasn't enabled it yet. Administrators can learn "
@@ -5037,10 +4865,6 @@ msgstr ""
 
 #: ../extras/chat.rst:6
 #, fuzzy
-#| msgid ""
-#| "This feature is **optional**; if you don’t see it in the main menu, that "
-#| "means your administrator hasn’t enabled it yet. Administrators can learn "
-#| "more `here <https://admin-docs.zammad.org/en/latest/channels-chat.html>`_."
 msgid ""
 "This feature is **optional**; if you don't see it in the main menu, that "
 "means your administrator hasn't enabled it yet. Administrators can learn "
@@ -5154,9 +4978,6 @@ msgstr ""
 
 #: ../extras/chat.rst:49
 #, fuzzy
-#| msgid ""
-#| "⌨️ Live chat supports `text modules <https://admin-docs.zammad.org/en/"
-#| "latest/manage-text-modules.html>`_."
 msgid ""
 "⌨️ Live chat supports :admin-docs:`text modules </manage-text-modules.html>`."
 msgstr ""
@@ -5165,9 +4986,6 @@ msgstr ""
 
 #: ../extras/chat.rst:50
 #, fuzzy
-#| msgid ""
-#| "📝 Chats can be **renamed** or **tagged**, and record technical details "
-#| "about the customer’s connection."
 msgid ""
 "📝 Chats can be **renamed** or **tagged**, and record technical details "
 "about the customer's connection."
@@ -5223,7 +5041,6 @@ msgstr "Clientes"
 
 #: ../extras/customers.rst:4
 #, fuzzy
-#| msgid "Use the **ticket pane** to manage customer profiles."
 msgid "Use the **ticket pane** to view and manage customer profiles."
 msgstr "Utilize o **painel do chamado** para gerenciar os perfis dos clientes."
 
@@ -5233,7 +5050,6 @@ msgstr ""
 
 #: ../extras/customers.rst:13
 #, fuzzy
-#| msgid "Click the 👨 tab in the ticket pane to see the customer’s profile."
 msgid "Click the 👨 tab in the ticket pane to see the customer's profile."
 msgstr "Clique na aba 👨 no painel do chamado para ver o perfil do cliente."
 
@@ -5249,9 +5065,6 @@ msgstr ""
 
 #: ../extras/customers.rst:23
 #, fuzzy
-#| msgid ""
-#| "Hover over the **open/closed** labels to see a summary of the customer’s "
-#| "other tickets."
 msgid ""
 "Hover over the **open/closed** labels to see a summary of the customer's "
 "other tickets."
@@ -5265,7 +5078,6 @@ msgstr "Editando um cliente"
 
 #: ../extras/customers.rst:29
 #, fuzzy
-#| msgid "To edit the customer’s profile, use the **customer submenu**:"
 msgid ""
 "To edit the customer's profile, use the **customer submenu** and select "
 "\"Edit Customer\":"
@@ -5281,7 +5093,6 @@ msgstr "Clique em **Cliente ▾* para acessar ações adicionais."
 
 #: ../extras/customers.rst:46
 #, fuzzy
-#| msgid "The edit customer dialog."
 msgid "Customer edit dialog"
 msgstr "A janela de edição de cliente."
 
@@ -5311,7 +5122,6 @@ msgstr ""
 
 #: ../extras/customers.rst:0
 #, fuzzy
-#| msgid "Organizations"
 msgid "Secondary Organizations"
 msgstr "Organizações"
 
@@ -5327,11 +5137,6 @@ msgstr "VIP"
 
 #: ../extras/customers.rst:63
 #, fuzzy
-#| msgid ""
-#| "Like :doc:`ticket priority </basics/service-ticket/settings/priority>`, "
-#| "**VIP status** doesn’t actually do anything out-of-the-box, but an admin "
-#| "*can* set up automated system hooks based on this value, or use it as a "
-#| "filter for :doc:`custom overviews </basics/find-ticket/browse>`."
 msgid ""
 "Like :doc:`ticket priority </basics/service-ticket/settings/priority>`, "
 "**VIP status** doesn't actually do anything out-of-the-box, but an admin "
@@ -5346,9 +5151,6 @@ msgstr ""
 
 #: ../extras/customers.rst:68
 #, fuzzy
-#| msgid ""
-#| "**Ask your administrator** about how she’d like you to use this attribute "
-#| "(or just leave it alone)."
 msgid ""
 "**Ask your administrator** about how she'd like you to use this attribute "
 "(or just leave it alone)."
@@ -5466,11 +5268,6 @@ msgstr ""
 
 #: ../extras/github-gitlab-integration.rst:7
 #, fuzzy
-#| msgid ""
-#| "This feature is **optional**; if you don’t see it in the ticket pane, "
-#| "that means your administrator hasn’t enabled it yet. Administrators can "
-#| "learn more `here <https://admin-docs.zammad.org/en/latest/system/"
-#| "integrations.html#integrations-for-issue-trackers>`_."
 msgid ""
 "This feature is **optional**; if you don't see it in the ticket pane, that "
 "means your administrator hasn't enabled it yet. Administrators can learn "
@@ -5534,9 +5331,6 @@ msgstr "Vincule um novo problema"
 
 #: ../extras/github-gitlab-integration.rst:30
 #, fuzzy
-#| msgid ""
-#| "At the top of the ticket pane, select **GitHub / GitLab > Link Issue**, "
-#| "then enter a valid issue URL."
 msgid ""
 "At the top of the ticket pane, select **GitHub / GitLab > Link Issue**, then "
 "enter a valid issue URL. Please note that linking a new issue can be slow "
@@ -5593,7 +5387,6 @@ msgstr ""
 
 #: ../extras/i-doit-track-company-property.rst:23
 #, fuzzy
-#| msgid "Use the **ticket pane** to manage a ticket’s settings:"
 msgid ""
 "Use the 🖨 **printer** tab to view or manage a ticket's assets from i-doit."
 msgstr ""
@@ -6143,7 +5936,6 @@ msgstr ""
 
 #: ../extras/mobile-view.rst:39
 #, fuzzy
-#| msgid "Search phrase"
 msgid "Search & Overview"
 msgstr "Frase pesquisada"
 
@@ -6153,7 +5945,6 @@ msgstr ""
 
 #: ../extras/mobile-view.rst:47
 #, fuzzy
-#| msgid "Search for Tickets"
 msgid "Search Results"
 msgstr "Pesquisar por chamados"
 
@@ -6163,13 +5954,11 @@ msgstr ""
 
 #: ../extras/mobile-view.rst:55
 #, fuzzy
-#| msgid "Ticket attributes"
 msgid "Ticket Overview"
 msgstr "Atributos do ticket"
 
 #: ../extras/mobile-view.rst:61
 #, fuzzy
-#| msgid "Ticket Settings"
 msgid "Ticket Details"
 msgstr "Configurações dos chamados"
 
@@ -6179,7 +5968,6 @@ msgstr ""
 
 #: ../extras/mobile-view.rst:69
 #, fuzzy
-#| msgid "Ticket Settings"
 msgid "Ticket Detail View"
 msgstr "Configurações dos chamados"
 
@@ -6189,19 +5977,16 @@ msgstr ""
 
 #: ../extras/mobile-view.rst:77
 #, fuzzy
-#| msgid "Ticket Actions"
 msgid "Ticket Information"
 msgstr "Ações dos Chamados"
 
 #: ../extras/mobile-view.rst:83
 #, fuzzy
-#| msgid "Notifications"
 msgid "Notifications & Account"
 msgstr "Notificações"
 
 #: ../extras/mobile-view.rst:0
 #, fuzzy
-#| msgid "Notifications"
 msgid "Mobile View Notifications"
 msgstr "Notificações"
 
@@ -6236,7 +6021,6 @@ msgstr ""
 
 #: ../extras/mobile-view.rst:118
 #, fuzzy
-#| msgid "Search for Tickets"
 msgid "Search for existing records"
 msgstr "Pesquisar por chamados"
 
@@ -6246,19 +6030,16 @@ msgstr ""
 
 #: ../extras/mobile-view.rst:121
 #, fuzzy
-#| msgid "Ticket attributes"
 msgid "Modify ticket attributes"
 msgstr "Atributos do ticket"
 
 #: ../extras/mobile-view.rst:122
 #, fuzzy
-#| msgid "Ticket attributes"
 msgid "Modify customer attributes"
 msgstr "Atributos do ticket"
 
 #: ../extras/mobile-view.rst:123
 #, fuzzy
-#| msgid "Organization Profiles"
 msgid "Modify organization attributes"
 msgstr "Perfis de organização"
 
@@ -6284,7 +6065,6 @@ msgstr ""
 
 #: ../extras/mobile-view.rst:133
 #, fuzzy
-#| msgid "Notifications"
 msgid "Limitations"
 msgstr "Notificações"
 
@@ -6296,7 +6076,6 @@ msgstr ""
 
 #: ../extras/mobile-view.rst:138
 #, fuzzy
-#| msgid "Time Accounting"
 msgid "Ticket Article Time Accounting"
 msgstr "Gestão de Tempo"
 
@@ -6310,13 +6089,11 @@ msgstr ""
 
 #: ../extras/mobile-view.rst:141
 #, fuzzy
-#| msgid "Ticket Actions"
 msgid "Ticket Macros"
 msgstr "Ações dos Chamados"
 
 #: ../extras/mobile-view.rst:142
 #, fuzzy
-#| msgid "History"
 msgid "Ticket History"
 msgstr "Histórico"
 
@@ -6349,7 +6126,6 @@ msgstr ""
 
 #: ../extras/mobile-view.rst:156
 #, fuzzy
-#| msgid "Token Access"
 msgid "Access"
 msgstr "Acesso por token"
 
@@ -6400,11 +6176,6 @@ msgstr ""
 
 #: ../extras/organizations.rst:4
 #, fuzzy
-#| msgid ""
-#| "Tickets track communication between individuals, but oftentimes, your "
-#| "company’s real client is **another company** (or **organization**). "
-#| "Customers can be grouped into organizations to monitor their activity as "
-#| "a whole."
 msgid ""
 "Tickets track communication between individuals, but often your company's "
 "real client is **another company** (or **organization**). Customers can be "
@@ -6421,7 +6192,6 @@ msgstr "Perfis de organização"
 
 #: ../extras/organizations.rst:12
 #, fuzzy
-#| msgid "Use the **ticket pane** to manage organization profiles."
 msgid "Use the **ticket pane** to view and manage organization profiles."
 msgstr ""
 "Utilize o **painel do chamado** para gerenciar o perfil de uma organização."
@@ -6432,8 +6202,6 @@ msgstr ""
 
 #: ../extras/organizations.rst:18
 #, fuzzy
-#| msgid ""
-#| "Click the 👪 tab in the ticket pane to see the organization’s profile."
 msgid "Click the 👪 tab in the ticket pane to see the organization's profile."
 msgstr ""
 "Clique na aba com o símbolo 👪 no painel do chamado para ver o perfil da "
@@ -6441,8 +6209,6 @@ msgstr ""
 
 #: ../extras/organizations.rst:20
 #, fuzzy
-#| msgid ""
-#| "To edit the organization’s profile, use the **organization submenu**:"
 msgid "To edit the organization's profile, use the **organization submenu**:"
 msgstr ""
 "Para editar o perfil de uma organização, utilize o **submenu organização**:"
@@ -6457,7 +6223,6 @@ msgstr "Clique em **Organização ▾** para acessar ações adicionais."
 
 #: ../extras/organizations.rst:35
 #, fuzzy
-#| msgid "Organization Stats"
 msgid "Organization edit dialog"
 msgstr "Estatísticas da organização"
 
@@ -6492,9 +6257,6 @@ msgstr "\"Quão antigo é o chamado aberto há mais tempo desta empresa?\""
 
 #: ../extras/organizations.rst:51
 #, fuzzy
-#| msgid ""
-#| "Click the 🏢 button in the ticket pane to see a detailed breakdown of the "
-#| "organization’s stats."
 msgid ""
 "Click the 🏢 button in the ticket pane to see a detailed breakdown of the "
 "organization's stats."
@@ -6508,9 +6270,6 @@ msgstr "Perfil e configurações"
 
 #: ../extras/profile-and-settings.rst:4
 #, fuzzy
-#| msgid ""
-#| "Click on your avatar at the bottom of the main menu to access your "
-#| "**profile and settings**."
 msgid ""
 "Click on your avatar or initials at the bottom of the main menu to access "
 "your **profile and settings**."
@@ -6528,7 +6287,6 @@ msgstr ""
 
 #: ../extras/profile-and-settings.rst:17
 #, fuzzy
-#| msgid "User"
 msgid "User Menu"
 msgstr "Usuário"
 
@@ -6568,15 +6326,11 @@ msgstr ""
 
 #: ../extras/profile-and-settings.rst:36
 #, fuzzy
-#| msgid "Keyboard Shortcuts"
 msgid "Keyboard shortcuts"
 msgstr "Atalhos de teclado"
 
 #: ../extras/profile-and-settings.rst:36
 #, fuzzy
-#| msgid ""
-#| "Use the built-in :doc:`keyboard shortcuts </advanced/keyboard-shortcuts>` "
-#| "to apply rich text formatting."
 msgid ""
 ":doc:`Opens the keyboard shortcut section </advanced/keyboard-shortcuts>`."
 msgstr ""
@@ -6585,7 +6339,6 @@ msgstr ""
 
 #: ../extras/profile-and-settings.rst:41
 #, fuzzy
-#| msgid "Profile Settings"
 msgid "Profile"
 msgstr "Configurações de perfil"
 
@@ -6666,19 +6419,16 @@ msgstr "Determina a linguagem de exibição do sistema."
 
 #: ../extras/profile-and-settings.rst:82
 #, fuzzy
-#| msgid "Upload an avatar."
 msgid "Upload an avatar image."
 msgstr "Carrega uma imagem de avatar."
 
 #: ../extras/profile-and-settings.rst:0
 #, fuzzy
-#| msgid "Password"
 msgid "Password & Auth"
 msgstr "Senha"
 
 #: ../extras/profile-and-settings.rst:86
 #, fuzzy
-#| msgid "Change your login password (may be disabled by system admin)."
 msgid ""
 "Change your login password and manage your two-factor authentication methods "
 "(both may be disabled by system admin)."
@@ -6695,9 +6445,6 @@ msgstr ""
 
 #: ../extras/profile-and-settings.rst:97
 #, fuzzy
-#| msgid ""
-#| "Select where, when, and for which groups you want to receive "
-#| "notifications, or choose a new notification sound."
 msgid ""
 "Select where, when, and for which groups you want to receive notifications, "
 "or choose a new notification sound. Notifications are available to agents "
@@ -6761,9 +6508,6 @@ msgstr "Fora do escritório"
 
 #: ../extras/profile-and-settings.rst:139
 #, fuzzy
-#| msgid ""
-#| "Schedule out-of-office periods in advance, and designate a substitute to "
-#| "handle your tickets while you’re gone."
 msgid ""
 "Schedule absence periods in advance, and designate a substitute to handle "
 "your tickets while you're gone."
@@ -6783,9 +6527,6 @@ msgstr ""
 
 #: ../extras/profile-and-settings.rst:146
 #, fuzzy
-#| msgid ""
-#| "🔔 You **will** continue to receive notifications while you are out-of-"
-#| "office!"
 msgid "You will reveive notifications while you are absent."
 msgstr ""
 "🔔 Você **continuará** recebendo as notificações enquanto estiver fora do "
@@ -6828,9 +6569,6 @@ msgstr "Calendário"
 
 #: ../extras/profile-and-settings.rst:171
 #, fuzzy
-#| msgid ""
-#| "Add your ticket deadlines to your own favorite calendar app with the ICAL "
-#| "link listed at this settings panel."
 msgid ""
 "Add your ticket deadlines to your own favorite calendar app with the ICAL "
 "link listed at this setting's panel."
@@ -6844,9 +6582,6 @@ msgstr "Dispositivos"
 
 #: ../extras/profile-and-settings.rst:176
 #, fuzzy
-#| msgid ""
-#| "See a list of all devices logged in to your Zammad account (and revoke "
-#| "access, if necessary)."
 msgid ""
 "See a list of all devices logged into your Zammad account (and revoke "
 "access, if necessary)."
@@ -6860,9 +6595,6 @@ msgstr "Acesso por token"
 
 #: ../extras/profile-and-settings.rst:181
 #, fuzzy
-#| msgid ""
-#| "Generate personal access tokens for third-party applications to use the "
-#| "Zammad API."
 msgid ""
 "Generate personal access tokens for third party applications to use the "
 "Zammad API."
@@ -6886,9 +6618,6 @@ msgstr "Contas vinculadas"
 
 #: ../extras/profile-and-settings.rst:191
 #, fuzzy
-#| msgid ""
-#| "See a list of third-party services (*e.g.,* Facebook or Twitter) linked "
-#| "to your Zammad account."
 msgid ""
 "See a list of third party services (*e.g.,* Facebook or Twitter) linked to "
 "your Zammad account."
@@ -7946,7 +7675,6 @@ msgstr "Extras"
 
 #: ../index.rst:2
 #, fuzzy
-#| msgid "Zammad Agent Documentation"
 msgid "Zammad User Documentation"
 msgstr "Documentação do Agente Zammad"
 
@@ -7955,6 +7683,19 @@ msgid ""
 "You are currently reading the Zammad user documentation. There are also :"
 "docs:`system </index.html>` and :admin-docs:`administration manuals </index."
 "html>` available."
+msgstr ""
+
+#: ../basics/zammad-glossary.rst:618
+#, fuzzy
+msgid "Bottom section:"
+msgstr "Notificações"
+
+#: ../basics/zammad-glossary.rst:732
+msgid ""
+"The title of a ticket is different based on the channel it came in. You can "
+"find the title in the sidebar and in the top area in the ticket view. If the "
+"title is not very meaningful, you can change it by clicking on the title in "
+"a ticket view."
 msgstr ""
 
 #~ msgid "Status"
@@ -8051,9 +7792,6 @@ msgstr ""
 #~ "**🤔 Hum? Eu não vejo nenhuma janela de diálogo \"Contagem de tempo\"...**"
 
 #, fuzzy
-#~| msgid ""
-#~| "This way, you can share correspondences with people who don’t have "
-#~| "Zammad (like a third-party supplier)."
 #~ msgid ""
 #~ "This way, you can share correspondences with people who don't have Zammad "
 #~ "(like a third-party supplier)."
@@ -8069,7 +7807,6 @@ msgstr ""
 #~ "Clique no botão 🔒 para alterar a visibilidade de uma nota ou mensagem."
 
 #, fuzzy
-#~| msgid "**🙅 I’m working here!**"
 #~ msgid "**🙅 I'm working here!**"
 #~ msgstr "**🙅 Estou trabalhando aqui!**"
 
@@ -8101,9 +7838,6 @@ msgstr ""
 #~ msgstr "Notificações internas não podem ser desabilitadas."
 
 #, fuzzy
-#~| msgid ""
-#~| "🔔 You **will** continue to receive notifications while you are out-of-"
-#~| "office!"
 #~ msgid "(You will continue to receive notifications for your own tickets.)"
 #~ msgstr ""
 #~ "🔔 Você **continuará** recebendo as notificações enquanto estiver fora do "

--- a/locale/ru/LC_MESSAGES/user-docs.po
+++ b/locale/ru/LC_MESSAGES/user-docs.po
@@ -26,9 +26,6 @@ msgstr "Горячие клавиши"
 
 #: ../advanced/keyboard-shortcuts.rst:6
 #, fuzzy
-#| msgid ""
-#| "Zammad supports a wide array of keyboard shortcuts to expedite your "
-#| "workflow as an expert user."
 msgid ""
 "Zammad supports a wide array of keyboard shortcuts to expedite your workflow "
 "as an expert user. But don't be afraid, you don't have to remember all of "
@@ -56,9 +53,6 @@ msgstr "Подменю пользователя"
 
 #: ../advanced/keyboard-shortcuts.rst:20
 #, fuzzy
-#| msgid ""
-#| "Alternately, bring it up with one of the shortcuts below (shortcut-"
-#| "ception!)"
 msgid "Alternatively, open it with one of the shortcuts below:"
 msgstr ""
 "В качестве альтернативы, вызовите его с помощью одного из приведенных ниже "
@@ -66,13 +60,11 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:22
 #, fuzzy
-#| msgid "``Ctrl`` + ``Shift`` + ``H`` (on Windows)"
 msgid "``ctrl`` + ``shift`` + ``h`` (on Linux and Windows)"
 msgstr "``Ctrl`` + ``Shift`` + ``H`` (в Windows)"
 
 #: ../advanced/keyboard-shortcuts.rst:23
 #, fuzzy
-#| msgid "``Cmd`` + ``Ctrl`` + ``Shift`` + ``H`` (on macOS)"
 msgid "``cmd`` + ``ctrl`` + ``shift`` + ``h`` (on macOS)"
 msgstr "``Cmd`` + ``Ctrl`` + ``Shift`` + ``H`` (в macOS)"
 
@@ -88,13 +80,11 @@ msgstr "Памятка по сочетаниям клавиш"
 
 #: ../advanced/keyboard-shortcuts.rst:33
 #, fuzzy
-#| msgid "Keyboard shortcut cheat sheet"
 msgid "The keyboard shortcut cheat sheet."
 msgstr "Памятка по сочетаниям клавиш"
 
 #: ../advanced/keyboard-shortcuts.rst:37
 #, fuzzy
-#| msgid "Keyboard Shortcuts"
 msgid "List of Available Keyboard Shortcuts"
 msgstr "Горячие клавиши"
 
@@ -188,7 +178,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:54
 #, fuzzy
-#| msgid "``Cmd`` + ``Ctrl`` + ``Shift`` + ``H`` (on macOS)"
 msgid "``shift`` + ``ctrl`` + ``shift+tab``"
 msgstr "``Cmd`` + ``Ctrl`` + ``Shift`` + ``H`` (в macOS)"
 
@@ -282,7 +271,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:86
 #, fuzzy
-#| msgid "Macros"
 msgid "Tickets"
 msgstr "Макрос"
 
@@ -320,7 +308,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:95
 #, fuzzy
-#| msgid "``Cmd`` + ``Ctrl`` + ``Shift`` + ``H`` (on macOS)"
 msgid "``shift`` + ``ctrl`` + ``←`` / ``→``"
 msgstr "``Cmd`` + ``Ctrl`` + ``Shift`` + ``H`` (в macOS)"
 
@@ -370,7 +357,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:109
 #, fuzzy
-#| msgid "Press ``Cmd`` + ``I`` to enter Italics mode,"
 msgid "Press ``cmd`` + ``i`` to enter *italics* mode,"
 msgstr "Нажмите ``Cmd`` ``I``, чтобы войти в режим курсива,"
 
@@ -380,7 +366,6 @@ msgstr "введите желаемый текст, и"
 
 #: ../advanced/keyboard-shortcuts.rst:111
 #, fuzzy
-#| msgid "press ``Cmd`` + ``I`` again to return to normal text mode."
 msgid "press ``cmd`` + ``i`` again to return to normal text mode."
 msgstr ""
 "нажмите ``Cmd`` + ``I`` снова, чтобы вернуть текст обратно в нормальный вид."
@@ -399,7 +384,6 @@ msgstr "щелкните и перетащите мышью, чтобы выбр
 
 #: ../advanced/keyboard-shortcuts.rst:117
 #, fuzzy
-#| msgid "press ``Cmd`` + ``I`` to italicize."
 msgid "press ``cmd`` + ``i`` to set the text in *italics*."
 msgstr "нажмите ``Cmd`` + ``I``, чтобы выделить курсивом."
 
@@ -449,7 +433,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:128
 #, fuzzy
-#| msgid "``Ctrl`` + ``Shift`` + ``H`` (on Linux)"
 msgid "``ctrl`` + ``shift`` + ``v``"
 msgstr "``Ctrl`` + ``Shift`` + ``H`` (в Linux)"
 
@@ -463,7 +446,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:129
 #, fuzzy
-#| msgid "Formatting Text"
 msgid "Remove formatting of text"
 msgstr "Форматирование текста"
 
@@ -553,10 +535,6 @@ msgstr ""
 
 #: ../advanced/macros.rst:10
 #, fuzzy
-#| msgid ""
-#| "You don’t – that’s the `administrator’s job <https://admin-docs.zammad."
-#| "org/en/latest/manage/macros.html>`_. If you have an idea for a macro "
-#| "you’d like to use, your Zammad admin can probably make it happen."
 msgid ""
 "Macros can be created by your :admin-docs:`administrator </manage/macros."
 "html>`. If you have an idea for a macro you'd like to use, your Zammad admin "
@@ -568,8 +546,6 @@ msgstr ""
 
 #: ../advanced/macros.rst:14
 #, fuzzy
-#| msgid ""
-#| "Macros can be applied in one of two ways: on a single ticket, or in bulk."
 msgid "Macros can be applied in two ways: on a single ticket, or in bulk."
 msgstr ""
 "Макрос может быть применён в 2-х вариантах: на единичный билет или на группу."
@@ -580,9 +556,6 @@ msgstr "На единичный билет"
 
 #: ../advanced/macros.rst:19
 #, fuzzy
-#| msgid ""
-#| "The simplest way to apply a macro is to select it from the **Update ᐱ** "
-#| "submenu in the Ticket View:"
 msgid ""
 "The simplest way to apply a macro is to select it from the **Update ^** "
 "submenu in the Ticket View:"
@@ -1674,7 +1647,6 @@ msgstr ""
 
 #: ../advanced/ticket-actions/merge.rst:40
 #, fuzzy
-#| msgid "Macros"
 msgid "Merge dialog"
 msgstr "Макрос"
 
@@ -1909,7 +1881,6 @@ msgstr ""
 
 #: ../advanced/time-accounting.rst:57
 #, fuzzy
-#| msgid "Screencast showing how to run a macro within a ticket view."
 msgid "Screenshot showing accounted times in ticket pane"
 msgstr "Запись экрана показывает как запустить макрос в просмотре билета."
 
@@ -1931,8 +1902,6 @@ msgstr "Поиск Тикетов"
 
 #: ../basics/find-ticket.rst:4
 #, fuzzy
-#| msgid ""
-#| "If you plan to work on tickets, you’d better know how to find ’em first."
 msgid ""
 "If you plan to work on tickets, you'd better know how to find them first."
 msgstr "Прежде чем начать работу с Тикетами, вам стоит прежде"
@@ -3027,7 +2996,6 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:48
 #, fuzzy
-#| msgid "article.from"
 msgid "Article"
 msgstr "article.from"
 
@@ -4165,7 +4133,6 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:663
 #, fuzzy
-#| msgid "Finding Tickets"
 msgid "Splitting tickets"
 msgstr "Поиск Тикетов"
 
@@ -4305,7 +4272,6 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:741
 #, fuzzy
-#| msgid "Macros"
 msgid "Ticket hook"
 msgstr "Макрос"
 
@@ -4430,7 +4396,6 @@ msgstr ""
 
 #: ../extras/caller-log.rst:34
 #, fuzzy
-#| msgid "Macros"
 msgid "New Ticket dialog"
 msgstr "Макрос"
 
@@ -5599,7 +5564,6 @@ msgstr ""
 
 #: ../extras/mobile-view.rst:118
 #, fuzzy
-#| msgid "Search for a Ticketnumber"
 msgid "Search for existing records"
 msgstr "Поиск по номеру Тикета"
 
@@ -5663,7 +5627,6 @@ msgstr ""
 
 #: ../extras/mobile-view.rst:141
 #, fuzzy
-#| msgid "Macros"
 msgid "Ticket Macros"
 msgstr "Макрос"
 
@@ -5826,9 +5789,6 @@ msgstr ""
 
 #: ../extras/profile-and-settings.rst:4
 #, fuzzy
-#| msgid ""
-#| "Click on your avatar at the bottom of the main menu to access the "
-#| "**keyboard shortcuts cheat sheet**."
 msgid ""
 "Click on your avatar or initials at the bottom of the main menu to access "
 "your **profile and settings**."
@@ -5844,7 +5804,6 @@ msgstr ""
 
 #: ../extras/profile-and-settings.rst:17
 #, fuzzy
-#| msgid "User submenu"
 msgid "User Menu"
 msgstr "Подменю пользователя"
 
@@ -5884,7 +5843,6 @@ msgstr ""
 
 #: ../extras/profile-and-settings.rst:36
 #, fuzzy
-#| msgid "Keyboard Shortcuts"
 msgid "Keyboard shortcuts"
 msgstr "Горячие клавиши"
 
@@ -6663,7 +6621,6 @@ msgstr ""
 
 #: ../extras/shared-drafts.rst:109
 #, fuzzy
-#| msgid "Finding Tickets"
 msgid "Existing ticket"
 msgstr "Поиск Тикетов"
 
@@ -7190,6 +7147,18 @@ msgid ""
 "You are currently reading the Zammad user documentation. There are also :"
 "docs:`system </index.html>` and :admin-docs:`administration manuals </index."
 "html>` available."
+msgstr ""
+
+#: ../basics/zammad-glossary.rst:618
+msgid "Bottom section:"
+msgstr ""
+
+#: ../basics/zammad-glossary.rst:732
+msgid ""
+"The title of a ticket is different based on the channel it came in. You can "
+"find the title in the sidebar and in the top area in the ticket view. If the "
+"title is not very meaningful, you can change it by clicking on the title in "
+"a ticket view."
 msgstr ""
 
 #~ msgid "🤔 **How do I make macros?**"

--- a/locale/sr/LC_MESSAGES/user-docs.po
+++ b/locale/sr/LC_MESSAGES/user-docs.po
@@ -3482,7 +3482,7 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:54
 msgid "Auto Response"
-msgstr ""
+msgstr "Аутоматски одговор"
 
 #: ../basics/zammad-glossary.rst:51
 msgid ""
@@ -3491,6 +3491,11 @@ msgid ""
 "received and to provide the ticket number to the customer). Your admin may "
 "change this or even add more auto generated messages."
 msgstr ""
+"Zammad може да шаље аутоматски генерисане одговоре клијентима. "
+"Подразумевано, ово је подешено за новоотворене тикете (као потврда да је "
+"имејл порука примљена и да обавести клијента о броју тикета). Ваш "
+"администратор може ово изменити или чак подесити додатне ауто генерисане "
+"поруке."
 
 #: ../basics/zammad-glossary.rst:60
 msgid "Automation"
@@ -3543,6 +3548,10 @@ msgid ""
 "To customize it, go to the avatar section in your :doc:`user profile </"
 "extras/profile-and-settings>`."
 msgstr ""
+"Аватар је у основи графички приказ корисника. Подразумевано, кориснички "
+"аватар се састоји од иницијала корисника. Такође може бити и сличица. За "
+"прилагођавање, посетите одељак аватара у вашем :doc:`корисничком профилу </"
+"extras/profile-and-settings>`."
 
 #: ../basics/zammad-glossary.rst:78
 msgid ""
@@ -3550,6 +3559,9 @@ msgid ""
 "you can see it next to an article in a ticket or in the bottom bar if "
 "another agent is viewing or editing the same ticket."
 msgstr ""
+"Аватар корисника је видљив у различитим деловима Zammad-а. На пример можете "
+"га видети поред чланка тикета или у доњој траци уколико други оператер гледа "
+"или уређује исти тикет."
 
 #: ../basics/zammad-glossary.rst:84
 msgid "B"
@@ -3602,10 +3614,8 @@ msgstr ""
 "stable/CHANGELOG.md>` страни_!"
 
 #: ../basics/zammad-glossary.rst:105
-#, fuzzy
-#| msgid "Changelog"
 msgid "Channel"
-msgstr "Листа измена"
+msgstr "Канал"
 
 #: ../basics/zammad-glossary.rst:104
 msgid ""
@@ -3613,6 +3623,9 @@ msgid ""
 "channels are email and phone. Additional channels can be configured by your "
 "admin."
 msgstr ""
+"Канал је начин на који клијенти могу ступити у контакт са вама. Стандардни "
+"канали су имејл и позив. Додатни канали могу бити подешени од стране вашег "
+"администратора."
 
 #: ../basics/zammad-glossary.rst:114
 msgid "Checkmk"
@@ -3774,22 +3787,25 @@ msgstr ""
 "сатима рада програмера)."
 
 #: ../basics/zammad-glossary.rst:172
-#, fuzzy
-#| msgid "Modify customer attributes"
 msgid "Custom Object Attributes"
-msgstr "Измените атрибуте клијента"
+msgstr "Прилагођени атрибути објекта"
 
 #: ../basics/zammad-glossary.rst:168
 msgid ""
 "Zammad allows the creation of custom object attributes by admins. This can "
 "be done on ticket level, user level, organization level or group level."
 msgstr ""
+"Zammad омогућава дефиницију прилагођених атрибута објекта од стране "
+"администратора. Ово се може применити на нивоу тикета, корисника, "
+"организације или групе."
 
 #: ../basics/zammad-glossary.rst:171
 msgid ""
 "You can think of such a custom object attribute as a new field which has a "
 "pre-defined format and optionally selectable values."
 msgstr ""
+"Прилагођене атрибуте објекта можете сматрати новим пољима која имају "
+"предефинисан формат или могућност избора вредности."
 
 #: ../basics/zammad-glossary.rst:175
 msgid ""
@@ -4439,10 +4455,15 @@ msgid ""
 "response, Zammad can't assign the message to the existing ticket but creates "
 "a new one."
 msgstr ""
+"Уколико имате два (или више) тикета о истом проблему, можете их спојити у "
+"један. Подразумевано, Zammad врши провере да ли екстерна порука припада "
+"постојећем тикету. Међутим, уколико ваш клијент пошаље потпуно нову имејл "
+"поруку уместо одговора на аутоматски одговор, Zammad не може да додели "
+"поруку постојећем тикету већ отвара нови."
 
 #: ../basics/zammad-glossary.rst:458
 msgid "See :doc:`/advanced/ticket-actions` for further information."
-msgstr ""
+msgstr "Погледајте :doc:`/advanced/ticket-actions` за више информација."
 
 #: ../basics/zammad-glossary.rst:464
 msgid "Migrator / Migration Wizard"
@@ -4522,16 +4543,15 @@ msgid ""
 "notification settings in your user profile. You can even mention other users "
 "or subscribe to a specific ticket if you are interested how it proceeds."
 msgstr ""
+"Да бисте избегли превид нових порука (нпр. од стране клијента) Zammad вас "
+"подразумевано обавештава о свакој важној промени. Можете подесити сопствена "
+"подешавања општих обавештења у вашем корисничком профилу. Такође можете "
+"напоменути друге кориснике или претплатити се на одговарајућ тикет уколико "
+"сте заинтересовани о његовој будућности."
 
 #: ../basics/zammad-glossary.rst:490
-#, fuzzy
-#| msgid ""
-#| "Check your :doc:`/extras/profile-and-settings` to customize how you "
-#| "receive notifications."
 msgid "See :doc:`/extras/profile-and-settings` for more information."
-msgstr ""
-"Проверите свој :doc:`/extras/profile-and-settings` да бисте прилагодили "
-"начин на који примате обавештења."
+msgstr "Погледајте :doc:`/extras/profile-and-settings` за више информација."
 
 #: ../basics/zammad-glossary.rst:493
 msgid "O"
@@ -4566,11 +4586,16 @@ msgid ""
 "shipped with Zammad by default. If you want to have a custom overview, ask "
 "your admin to create it."
 msgstr ""
+"Прегледи су почетна тачка вашег рада на тикетима. Можете их сматрати врстом "
+"филтера постојећих тикета. Неки основни прегледи су подразумевано доступни у "
+"Zammad-u. Уколико желите прилагођени преглед, замолите вашег администратора "
+"да га дода."
 
 #: ../basics/zammad-glossary.rst:507
 msgid ""
 "For more information please have a look in :doc:`/basics/find-ticket/browse`."
 msgstr ""
+"За више информација молимо погледајте :doc:`/basics/find-ticket/browse`."
 
 #: ../basics/zammad-glossary.rst:511
 msgid ""
@@ -4671,6 +4696,9 @@ msgid ""
 "administrator can find more information :admin-docs:`here </system/objects."
 "html#system-attributes>`."
 msgstr ""
+"Приоритети могу чак бити подешени или прилагођени вашим потребама. Ваш "
+"администратор може наћи више информација :admin-docs:`овде </system/objects."
+"html#system-attributes>`."
 
 #: ../basics/zammad-glossary.rst:557
 msgid "Q"
@@ -4705,10 +4733,8 @@ msgstr ""
 "и доносе мања ажурирања."
 
 #: ../basics/zammad-glossary.rst:580 ../basics/zammad-glossary.rst:621
-#, fuzzy
-#| msgid "Reports"
 msgid "Reporting"
-msgstr "Извештаји"
+msgstr "Извештавање"
 
 #: ../basics/zammad-glossary.rst:575
 msgid ""
@@ -4716,18 +4742,17 @@ msgid ""
 "tickets per month). There are two types of reporting: the reporting "
 "functionality integrated in Zammad and the reporting with external tools."
 msgstr ""
+"Извештавање вам омогућује преглед статистика и метрика (нпр. број отворених "
+"тикета месечно). Постоје два типа извештавања: функција извештаја у Zammad-у "
+"и извештавање путем екстерних алата."
 
 #: ../basics/zammad-glossary.rst:579
-#, fuzzy
-#| msgid ""
-#| "Administrators can learn more about customizing text modules :admin-docs:"
-#| "`here </manage/text-modules.html>`."
 msgid ""
 "Admins can find further information :admin-docs:`here </manage/report-"
 "profiles.html>`."
 msgstr ""
-"Администратори могу да сазнају више о прилагођавању текстуалних исечака :"
-"admin-docs:`овде </manage/text-modules.html>`."
+"Администратори могу да сазнају више :admin-docs:`овде </manage/report-"
+"profiles.html>`."
 
 #: ../basics/zammad-glossary.rst:593
 msgid "Role"
@@ -4771,7 +4796,7 @@ msgstr "С"
 
 #: ../basics/zammad-glossary.rst:603
 msgid "Scheduler"
-msgstr ""
+msgstr "Планер"
 
 #: ../basics/zammad-glossary.rst:599
 msgid ""
@@ -4781,10 +4806,15 @@ msgid ""
 "documentation in the :admin-docs:`scheduler section </manage/scheduler."
 "html>`."
 msgstr ""
+"Планер је једна од Zammad-ових функција аутоматизације. Администратор може "
+"одредити одговарајуће услове и радње које се извршавају на тикетима који "
+"задовољавају услове засноване на времену. Више информација можете наћи у "
+"администраторској документацији у :admin-docs:`одељку планера </manage/"
+"scheduler.html>`."
 
 #: ../basics/zammad-glossary.rst:623
 msgid "Sidebar"
-msgstr ""
+msgstr "Трака са стране"
 
 #: ../basics/zammad-glossary.rst:606
 msgid ""
@@ -4792,60 +4822,49 @@ msgid ""
 "might need. Depending on the configured channels and your permissions, it "
 "might not include all sections which are listed below:"
 msgstr ""
+"Трана са леве стране садржи све битне локације и објекте који вам могу бити "
+"потребни. Зависно од подешених канала и ваших дозвола, можда неће укључивати "
+"све одељке који су излистани испод:"
 
 #: ../basics/zammad-glossary.rst:610
-#, fuzzy
-#| msgid "Search phrase"
 msgid "Search bar"
-msgstr "Фраза за претрагу"
+msgstr "Трака претраге"
 
 #: ../basics/zammad-glossary.rst:611
-#, fuzzy
-#| msgid "Notifications"
 msgid "Notification section"
-msgstr "Обавештења"
+msgstr "Одељак обавештења"
 
 #: ../basics/zammad-glossary.rst:613 ../extras/profile-and-settings.rst:0
 msgid "Overviews"
 msgstr "Прегледи"
 
 #: ../basics/zammad-glossary.rst:615
-#, fuzzy
-#| msgid "Customer"
 msgid "Customer Chat"
-msgstr "Клијент"
+msgstr "Клијент ћаскање"
 
 #: ../basics/zammad-glossary.rst:616
 msgid "Phone"
-msgstr ""
+msgstr "Позив"
 
 #: ../basics/zammad-glossary.rst:617
-#, fuzzy
-#| msgid "How to merge tickets?"
 msgid "One or more open tickets"
-msgstr "Како повезати тикете?"
+msgstr "Један или више отворених тикета"
 
 #: ../basics/zammad-glossary.rst:618
 msgid "Bootom section:"
 msgstr ""
 
 #: ../basics/zammad-glossary.rst:622
-#, fuzzy
-#| msgid "Ticket Settings"
 msgid "Admin settings"
-msgstr "Подешавање тикета"
+msgstr "Администраторска подешавања"
 
 #: ../basics/zammad-glossary.rst:623
-#, fuzzy
-#| msgid "Text modules on ticket creation"
 msgid "Button for ticket creation"
-msgstr "Текстуални исечци приликом отварања тикета"
+msgstr "Дугме за отварање тикета"
 
 #: ../basics/zammad-glossary.rst:632
-#, fuzzy
-#| msgid "Feature"
 msgid "Signature"
-msgstr "Функција"
+msgstr "Потпис"
 
 #: ../basics/zammad-glossary.rst:626
 msgid ""
@@ -4853,12 +4872,17 @@ msgid ""
 "contact details and the name of your company/department there. It can even "
 "contain your :ref:`avatar image <glossary-avatar>`."
 msgstr ""
+"Потпис је ваша фуснота у одлазним порукама. Ваши клијенти могу сазнати ваше "
+"контакт информацији или назив ваше компаније/одељења. Такоће може садржати "
+"вашу :ref:`аватар сличицу <glossary-avatar>`."
 
 #: ../basics/zammad-glossary.rst:631
 msgid ""
 "It can be customized by your admin. Further information can be found :admin-"
 "docs:`here </channels/email/signatures.html>`."
 msgstr ""
+"Ваш администратор га може прилагодити. Додатне информације се могу пронаћи :"
+"admin-docs:`овде </channels/email/signatures.html>`."
 
 #: ../basics/zammad-glossary.rst:642
 msgid "Sipgate"
@@ -4920,8 +4944,6 @@ msgstr ""
 "features/sla>`_."
 
 #: ../basics/zammad-glossary.rst:663
-#, fuzzy
-#| msgid "Splitting Tickets"
 msgid "Splitting tickets"
 msgstr "Раздељивање тикета"
 
@@ -4932,6 +4954,10 @@ msgid ""
 "based on the selected article for splitting. See :doc:`/advanced/ticket-"
 "actions` for more information."
 msgstr ""
+"У случају да тикет садржи више од једног проблема и желите да га обрадите у "
+"одвојеном тикету, можете разделити тикет. Zammad онда отвара нови тикет на "
+"основу одабраног чланка за раздељивање. Погледајте :doc:`/advanced/ticket-"
+"actions` за више информација."
 
 #: ../basics/zammad-glossary.rst:672
 msgid "SSO"
@@ -4963,10 +4989,6 @@ msgstr ""
 "features/sso>`_."
 
 #: ../basics/zammad-glossary.rst:675
-#, fuzzy
-#| msgid ""
-#| "Every ticket has a status. You can change it once you've updated the "
-#| "ticket. There are four types of status, and they are all color-coded."
 msgid ""
 "Every ticket has a state. You can change it once you've updated the ticket. "
 "There are four types of states, and they are all color-coded."
@@ -4975,10 +4997,6 @@ msgstr ""
 "четири типа стања и сви су означени бојама."
 
 #: ../basics/zammad-glossary.rst:678
-#, fuzzy
-#| msgid ""
-#| "Learn more about states and they color coding on this page: :doc:`/basics/"
-#| "service-ticket/settings/state`"
 msgid ""
 "Learn more about states and their color coding on this page: :doc:`/basics/"
 "service-ticket/settings/state`"
@@ -4991,6 +5009,9 @@ msgid ""
 "The available states can be changed or extended. Your admin can find further "
 "information :admin-docs:`here </system/objects.html#system-attributes>`."
 msgstr ""
+"Доступна стања могу бити измењена или прилагођена. Ваш администратор може "
+"пронаћи додатне информације :admin-docs:`овде </system/objects.html#system-"
+"attributes>`."
 
 #: ../basics/zammad-glossary.rst:692
 msgid "S/MIME"
@@ -5107,10 +5128,8 @@ msgid ""
 msgstr ""
 
 #: ../basics/zammad-glossary.rst:741
-#, fuzzy
-#| msgid "Ticket Macros"
 msgid "Ticket hook"
-msgstr "Макрои тикета"
+msgstr "Прикључак тикета"
 
 #: ../basics/zammad-glossary.rst:738
 msgid ""
@@ -5119,10 +5138,14 @@ msgid ""
 "admin. See :admin-docs:`here </settings/ticket.html>` for further "
 "information."
 msgstr ""
+"Прикључак тикета служи за идентификацију тиекта. Подразумевано, користи "
+"``Ticket#`` са додатком броја (нпр. ``Ticket#904627``). Може бити измењен од "
+"стране администратора. Погледајте :admin-docs:`овде </settings/ticket.html>` "
+"за више информација."
 
 #: ../basics/zammad-glossary.rst:748
 msgid "Trigger"
-msgstr ""
+msgstr "Окидач"
 
 #: ../basics/zammad-glossary.rst:744
 msgid ""
@@ -5131,6 +5154,10 @@ msgid ""
 "conditions. More information in the admin documentation in the :admin-docs:"
 "`trigger section </manage/trigger.html>`."
 msgstr ""
+"Окидачи су једна од Zammad-ових функција аутоматизације. Администратор може "
+"дефинисати одговарајуће услове и радње које се извршавају на тикетима који "
+"задовољавају услове. Више информација у администраторској документацији у :"
+"admin-docs:`одељку окидача </manage/trigger.html>`."
 
 #: ../basics/zammad-glossary.rst:751
 msgid "U"
@@ -8598,6 +8625,23 @@ msgstr ""
 "`системски </index.html>` и :admin-docs:`администраторски </index.html>` "
 "приручници."
 
+#: ../basics/zammad-glossary.rst:618
+#, fuzzy
+msgid "Bottom section:"
+msgstr "Доњи одељак:"
+
+#: ../basics/zammad-glossary.rst:732
+#, fuzzy
+msgid ""
+"The title of a ticket is different based on the channel it came in. You can "
+"find the title in the sidebar and in the top area in the ticket view. If the "
+"title is not very meaningful, you can change it by clicking on the title in "
+"a ticket view."
+msgstr ""
+"Наслов тикета је другачији у зависности од канала на коме је примљен. Наслов "
+"можете пронаћи у траци са стране и при врху екрана у приказу тикета. Уколико "
+"вам наслов нема смисла, можете га изменити кликом на исти у приказу тикета."
+
 #~ msgid "Status"
 #~ msgstr "Статус"
 
@@ -9202,3 +9246,17 @@ msgstr ""
 #~ msgstr ""
 #~ "Оригинални тикет ће бити :doc:`повезан <link>` са новим, као што се види "
 #~ "у панелу тикета."
+
+#~ msgid ""
+#~ "Every ticket has a status. You can change it once you've updated the "
+#~ "ticket. There are four types of status, and they are all color-coded."
+#~ msgstr ""
+#~ "Сваки тикет има стање. Можете га променити док освежавате тикет. Постоје "
+#~ "четири типа стања и сви су означени бојама."
+
+#~ msgid ""
+#~ "Learn more about states and they color coding on this page: :doc:`/basics/"
+#~ "service-ticket/settings/state`"
+#~ msgstr ""
+#~ "Сазнајте више о стањима и њиховим бојама у секцији :doc:`/basics/service-"
+#~ "ticket/settings/state`."

--- a/locale/sv/LC_MESSAGES/user-docs.po
+++ b/locale/sv/LC_MESSAGES/user-docs.po
@@ -7085,3 +7085,15 @@ msgid ""
 "docs:`system </index.html>` and :admin-docs:`administration manuals </index."
 "html>` available."
 msgstr ""
+
+#: ../basics/zammad-glossary.rst:618
+msgid "Bottom section:"
+msgstr ""
+
+#: ../basics/zammad-glossary.rst:732
+msgid ""
+"The title of a ticket is different based on the channel it came in. You can "
+"find the title in the sidebar and in the top area in the ticket view. If the "
+"title is not very meaningful, you can change it by clicking on the title in "
+"a ticket view."
+msgstr ""

--- a/locale/th/LC_MESSAGES/user-docs.po
+++ b/locale/th/LC_MESSAGES/user-docs.po
@@ -51,13 +51,11 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:22
 #, fuzzy
-#| msgid "``Ctrl`` + ``Shift`` + ``H`` (on Windows)"
 msgid "``ctrl`` + ``shift`` + ``h`` (on Linux and Windows)"
 msgstr "``Ctrl`` + ``Shift`` + ``H`` (on Windows)"
 
 #: ../advanced/keyboard-shortcuts.rst:23
 #, fuzzy
-#| msgid "``Cmd`` + ``Ctrl`` + ``Shift`` + ``H`` (on macOS)"
 msgid "``cmd`` + ``ctrl`` + ``shift`` + ``h`` (on macOS)"
 msgstr "``Cmd`` + ``Ctrl`` + ``Shift`` + ``H`` (on macOS)"
 
@@ -81,7 +79,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:40
 #, fuzzy
-#| msgid "Organization"
 msgid "Navigation"
 msgstr "องค์กร"
 
@@ -127,7 +124,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:48
 #, fuzzy
-#| msgid "Notifications"
 msgid "Open notifications"
 msgstr "แจ้งเตือน"
 
@@ -137,7 +133,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:49 ../extras/mobile-view.rst:119
 #, fuzzy
-#| msgid "New tickets"
 msgid "Create a new ticket"
 msgstr "สร้างใบแจ้งซ่อม"
 
@@ -175,7 +170,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:54
 #, fuzzy
-#| msgid "``Cmd`` + ``Ctrl`` + ``Shift`` + ``H`` (on macOS)"
 msgid "``shift`` + ``ctrl`` + ``shift+tab``"
 msgstr "``Cmd`` + ``Ctrl`` + ``Shift`` + ``H`` (on macOS)"
 
@@ -241,7 +235,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:66
 #, fuzzy
-#| msgid "Organizations"
 msgid "Translations"
 msgstr "องค์กร"
 
@@ -271,7 +264,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:86
 #, fuzzy
-#| msgid "Ticket Templates"
 msgid "Tickets"
 msgstr "ต้นแบบ ใบแจ้งซ่อม"
 
@@ -281,7 +273,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:91
 #, fuzzy
-#| msgid "New tickets"
 msgid "Create a new note article"
 msgstr "สร้างใบแจ้งซ่อม"
 
@@ -311,7 +302,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:95
 #, fuzzy
-#| msgid "``Cmd`` + ``Ctrl`` + ``Shift`` + ``H`` (on macOS)"
 msgid "``shift`` + ``ctrl`` + ``←`` / ``→``"
 msgstr "``Cmd`` + ``Ctrl`` + ``Shift`` + ``H`` (on macOS)"
 
@@ -433,7 +423,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:128
 #, fuzzy
-#| msgid "``Ctrl`` + ``Shift`` + ``H`` (on Linux)"
 msgid "``ctrl`` + ``shift`` + ``v``"
 msgstr "``Ctrl`` + ``Shift`` + ``H`` (on Linux)"
 
@@ -447,7 +436,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:129
 #, fuzzy
-#| msgid "Formatting Text"
 msgid "Remove formatting of text"
 msgstr "รูปแบบตัวอักษร"
 
@@ -1299,7 +1287,6 @@ msgstr "**ปิด**"
 
 #: ../snippets/ticket-state-type-circles.rst:7
 #, fuzzy
-#| msgid "Merge"
 msgid "**Merged**"
 msgstr "รวม"
 
@@ -1628,7 +1615,6 @@ msgstr ""
 
 #: ../advanced/ticket-actions/merge.rst:40
 #, fuzzy
-#| msgid "New tickets"
 msgid "Merge dialog"
 msgstr "สร้างใบแจ้งซ่อม"
 
@@ -3270,7 +3256,6 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:206
 #, fuzzy
-#| msgid "Zammad Agent Documentation"
 msgid "Documentation"
 msgstr "Zammad Agent Documentation"
 
@@ -3505,7 +3490,6 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:338
 #, fuzzy
-#| msgid "Group"
 msgid "Groups"
 msgstr "กลุ่ม"
 
@@ -4024,7 +4008,6 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:611
 #, fuzzy
-#| msgid "Notifications"
 msgid "Notification section"
 msgstr "แจ้งเตือน"
 
@@ -4034,7 +4017,6 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:615
 #, fuzzy
-#| msgid "Customer"
 msgid "Customer Chat"
 msgstr "ลูกค้า"
 
@@ -4052,7 +4034,6 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:622
 #, fuzzy
-#| msgid "Ticket Settings"
 msgid "Admin settings"
 msgstr "ตั้งค่า ใบแจ้งซ่อม"
 
@@ -4122,7 +4103,6 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:663
 #, fuzzy
-#| msgid "Finding Tickets"
 msgid "Splitting tickets"
 msgstr "กำลังค้นหา ใบแจ้งซ่อม"
 
@@ -4239,7 +4219,6 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:729
 #, fuzzy
-#| msgid "Ticket Templates"
 msgid "(Ticket) Template"
 msgstr "ต้นแบบ ใบแจ้งซ่อม"
 
@@ -4264,7 +4243,6 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:741
 #, fuzzy
-#| msgid "Ticket Templates"
 msgid "Ticket hook"
 msgstr "ต้นแบบ ใบแจ้งซ่อม"
 
@@ -4389,7 +4367,6 @@ msgstr ""
 
 #: ../extras/caller-log.rst:34
 #, fuzzy
-#| msgid "New tickets"
 msgid "New Ticket dialog"
 msgstr "สร้างใบแจ้งซ่อม"
 
@@ -4709,7 +4686,6 @@ msgstr ""
 
 #: ../extras/customers.rst:0
 #, fuzzy
-#| msgid "Organizations"
 msgid "Secondary Organizations"
 msgstr "องค์กร"
 
@@ -5491,7 +5467,6 @@ msgstr ""
 
 #: ../extras/mobile-view.rst:47
 #, fuzzy
-#| msgid "Search for Tickets"
 msgid "Search Results"
 msgstr "ค้นหา ใบแจ้งซ่อม"
 
@@ -5501,13 +5476,11 @@ msgstr ""
 
 #: ../extras/mobile-view.rst:55
 #, fuzzy
-#| msgid "Ticket Settings"
 msgid "Ticket Overview"
 msgstr "ตั้งค่า ใบแจ้งซ่อม"
 
 #: ../extras/mobile-view.rst:61
 #, fuzzy
-#| msgid "Ticket Settings"
 msgid "Ticket Details"
 msgstr "ตั้งค่า ใบแจ้งซ่อม"
 
@@ -5517,7 +5490,6 @@ msgstr ""
 
 #: ../extras/mobile-view.rst:69
 #, fuzzy
-#| msgid "Ticket Settings"
 msgid "Ticket Detail View"
 msgstr "ตั้งค่า ใบแจ้งซ่อม"
 
@@ -5527,19 +5499,16 @@ msgstr ""
 
 #: ../extras/mobile-view.rst:77
 #, fuzzy
-#| msgid "Ticket Settings"
 msgid "Ticket Information"
 msgstr "ตั้งค่า ใบแจ้งซ่อม"
 
 #: ../extras/mobile-view.rst:83
 #, fuzzy
-#| msgid "Notifications"
 msgid "Notifications & Account"
 msgstr "แจ้งเตือน"
 
 #: ../extras/mobile-view.rst:0
 #, fuzzy
-#| msgid "Notifications"
 msgid "Mobile View Notifications"
 msgstr "แจ้งเตือน"
 
@@ -5574,7 +5543,6 @@ msgstr ""
 
 #: ../extras/mobile-view.rst:118
 #, fuzzy
-#| msgid "Search for Tickets"
 msgid "Search for existing records"
 msgstr "ค้นหา ใบแจ้งซ่อม"
 
@@ -5592,7 +5560,6 @@ msgstr ""
 
 #: ../extras/mobile-view.rst:123
 #, fuzzy
-#| msgid "Organizations"
 msgid "Modify organization attributes"
 msgstr "องค์กร"
 
@@ -5618,7 +5585,6 @@ msgstr ""
 
 #: ../extras/mobile-view.rst:133
 #, fuzzy
-#| msgid "Notifications"
 msgid "Limitations"
 msgstr "แจ้งเตือน"
 
@@ -5642,13 +5608,11 @@ msgstr ""
 
 #: ../extras/mobile-view.rst:141
 #, fuzzy
-#| msgid "Ticket Templates"
 msgid "Ticket Macros"
 msgstr "ต้นแบบ ใบแจ้งซ่อม"
 
 #: ../extras/mobile-view.rst:142
 #, fuzzy
-#| msgid "Ticket Settings"
 msgid "Ticket History"
 msgstr "ตั้งค่า ใบแจ้งซ่อม"
 
@@ -5765,7 +5729,6 @@ msgstr ""
 
 #: ../extras/organizations.rst:35
 #, fuzzy
-#| msgid "Organization"
 msgid "Organization edit dialog"
 msgstr "องค์กร"
 
@@ -5809,9 +5772,6 @@ msgstr "ส่วนตัว & ตั้งค่า"
 
 #: ../extras/profile-and-settings.rst:4
 #, fuzzy
-#| msgid ""
-#| "Click on your avatar at the bottom of the main menu to access your "
-#| "**profile and settings**."
 msgid ""
 "Click on your avatar or initials at the bottom of the main menu to access "
 "your **profile and settings**."
@@ -5872,7 +5832,6 @@ msgstr ""
 
 #: ../extras/profile-and-settings.rst:41
 #, fuzzy
-#| msgid "Profile Settings"
 msgid "Profile"
 msgstr "ตั้งค่า ส่วนตัว"
 
@@ -5953,19 +5912,16 @@ msgstr "ตั้งค่าระบบให้แสดงภาษา"
 
 #: ../extras/profile-and-settings.rst:82
 #, fuzzy
-#| msgid "Upload an avatar."
 msgid "Upload an avatar image."
 msgstr "อับโหลดอวตาร"
 
 #: ../extras/profile-and-settings.rst:0
 #, fuzzy
-#| msgid "Password"
 msgid "Password & Auth"
 msgstr "รหัสผ่าน"
 
 #: ../extras/profile-and-settings.rst:86
 #, fuzzy
-#| msgid "Change your login password (may be disabled by system admin)."
 msgid ""
 "Change your login password and manage your two-factor authentication methods "
 "(both may be disabled by system admin)."
@@ -6000,7 +5956,6 @@ msgstr ""
 
 #: ../extras/profile-and-settings.rst:130
 #, fuzzy
-#| msgid "Group"
 msgid "Limit Groups"
 msgstr "กลุ่ม"
 
@@ -6549,7 +6504,6 @@ msgstr ""
 
 #: ../extras/shared-drafts.rst:54
 #, fuzzy
-#| msgid "New tickets"
 msgid "New Ticket dialogue"
 msgstr "สร้างใบแจ้งซ่อม"
 
@@ -6608,7 +6562,6 @@ msgstr ""
 
 #: ../extras/shared-drafts.rst:97
 #, fuzzy
-#| msgid "New tickets"
 msgid "New ticket"
 msgstr "สร้างใบแจ้งซ่อม"
 
@@ -6654,7 +6607,6 @@ msgstr ""
 
 #: ../extras/shared-drafts.rst:109
 #, fuzzy
-#| msgid "Finding Tickets"
 msgid "Existing ticket"
 msgstr "กำลังค้นหา ใบแจ้งซ่อม"
 
@@ -7104,7 +7056,6 @@ msgstr ""
 #: ../extras/two-factor-authentication/security-keys-setup.rst:50
 #: ../extras/two-factor-authentication/security-keys-setup.rst:None
 #, fuzzy
-#| msgid "Editing Categories"
 msgid "Editing Security Keys"
 msgstr "กำลังแก้ไข หมวดหมู่"
 
@@ -7176,7 +7127,6 @@ msgstr "พิเศษ"
 
 #: ../index.rst:2
 #, fuzzy
-#| msgid "Zammad Agent Documentation"
 msgid "Zammad User Documentation"
 msgstr "Zammad Agent Documentation"
 
@@ -7187,7 +7137,19 @@ msgid ""
 "html>` available."
 msgstr ""
 
+#: ../basics/zammad-glossary.rst:618
 #, fuzzy
-#~| msgid "**🙅 I’m working here!**"
+msgid "Bottom section:"
+msgstr "แจ้งเตือน"
+
+#: ../basics/zammad-glossary.rst:732
+msgid ""
+"The title of a ticket is different based on the channel it came in. You can "
+"find the title in the sidebar and in the top area in the ticket view. If the "
+"title is not very meaningful, you can change it by clicking on the title in "
+"a ticket view."
+msgstr ""
+
+#, fuzzy
 #~ msgid "**🙅 I'm working here!**"
 #~ msgstr "**🙅 เจ้าหน้าที่ กำลังแก้ไข!**"

--- a/locale/tr/LC_MESSAGES/user-docs.po
+++ b/locale/tr/LC_MESSAGES/user-docs.po
@@ -25,9 +25,6 @@ msgstr "Klavye Kısayolları"
 
 #: ../advanced/keyboard-shortcuts.rst:6
 #, fuzzy
-#| msgid ""
-#| "Zammad supports a wide array of keyboard shortcuts to expedite your "
-#| "workflow as an expert user."
 msgid ""
 "Zammad supports a wide array of keyboard shortcuts to expedite your workflow "
 "as an expert user. But don't be afraid, you don't have to remember all of "
@@ -55,22 +52,17 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:20
 #, fuzzy
-#| msgid ""
-#| "Alternately, bring it up with one of the shortcuts below (shortcut-"
-#| "ception!)"
 msgid "Alternatively, open it with one of the shortcuts below:"
 msgstr ""
 "Alternatif olarak, aşağıdaki kısayollardan biriyle açın (iç içe kısayollar!)"
 
 #: ../advanced/keyboard-shortcuts.rst:22
 #, fuzzy
-#| msgid "``Ctrl`` + ``Shift`` + ``H`` (on Windows)"
 msgid "``ctrl`` + ``shift`` + ``h`` (on Linux and Windows)"
 msgstr "``Ctrl`` + ``Shift`` + ``H`` (Windows'da)"
 
 #: ../advanced/keyboard-shortcuts.rst:23
 #, fuzzy
-#| msgid "``Cmd`` + ``Ctrl`` + ``Shift`` + ``H`` (on macOS)"
 msgid "``cmd`` + ``ctrl`` + ``shift`` + ``h`` (on macOS)"
 msgstr "``Cmd`` + ``Ctrl`` + ``Shift`` + ``H`` (macOS'da)"
 
@@ -86,19 +78,16 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:33
 #, fuzzy
-#| msgid "The keyboard shortcut cheat sheet on Windows."
 msgid "The keyboard shortcut cheat sheet."
 msgstr "Windows'ta klavye kısayolu hile sayfası."
 
 #: ../advanced/keyboard-shortcuts.rst:37
 #, fuzzy
-#| msgid "Keyboard Shortcuts"
 msgid "List of Available Keyboard Shortcuts"
 msgstr "Klavye Kısayolları"
 
 #: ../advanced/keyboard-shortcuts.rst:40
 #, fuzzy
-#| msgid "organization"
 msgid "Navigation"
 msgstr "organizasyon"
 
@@ -112,7 +101,6 @@ msgstr ""
 #: ../advanced/keyboard-shortcuts.rst:80 ../advanced/keyboard-shortcuts.rst:89
 #: ../advanced/keyboard-shortcuts.rst:121
 #, fuzzy
-#| msgid "Encryption"
 msgid "Function"
 msgstr "Şifreleme"
 
@@ -130,7 +118,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:46
 #, fuzzy
-#| msgid "Overview"
 msgid "Show overviews"
 msgstr "Genel Bakış"
 
@@ -148,7 +135,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:48
 #, fuzzy
-#| msgid "Notifications"
 msgid "Open notifications"
 msgstr "Bildirimler"
 
@@ -158,7 +144,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:49 ../extras/mobile-view.rst:119
 #, fuzzy
-#| msgid "Creating a Ticket"
 msgid "Create a new ticket"
 msgstr "Bir Bilet Oluşturmak"
 
@@ -196,7 +181,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:54
 #, fuzzy
-#| msgid "``Cmd`` + ``Ctrl`` + ``Shift`` + ``H`` (on macOS)"
 msgid "``shift`` + ``ctrl`` + ``shift+tab``"
 msgstr "``Cmd`` + ``Ctrl`` + ``Shift`` + ``H`` (macOS'da)"
 
@@ -262,7 +246,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:66
 #, fuzzy
-#| msgid "Organizations"
 msgid "Translations"
 msgstr "Organizasyonlar"
 
@@ -292,7 +275,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:86
 #, fuzzy
-#| msgid "Ticket Actions"
 msgid "Tickets"
 msgstr "Bilet Hareketleri"
 
@@ -302,7 +284,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:91
 #, fuzzy
-#| msgid "Creating a Ticket"
 msgid "Create a new note article"
 msgstr "Bir Bilet Oluşturmak"
 
@@ -332,7 +313,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:95
 #, fuzzy
-#| msgid "``Cmd`` + ``Ctrl`` + ``Shift`` + ``H`` (on macOS)"
 msgid "``shift`` + ``ctrl`` + ``←`` / ``→``"
 msgstr "``Cmd`` + ``Ctrl`` + ``Shift`` + ``H`` (macOS'da)"
 
@@ -382,7 +362,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:109
 #, fuzzy
-#| msgid "Press ``Cmd`` + ``I`` to enter Italics mode,"
 msgid "Press ``cmd`` + ``i`` to enter *italics* mode,"
 msgstr "İtalik mod için ``Cmd`` + ``I`` tuşlarına basın,"
 
@@ -392,7 +371,6 @@ msgstr "istediğiniz metni yazın ve"
 
 #: ../advanced/keyboard-shortcuts.rst:111
 #, fuzzy
-#| msgid "press ``Cmd`` + ``I`` again to return to normal text mode."
 msgid "press ``cmd`` + ``i`` again to return to normal text mode."
 msgstr ""
 "normal metin moduna geri dönmek için ``Cmd`` + ``I`` tuşlarına tekrar basın."
@@ -411,7 +389,6 @@ msgstr "seçmek için fareyle tıklayın ve sürükleyin, sonra"
 
 #: ../advanced/keyboard-shortcuts.rst:117
 #, fuzzy
-#| msgid "press ``Cmd`` + ``I`` to italicize."
 msgid "press ``cmd`` + ``i`` to set the text in *italics*."
 msgstr "italikleştirmek için ``Cmd`` + ``I`` tuşlarına basın."
 
@@ -461,7 +438,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:128
 #, fuzzy
-#| msgid "``Ctrl`` + ``Shift`` + ``H`` (on Linux)"
 msgid "``ctrl`` + ``shift`` + ``v``"
 msgstr "``Ctrl`` + ``Shift`` + ``H`` (Linux'da)"
 
@@ -475,7 +451,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:129
 #, fuzzy
-#| msgid "Formatting Text"
 msgid "Remove formatting of text"
 msgstr "Metni Biçimlendirmek"
 
@@ -541,7 +516,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:137
 #, fuzzy
-#| msgid "Remove an issue"
 msgid "Remove any hyperlink"
 msgstr "Bir sorunu kaldırın"
 
@@ -567,10 +541,6 @@ msgstr ""
 
 #: ../advanced/macros.rst:10
 #, fuzzy
-#| msgid ""
-#| "You don’t – that’s the `administrator’s job <https://admin-docs.zammad."
-#| "org/en/latest/manage/macros.html>`_. If you have an idea for a macro "
-#| "you’d like to use, your Zammad admin can probably make it happen."
 msgid ""
 "Macros can be created by your :admin-docs:`administrator </manage/macros."
 "html>`. If you have an idea for a macro you'd like to use, your Zammad admin "
@@ -582,8 +552,6 @@ msgstr ""
 
 #: ../advanced/macros.rst:14
 #, fuzzy
-#| msgid ""
-#| "Macros can be applied in one of two ways: on a single ticket, or in bulk."
 msgid "Macros can be applied in two ways: on a single ticket, or in bulk."
 msgstr ""
 "Makrolar iki yoldan biri ile uygulanabilir: sadece bir bilette veya toplu "
@@ -595,9 +563,6 @@ msgstr "Sadece bir Bilette"
 
 #: ../advanced/macros.rst:19
 #, fuzzy
-#| msgid ""
-#| "The simplest way to apply a macro is to select it from the **Update ᐱ** "
-#| "submenu in the Ticket View:"
 msgid ""
 "The simplest way to apply a macro is to select it from the **Update ^** "
 "submenu in the Ticket View:"
@@ -615,10 +580,6 @@ msgstr "💾 **Makro = Güncelleme**"
 
 #: ../advanced/macros.rst:29
 #, fuzzy
-#| msgid ""
-#| "If you’ve made changes to any other :ref:`settings on the ticket "
-#| "<ticket_settings>` (including typing up a reply to the customer), "
-#| "applying a macro will save them, too."
 msgid ""
 "If you've made changes to any other :ref:`settings on the ticket "
 "<ticket_settings>` (including typing up a reply to the customer), applying a "
@@ -630,10 +591,6 @@ msgstr ""
 
 #: ../advanced/macros.rst:34
 #, fuzzy
-#| msgid ""
-#| "⚠️ **But beware:** in the event of a conflict, the macro’s actions "
-#| "override any manual changes – including messages to the customer! When in "
-#| "doubt, apply your macro and your manual changes *separately.*"
 msgid ""
 "⚠️ **But beware:** in the event of a conflict, the macro's actions override "
 "any manual changes - including messages to the customer! When in doubt, "
@@ -709,10 +666,6 @@ msgstr "Gelişmiş Arama"
 
 #: ../advanced/search.rst:4
 #, fuzzy
-#| msgid ""
-#| "With Zammad, you can limit your search to specific Information. This "
-#| "allows you to find e.g. Tickets with specific key words and states. Below "
-#| "information will help you to improve your search results."
 msgid ""
 "With Zammad, you can limit your search to specific attributes. This allows "
 "you to find e.g. tickets with specific key words and states. Below "
@@ -736,9 +689,6 @@ msgstr "veya::"
 
 #: ../advanced/search.rst:18
 #, fuzzy
-#| msgid ""
-#| "If you want to run a more complex search you can use conditions with "
-#| "``()`` and ``AND``/``OR`` options::"
 msgid ""
 "If you want to run a more complex search, you can use conditions with ``()`` "
 "and ``AND``/``OR`` options::"
@@ -752,10 +702,6 @@ msgstr "Kullanılabilir nitelikler"
 
 #: ../advanced/search.rst:28
 #, fuzzy
-#| msgid ""
-#| "For a more detailed list of available attributes please take a look into "
-#| "our `Zammad Admin-Documentation <https://docs.zammad.org/en/latest/"
-#| "install/elasticsearch/indexed-attributes.html>`_"
 msgid ""
 "For a more detailed list of available attributes please take a look into "
 "our :docs:`Zammad System Documentation </install/elasticsearch/indexed-"
@@ -943,7 +889,6 @@ msgstr ""
 
 #: ../advanced/search.rst:48
 #, fuzzy
-#| msgid "**Combining search phrases**"
 msgid "Combining search phrases"
 msgstr "**Birleştirilen arama ifadeleri**"
 
@@ -1185,9 +1130,6 @@ msgstr ""
 
 #: ../advanced/suggested-workflows.rst:16
 #, fuzzy
-#| msgid ""
-#| "If you’ve done all you can on a ticket and it’s now another agent’s (or "
-#| "department’s) responsibility, **reassign it** to a new owner (or group)."
 msgid ""
 "If you've done all you can on a ticket and it's now another agent's (or "
 "department's) responsibility, **reassign it** to a new owner (or group)."
@@ -1198,10 +1140,6 @@ msgstr ""
 
 #: ../advanced/suggested-workflows.rst:19
 #, fuzzy
-#| msgid ""
-#| "If you just need another agent’s input on something, you can **@mention** "
-#| "them. (And if *you* want to get notifications for *someone else’s* "
-#| "ticket, use the **subscribe button**.)"
 msgid ""
 "If you just need another agent's input on something, you can **@mention** "
 "them. (And if *you* want to get notifications for *someone else's* ticket, "
@@ -1221,9 +1159,6 @@ msgstr ""
 
 #: ../advanced/suggested-workflows.rst:30
 #, fuzzy
-#| msgid ""
-#| "Reassign a ticket (via the *Group* and *Owner* settings) to let "
-#| "colleagues know you’re done with your part."
 msgid ""
 "Reassign a ticket (via the *Group* and *Owner* settings) to let colleagues "
 "know you're done with your part."
@@ -1245,12 +1180,6 @@ msgstr ""
 
 #: ../advanced/suggested-workflows.rst:39
 #, fuzzy
-#| msgid ""
-#| "Our sales rep can simply un-assign himself has the **owner** of the "
-#| "ticket and re-assign the ticket to the Customer Service **group**. *All "
-#| "customer service agents will be notified of the incoming ticket*, and the "
-#| "first available agent can assign herself to pick up where the sales rep "
-#| "left off."
 msgid ""
 "Our sales rep can simply un-assign himself as the **owner** of the ticket "
 "and re-assign the ticket to the Customer Service **group**. *All customer "
@@ -1277,11 +1206,6 @@ msgstr "@bahsetmeler ve Abonelik Butonu"
 
 #: ../advanced/suggested-workflows.rst:55
 #, fuzzy
-#| msgid ""
-#| "Now suppose you’ve reassigned the ticket to customer service. You won’t "
-#| "receive notifications for this ticket anymore, but maybe this is a really "
-#| "important contract, and you want to make sure they have an A+ experience "
-#| "from start to finish."
 msgid ""
 "Now suppose you've reassigned the ticket to customer service. You won't "
 "receive notifications for this ticket anymore, but maybe this is a really "
@@ -1295,9 +1219,6 @@ msgstr ""
 
 #: ../advanced/suggested-workflows.rst:60
 #, fuzzy
-#| msgid ""
-#| "To enable notifications for a ticket that doesn’t belong to you, simply "
-#| "click the **Subscribe** button at the bottom of the ticket pane:"
 msgid ""
 "To enable notifications for a ticket that doesn't belong to you, simply "
 "click the **Subscribe** button at the bottom of the ticket pane:"
@@ -1311,9 +1232,6 @@ msgstr ""
 
 #: ../advanced/suggested-workflows.rst:68
 #, fuzzy
-#| msgid ""
-#| "A list of all tickets you’re subscribed to can be found in the **My "
-#| "mentioned Tickets** overview."
 msgid ""
 "A list of all tickets you're subscribed to can be found in the **My "
 "mentioned Tickets** overview."
@@ -1323,10 +1241,6 @@ msgstr ""
 
 #: ../advanced/suggested-workflows.rst:71
 #, fuzzy
-#| msgid ""
-#| "Or, suppose you *don’t* want to reassign the ticket to customer service—"
-#| "you just have one quick question for them, and then you can take it from "
-#| "there."
 msgid ""
 "Or, suppose you *don't* want to reassign the ticket to customer service—you "
 "just have one quick question for them, and then you can take it from there."
@@ -1360,9 +1274,6 @@ msgstr ""
 
 #: ../advanced/suggested-workflows.rst:87
 #, fuzzy
-#| msgid ""
-#| "⚙️ Check your :doc:`/extras/profile-and-settings` to customize how you "
-#| "receive notifications."
 msgid ""
 "Check your :doc:`/extras/profile-and-settings` to customize how you receive "
 "notifications."
@@ -1376,9 +1287,6 @@ msgstr ""
 
 #: ../advanced/suggested-workflows.rst:92
 #, fuzzy
-#| msgid ""
-#| "Is the ticket assigned to a group that you don’t belong to? @mentions and "
-#| "subscriptions only work for tickets that you already have access to."
 msgid ""
 "Is the ticket assigned to a group that you don't belong to? @mentions and "
 "subscriptions only work for tickets that you already have access to."
@@ -1479,9 +1387,6 @@ msgstr ""
 
 #: ../advanced/tabs.rst:9
 #, fuzzy
-#| msgid ""
-#| "You can freely switch between open tabs without losing your work – all "
-#| "unsaved changes are automatically backed up to the server."
 msgid ""
 "You can freely switch between open tabs without losing your work - all "
 "unsaved changes are automatically backed up to the server."
@@ -1503,7 +1408,6 @@ msgstr ""
 
 #: ../advanced/tabs.rst:18
 #, fuzzy
-#| msgid "What items open in a new “tab”?"
 msgid "**What items open in a new “tab”?**"
 msgstr "Yeni bir \"sekmede\" hangi ögeler açılır?"
 
@@ -1552,7 +1456,6 @@ msgstr "**Kapalı**"
 
 #: ../snippets/ticket-state-type-circles.rst:7
 #, fuzzy
-#| msgid "Merge"
 msgid "**Merged**"
 msgstr "Birleştir"
 
@@ -1673,11 +1576,6 @@ msgstr "Metin Modülleri ile Çalışmak"
 
 #: ../advanced/text-modules.rst:4
 #, fuzzy
-#| msgid ""
-#| "Zammad offers so-called text modules. Text modules will help you to "
-#| "improve your workflow, as you don't have to type your answer on every "
-#| "ticket by hand. You can simply choose a fitting text module and insert it "
-#| "into the E-Mail."
 msgid ""
 "Zammad offers so-called text modules. Text modules will help you to improve "
 "your workflow, as you don't have to type your answer on every ticket by "
@@ -1710,22 +1608,16 @@ msgstr ""
 
 #: ../advanced/text-modules.rst:21
 #, fuzzy
-#| msgid "Text modules on ticket creation"
 msgid "Text modules missing?"
 msgstr "Bilet oluştururken metin modülleri"
 
 #: ../advanced/text-modules.rst:23
 #, fuzzy
-#| msgid "**🤔 How come some text modules don’t always appear?**"
 msgid "You noticed that some text modules don't always appear?"
 msgstr "**🤔 Neden bazı metin modülleri her zaman görünmüyor?**"
 
 #: ../advanced/text-modules.rst:25
 #, fuzzy
-#| msgid ""
-#| "Text modules can be tied to **groups**: that is, they only become active "
-#| "once the ticket you’re working on has been assigned to the appropriate "
-#| "group."
 msgid ""
 "Text modules can be tied to **groups**: that is, they only become active "
 "once the ticket you're working on has been assigned to the appropriate group."
@@ -1747,9 +1639,6 @@ msgstr ""
 
 #: ../advanced/text-modules.rst:35
 #, fuzzy
-#| msgid ""
-#| "How do you which groups go with which text modules? Ask your "
-#| "administrator!"
 msgid ""
 "How do you know which groups go with which text modules? Ask your "
 "administrator!"
@@ -1775,9 +1664,6 @@ msgstr "Metin modüllerini özelleştirmek"
 
 #: ../advanced/text-modules.rst:46
 #, fuzzy
-#| msgid ""
-#| "Administrators can learn more about customizing text modules `here "
-#| "<https://admin-docs.zammad.org/en/latest/manage-text-modules.html>`_."
 msgid ""
 "Administrators can learn more about customizing text modules :admin-docs:"
 "`here </manage/text-modules.html>`."
@@ -1881,7 +1767,6 @@ msgstr "Birleştirilen Biletler"
 
 #: ../advanced/ticket-actions/merge.rst:4
 #, fuzzy
-#| msgid "In such cases, you may want to **merge those tickets into one**."
 msgid ""
 "If you have two or more tickets about the same issue, you may want to merge "
 "those tickets into one."
@@ -1903,9 +1788,6 @@ msgstr ""
 
 #: ../advanced/ticket-actions/merge.rst:13
 #, fuzzy
-#| msgid ""
-#| "Merging a ticket migrates all messages and notes **out of the original** "
-#| "and into the selected one."
 msgid ""
 "Merging a ticket migrates all messages and notes of the ticket from where "
 "you select the merging into the selected one."
@@ -1924,7 +1806,6 @@ msgstr ""
 
 #: ../advanced/ticket-actions/merge.rst:28
 #, fuzzy
-#| msgid "Browse for Tickets"
 msgid "How to merge tickets?"
 msgstr "Biletlere Göre Tarama"
 
@@ -1940,7 +1821,6 @@ msgstr ""
 
 #: ../advanced/ticket-actions/merge.rst:40
 #, fuzzy
-#| msgid "The edit customer dialog."
 msgid "Merge dialog"
 msgstr "Müşteri diyaloğu düzenlemek."
 
@@ -1981,9 +1861,6 @@ msgstr ""
 
 #: ../advanced/ticket-actions/merge.rst:53
 #, fuzzy
-#| msgid ""
-#| "The original ticket is :doc:`linked <link>` to the new one, as seen in "
-#| "the ticket pane."
 msgid "The ticket is :doc:`linked <link>` to its \"parent\" ticket"
 msgstr ""
 "Orijinal bilet, bilet panelinde görüldüğü gibi yenisine :doc:`bağlıdır "
@@ -2002,7 +1879,6 @@ msgstr ""
 
 #: ../advanced/ticket-actions/split.rst:8
 #, fuzzy
-#| msgid "To rename a ticket, simply click on the title and start typing."
 msgid ""
 "To split a ticket, simply click on the \"split\" button under the article "
 "you want to split off:"
@@ -2025,9 +1901,6 @@ msgstr ""
 
 #: ../advanced/ticket-actions/split.rst:23
 #, fuzzy
-#| msgid ""
-#| "When splitting a ticket, the target message is imported into the new "
-#| "ticket dialog. As usual, remember to select the **type** (call/email)."
 msgid ""
 "It is prefilled with the content of the existing article. Remember to select "
 "the type (call/email)."
@@ -2037,9 +1910,6 @@ msgstr ""
 
 #: ../advanced/ticket-actions/split.rst:26
 #, fuzzy
-#| msgid ""
-#| "The original ticket is :doc:`linked <link>` to the new one, as seen in "
-#| "the ticket pane."
 msgid ""
 "The original ticket is :doc:`linked <link>` to the new one, as you can see "
 "in the ticket side panel:"
@@ -2053,10 +1923,6 @@ msgstr "Bilet Şablonları"
 
 #: ../advanced/ticket-templates.rst:6
 #, fuzzy
-#| msgid ""
-#| "If you find yourself creating lots of tickets with the same basic "
-#| "attributes, use **ticket templates** to fill them in next time with a "
-#| "single click."
 msgid ""
 "If you find yourself creating lots of tickets with the same basic "
 "attributes, use **ticket templates** to fill them in with a single click "
@@ -2072,7 +1938,6 @@ msgstr ""
 
 #: ../advanced/ticket-templates.rst:13
 #, fuzzy
-#| msgid "Use the ticket pane to load or create ticket templates."
 msgid "Use the ticket pane to load ticket templates."
 msgstr ""
 "Bilet şablonlarını yüklemek veya oluşturmak için bilet bölmesini kullanın."
@@ -2144,16 +2009,11 @@ msgstr ""
 
 #: ../advanced/time-accounting.rst:None
 #, fuzzy
-#| msgid "Time Accounting"
 msgid "Time Accounting Dialog"
 msgstr "Zaman Hesaplama"
 
 #: ../advanced/time-accounting.rst:11
 #, fuzzy
-#| msgid ""
-#| "If time accounting is enabled, this dialog will appear each time you "
-#| "update a ticket. Enter how much time you spent on it (in minutes, or "
-#| "whichever unit of time all your other colleagues are using)."
 msgid ""
 "If the time accounting is enabled, this dialog will appear each time you "
 "update a ticket. Enter how much time you spent on it."
@@ -2164,11 +2024,6 @@ msgstr ""
 
 #: ../advanced/time-accounting.rst:14
 #, fuzzy
-#| msgid ""
-#| "This feature is **optional**; if you don’t see it whenever you update a "
-#| "ticket, that means your administrator hasn’t enabled it yet. "
-#| "Administrators can learn more `here <https://admin-docs.zammad.org/en/"
-#| "latest/manage-time-accounting.html>`_."
 msgid ""
 "This feature is **optional**; if you don't see it whenever you update a "
 "ticket, that means your administrator hasn't enabled it yet. Administrators "
@@ -2192,13 +2047,11 @@ msgstr ""
 
 #: ../advanced/time-accounting.rst:None
 #, fuzzy
-#| msgid "Time Accounting"
 msgid "Time Accounting Unit"
 msgstr "Zaman Hesaplama"
 
 #: ../advanced/time-accounting.rst:31
 #, fuzzy
-#| msgid "Time Accounting"
 msgid "Activity Types"
 msgstr "Zaman Hesaplama"
 
@@ -2211,7 +2064,6 @@ msgstr ""
 
 #: ../advanced/time-accounting.rst:None
 #, fuzzy
-#| msgid "Time Accounting"
 msgid "Time Accounting Activity Type"
 msgstr "Zaman Hesaplama"
 
@@ -2256,8 +2108,6 @@ msgstr "Biletleri Bulmak"
 
 #: ../basics/find-ticket.rst:4
 #, fuzzy
-#| msgid ""
-#| "If you plan to work on tickets, you’d better know how to find ’em first."
 msgid ""
 "If you plan to work on tickets, you'd better know how to find them first."
 msgstr ""
@@ -2290,9 +2140,6 @@ msgstr "Biletleri taramak için ana menüden **Genel Bakış**a tıkla."
 
 #: ../basics/find-ticket/browse.rst:12
 #, fuzzy
-#| msgid ""
-#| "📥 Think of overviews as **inboxes**, each with a different filter for "
-#| "the tickets it displays."
 msgid ""
 "Think of overviews as **inboxes**, each with a different filter for the "
 "tickets it displays."
@@ -2373,7 +2220,6 @@ msgstr "Biletlere göre Arama"
 
 #: ../basics/find-ticket/search.rst:4
 #, fuzzy
-#| msgid "Looking for an archived ticket? Use the **search bar**."
 msgid "Looking for an a specific ticket? Use the **search bar**:"
 msgstr "Arşivlenmiş bir bilet mi arıyorsun? **arama çubuğu**nu kullan."
 
@@ -2383,9 +2229,6 @@ msgstr "Sonuçlar yazdığın anda arama çubuğu altında görüntülecektir."
 
 #: ../basics/find-ticket/search.rst:12
 #, fuzzy
-#| msgid ""
-#| "It’s not just for tickets! Results cover 💬 **chat logs**, 👨 "
-#| "**customers**, and 🏢 **organizations**, too."
 msgid ""
 "It's not just for tickets! Results cover 💬 **chat logs**, 👨 **customers**, "
 "and 🏢 **organizations**, too."
@@ -2437,15 +2280,11 @@ msgstr "Biletleri Hazırlamak"
 
 #: ../basics/service-ticket.rst:4
 #, fuzzy
-#| msgid "This is where you’ll spend the vast majority of your time in Zammad."
 msgid "This is where you'll spend the vast majority of your time in Zammad."
 msgstr "Zammad'da zamanınızın büyük çoğunluğunu geçireceğiniz yer burasıdır."
 
 #: ../basics/service-ticket.rst:6
 #, fuzzy
-#| msgid ""
-#| "Once you get the hang of the tasks below, there’s really not much more to "
-#| "it."
 msgid ""
 "Once you get the hang of the tasks below, there's really not much more to it."
 msgstr ""
@@ -2457,10 +2296,6 @@ msgstr "Bir Bilet Oluşturmak"
 
 #: ../basics/service-ticket/create.rst:4
 #, fuzzy
-#| msgid ""
-#| "Zammad does its best to create tickets automatically when new customer "
-#| "issues come your way. But sometimes, there’s just no way for Zammad to "
-#| "know when an issue arrives – like when a customer calls on the phone."
 msgid ""
 "Zammad does its best to create tickets automatically when new customer "
 "issues come your way. But sometimes, there's just no way for Zammad to know "
@@ -2483,9 +2318,6 @@ msgstr ""
 
 #: ../basics/service-ticket/create.rst:16
 #, fuzzy
-#| msgid ""
-#| "Click the **➕ button** to create a new ticket. The default ticket type "
-#| "is **received call**."
 msgid ""
 "Click the **➕ button** to create a new ticket. The default ticket type is "
 "**Received Call**."
@@ -2527,7 +2359,6 @@ msgstr "Form Doldurmak"
 
 #: ../basics/service-ticket/create.rst:28
 #, fuzzy
-#| msgid "Here’s a quick run-down of each input field in the New Ticket form:"
 msgid "Here's a quick run-down of each input field in the New Ticket form:"
 msgstr ""
 "İşte Yeni Bilet formundaki her bir giriş alanının hızlı bir incelemesi:"
@@ -2568,7 +2399,6 @@ msgstr ""
 
 #: ../basics/service-ticket/create.rst:46
 #, fuzzy
-#| msgid "Autocomplete can’t find customers by name."
 msgid "Autocomplete can't find customers by name."
 msgstr "Otomatik tamamlama ada göre müşterileri bulamaz."
 
@@ -2695,10 +2525,6 @@ msgstr ""
 
 #: ../basics/service-ticket/follow-up.rst:19
 #, fuzzy
-#| msgid ""
-#| "Tickets are threads of messages & notes about a customer service issue. :"
-#| "doc:`⚙️ Manage a ticket’s settings <settings>` in the **ticket pane** on "
-#| "the right."
 msgid ""
 "Tickets are threads of messages & notes about a customer service issue. :doc:"
 "`⚙️ Manage ticket settings <settings>` in the **ticket pane** on the right."
@@ -2709,9 +2535,6 @@ msgstr ""
 
 #: ../basics/service-ticket/follow-up.rst:23
 #, fuzzy
-#| msgid ""
-#| "📇 Any time you open a ticket, a new entry will appear in your :doc:`tab "
-#| "list</advanced/tabs>` in the main menu."
 msgid ""
 "Any time you open a ticket, a new entry will appear in your :doc:`tab list</"
 "advanced/tabs>` in the main menu."
@@ -2762,9 +2585,6 @@ msgstr ""
 
 #: ../basics/service-ticket/follow-up.rst:47
 #, fuzzy
-#| msgid ""
-#| "⏩ You can also **forward messages**, just as you would in any email "
-#| "client (attachments are included automatically)."
 msgid ""
 "You can also **forward messages**, just as you would in any email client "
 "(attachments are included automatically). This way, you can share "
@@ -2789,7 +2609,6 @@ msgstr "Yeni Mesajlar/Notlar Eklemek"
 
 #: ../basics/service-ticket/follow-up.rst:60
 #, fuzzy
-#| msgid "Click on the text field at the end of the thread to add a follow-up."
 msgid "Click on the text field at the end of the thread to add a follow-up:"
 msgstr "Bir takip eklemek için konunun sonundaki metin alanına tıklayın."
 
@@ -2906,10 +2725,6 @@ msgstr ""
 
 #: ../basics/service-ticket/follow-up.rst:131
 #, fuzzy
-#| msgid ""
-#| "This feature is **optional**; if you don’t see it in the main menu, that "
-#| "means your administrator hasn’t enabled it yet. Administrators can learn "
-#| "more `here <https://admin-docs.zammad.org/en/latest/channels-chat.html>`_."
 msgid ""
 "SLAs are optional and require configuration by your instance administrator. "
 "Administrators can learn more about SLAs :admin-docs:`in our admin "
@@ -2980,7 +2795,6 @@ msgstr ""
 
 #: ../basics/service-ticket/settings.rst:4
 #, fuzzy
-#| msgid "Use the **ticket pane** to manage a ticket’s settings:"
 msgid "Use the **ticket pane** to manage a ticket's settings:"
 msgstr "Bir bilet ayarlarını yönetmek için **bilet paneli**ni kullanın."
 
@@ -3017,9 +2831,6 @@ msgstr "Bilet Metnini Öne Çıkarmak"
 
 #: ../basics/service-ticket/settings.rst:39
 #, fuzzy
-#| msgid ""
-#| "Use the highlighter tool in the upper-righthand corner to mark up "
-#| "important text. (Your highlights are **not** visible to other agents.)"
 msgid ""
 "Use the highlighter tool in the upper-righthand corner to mark up important "
 "text. (Your highlights are visible to other agents.)"
@@ -3041,7 +2852,6 @@ msgstr ""
 
 #: ../basics/service-ticket/settings.rst:50
 #, fuzzy
-#| msgid "Ticket Actions"
 msgid "Further ticket actions"
 msgstr "Bilet Hareketleri"
 
@@ -3107,10 +2917,6 @@ msgstr "Ne?"
 
 #: ../basics/service-ticket/settings/group.rst:11
 #, fuzzy
-#| msgid ""
-#| "Suppose your organization uses Zammad for both sales and customer "
-#| "support. You’ve got ten different agents spread across two teams, "
-#| "handling dozens of tickets a day."
 msgid ""
 "Suppose your organization uses Zammad for both sales and customer support. "
 "You've got ten different agents spread across two teams, handling dozens of "
@@ -3122,14 +2928,6 @@ msgstr ""
 
 #: ../basics/service-ticket/settings/group.rst:15
 #, fuzzy
-#| msgid ""
-#| "Without groups, all ten agents can see (and respond to) every single "
-#| "ticket that comes in, regardless of which department it’s for. This isn’t "
-#| "problematic *per se,* but it does lead to a lot of unnecessary clutter in "
-#| "the :doc:`overviews menu </basics/find-ticket>`. (It can be much worse "
-#| "when, for example, a customer service rep sees tickets meant for your HR "
-#| "department, and finds out how much their colleagues in sales are making! "
-#| "💸💸💸)"
 msgid ""
 "Without groups, all ten agents can see (and respond to) every single ticket "
 "that comes in, regardless of which department it's for. This isn't "
@@ -3149,9 +2947,6 @@ msgstr ""
 
 #: ../basics/service-ticket/settings/group.rst:25
 #, fuzzy
-#| msgid ""
-#| "If, instead, each agent were assigned to an appropriate group, then "
-#| "they’d only ever see the tickets that belong to their own group."
 msgid ""
 "If, instead, each agent were assigned to an appropriate group, then they'd "
 "only ever see the tickets that belong to their own group."
@@ -3165,9 +2960,6 @@ msgstr ""
 
 #: ../basics/service-ticket/settings/group.rst:31
 #, fuzzy
-#| msgid ""
-#| "You don’t – that’s the `administrator’s job <https://admin-docs.zammad."
-#| "org/en/latest/manage-groups.html>`_."
 msgid ""
 "So how do I manage which team I'm on? You don't - that's the :admin-docs:"
 "`administrator's job </manage/groups/index.html>`."
@@ -3175,9 +2967,6 @@ msgstr "Yapamazsınız – bu `yöneticinin işidir `_."
 
 #: ../basics/service-ticket/settings/group.rst:34
 #, fuzzy
-#| msgid ""
-#| "However, you can *check* which teams you’re on in the Notifications "
-#| "section of your :doc:`user settings </extras/profile-and-settings>`:"
 msgid ""
 "However, you can *check* which teams you're on in the Notifications section "
 "of your :doc:`user settings </extras/profile-and-settings>`:"
@@ -3199,11 +2988,6 @@ msgstr "Öyleyse nereye gireceğim?"
 
 #: ../basics/service-ticket/settings/group.rst:48
 #, fuzzy
-#| msgid ""
-#| "If you belong to more than one group, you may re-assign a ticket from one "
-#| "of your groups to another. In general, though, you won’t need to do this "
-#| "unless you’re an admin, or an admin has discussed the procedure with you "
-#| "beforehand."
 msgid ""
 "If you belong to more than one group, you may re-assign a ticket from one of "
 "your groups to another. In general, though, you won't need to do this unless "
@@ -3220,9 +3004,6 @@ msgstr "Sahip"
 
 #: ../basics/service-ticket/settings/owner.rst:4
 #, fuzzy
-#| msgid ""
-#| "A ticket’s **owner** is simply *the agent that is currently responsible "
-#| "for it*."
 msgid ""
 "A ticket's **owner** is simply *the agent that is currently responsible for "
 "it*."
@@ -3234,10 +3015,6 @@ msgstr "Biletlere atama yapmak kimin işi?"
 
 #: ../basics/service-ticket/settings/owner.rst:10
 #, fuzzy
-#| msgid ""
-#| "It depends on your organization’s workflow, but in most cases, **you will "
-#| "assign tickets to yourself** when you choose an issue to work on from the "
-#| "pool of new tickets."
 msgid ""
 "It depends on your organization's workflow, but in most cases, **you will "
 "assign tickets to yourself** when you choose an issue to work on from the "
@@ -3249,9 +3026,6 @@ msgstr ""
 
 #: ../basics/service-ticket/settings/owner.rst:16
 #, fuzzy
-#| msgid ""
-#| "In principle, any agent may assign a ticket to any other, as long as both "
-#| "have the required privileges for the ticket’s :doc:`group <group>`."
 msgid ""
 "In principle, any agent may assign a ticket to any other, as long as both "
 "have the required privileges for the ticket's :doc:`group </basics/service-"
@@ -3388,18 +3162,11 @@ msgstr ""
 
 #: ../basics/service-ticket/settings/state.rst:30
 #, fuzzy
-#| msgid "What’s the difference between “new” and “open”?"
 msgid "What's the difference between “new” and “open”?"
 msgstr "\"Yeni\" ve \"açık\" arasındaki fark nedir?"
 
 #: ../basics/service-ticket/settings/state.rst:32
 #, fuzzy
-#| msgid ""
-#| "States do more than just indicate progress: Zammad has a fine-grained "
-#| "time tracking feature (so-called “\\ `service-level agreements <https://"
-#| "admin-docs.zammad.org/en/latest/manage-slas.html>`_\\ ”, or SLAs) that "
-#| "uses state information to measure how long it takes for customers to get "
-#| "a response on a new ticket or get their issues resolved entirely."
 msgid ""
 "States do more than just indicate progress: Zammad has a fine-grained time "
 "tracking feature (so-called “:admin-docs:`service-level agreements </manage/"
@@ -3415,9 +3182,6 @@ msgstr ""
 
 #: ../basics/service-ticket/settings/state.rst:38
 #, fuzzy
-#| msgid ""
-#| "On a *new* ticket, the customer still hasn’t received her first response "
-#| "on the issue."
 msgid ""
 "On a *new* ticket, the customer still hasn't received her first response on "
 "the issue."
@@ -3426,9 +3190,6 @@ msgstr ""
 
 #: ../basics/service-ticket/settings/state.rst:41
 #, fuzzy
-#| msgid ""
-#| "On an *open* ticket, the customer has received an initial response, but "
-#| "the issue still hasn’t been resolved."
 msgid ""
 "On an *open* ticket, the customer has received an initial response, but the "
 "issue still hasn't been resolved."
@@ -3445,10 +3206,6 @@ msgstr ""
 
 #: ../basics/service-ticket/settings/state.rst:47
 #, fuzzy
-#| msgid ""
-#| "So, for instance, a ticket may be marked *pending reminder* if it’s "
-#| "waiting on feedback from a third-party supplier who’s out of town until "
-#| "next week."
 msgid ""
 "So, for instance, a ticket may be marked *pending reminder* if it's waiting "
 "on feedback from a third-party supplier who's out of town until next week."
@@ -3660,7 +3417,6 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:48
 #, fuzzy
-#| msgid "article.from"
 msgid "Article"
 msgstr "article.from"
 
@@ -3839,7 +3595,6 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:142
 #, fuzzy
-#| msgid "Suggested Workflows"
 msgid "Core Workflows"
 msgstr "Önerilen İş Akışları"
 
@@ -3909,7 +3664,6 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:172
 #, fuzzy
-#| msgid "Ticket attributes"
 msgid "Custom Object Attributes"
 msgstr "Bilet nitelikleri"
 
@@ -3960,7 +3714,6 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:206
 #, fuzzy
-#| msgid "Zammad Agent Documentation"
 msgid "Documentation"
 msgstr "Zammad Aracı Dokümantasyonu"
 
@@ -3984,7 +3737,6 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:227
 #, fuzzy
-#| msgid "Omnisearch"
 msgid "Elasticsearch"
 msgstr "Omnisearch"
 
@@ -4013,7 +3765,6 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:235
 #, fuzzy
-#| msgid "Encryption"
 msgid "Escalation"
 msgstr "Şifreleme"
 
@@ -4139,9 +3890,6 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:294
 #, fuzzy
-#| msgid ""
-#| "Administrators can learn more about customizing text modules `here "
-#| "<https://admin-docs.zammad.org/en/latest/manage-text-modules.html>`_."
 msgid ""
 "Administrators can learn more about GitHub :admin-docs:`in the admin "
 "documentation </system/integrations/github.html>`, if you're an agent you "
@@ -4170,9 +3918,6 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:307
 #, fuzzy
-#| msgid ""
-#| "Administrators can learn more about customizing text modules `here "
-#| "<https://admin-docs.zammad.org/en/latest/manage-text-modules.html>`_."
 msgid ""
 "Administrators can learn more about GitLab :admin-docs:`in the admin "
 "documentation </system/integrations/gitlab.html>`, if you're an agent you "
@@ -4211,7 +3956,6 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:338
 #, fuzzy
-#| msgid "Group"
 msgid "Groups"
 msgstr "Grup"
 
@@ -4296,9 +4040,6 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:372
 #, fuzzy
-#| msgid ""
-#| "Administrators can learn more about customizing text modules `here "
-#| "<https://admin-docs.zammad.org/en/latest/manage-text-modules.html>`_."
 msgid ""
 "Administrators can learn more about i-doit :admin-docs:`in the admin "
 "documentation </system/integrations/i-doit.html>`, if you're an agent you "
@@ -4365,9 +4106,6 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:407
 #, fuzzy
-#| msgid ""
-#| "Administrators can learn more about customizing text modules `here "
-#| "<https://admin-docs.zammad.org/en/latest/manage-text-modules.html>`_."
 msgid ""
 "Administrators can learn more about the Knowledge Base :admin-docs:`in the "
 "admin documentation </manage/knowledge-base.html>`, if you're an agent you "
@@ -4404,7 +4142,6 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:441
 #, fuzzy
-#| msgid "Macros"
 msgid "Macro"
 msgstr "Makrolar"
 
@@ -4426,9 +4163,6 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:438
 #, fuzzy
-#| msgid ""
-#| "Administrators can learn more about customizing text modules `here "
-#| "<https://admin-docs.zammad.org/en/latest/manage-text-modules.html>`_."
 msgid ""
 "Administrators can learn more about Macros :admin-docs:`in the admin "
 "documentation </manage/macros.html>`, if you're an agent you can learn more "
@@ -4532,9 +4266,6 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:490
 #, fuzzy
-#| msgid ""
-#| "⚙️ Check your :doc:`/extras/profile-and-settings` to customize how you "
-#| "receive notifications."
 msgid "See :doc:`/extras/profile-and-settings` for more information."
 msgstr ""
 "⚙️ Bildirimleri nasıl aldığınızı özelleştirmek için :doc:`/extras/profile-and-"
@@ -4690,9 +4421,6 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:579
 #, fuzzy
-#| msgid ""
-#| "Administrators can learn more about customizing text modules `here "
-#| "<https://admin-docs.zammad.org/en/latest/manage-text-modules.html>`_."
 msgid ""
 "Admins can find further information :admin-docs:`here </manage/report-"
 "profiles.html>`."
@@ -4758,25 +4486,21 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:610
 #, fuzzy
-#| msgid "Search phrase"
 msgid "Search bar"
 msgstr "İfadeyi ara"
 
 #: ../basics/zammad-glossary.rst:611
 #, fuzzy
-#| msgid "Notifications"
 msgid "Notification section"
 msgstr "Bildirimler"
 
 #: ../basics/zammad-glossary.rst:613 ../extras/profile-and-settings.rst:0
 #, fuzzy
-#| msgid "Overview"
 msgid "Overviews"
 msgstr "Genel Bakış"
 
 #: ../basics/zammad-glossary.rst:615
 #, fuzzy
-#| msgid "Customer"
 msgid "Customer Chat"
 msgstr "Müşteri"
 
@@ -4786,7 +4510,6 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:617
 #, fuzzy
-#| msgid "Browse for Tickets"
 msgid "One or more open tickets"
 msgstr "Biletlere Göre Tarama"
 
@@ -4796,13 +4519,11 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:622
 #, fuzzy
-#| msgid "Ticket Settings"
 msgid "Admin settings"
 msgstr "Bilet Ayarları"
 
 #: ../basics/zammad-glossary.rst:623
 #, fuzzy
-#| msgid "Text modules on ticket creation"
 msgid "Button for ticket creation"
 msgstr "Bilet oluştururken metin modülleri"
 
@@ -4868,7 +4589,6 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:663
 #, fuzzy
-#| msgid "Splitting Tickets"
 msgid "Splitting tickets"
 msgstr "Bölünmüş Biletler"
 
@@ -4909,9 +4629,6 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:678
 #, fuzzy
-#| msgid ""
-#| "Administrators can learn more about customizing text modules `here "
-#| "<https://admin-docs.zammad.org/en/latest/manage-text-modules.html>`_."
 msgid ""
 "Learn more about states and their color coding on this page: :doc:`/basics/"
 "service-ticket/settings/state`"
@@ -4931,10 +4648,6 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:685
 #, fuzzy
-#| msgid ""
-#| "S/MIME is the most widely-supported method for secure email "
-#| "communication. With S/MIME, you can exchange **signed** and **encrypted** "
-#| "messages with others."
 msgid ""
 "S/MIME is the most widely-supported method for secure email communication. "
 "By activating it in Zammad, all messages sent from Zammad will be signed and "
@@ -4946,9 +4659,6 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:689
 #, fuzzy
-#| msgid ""
-#| "Administrators can learn more about customizing text modules `here "
-#| "<https://admin-docs.zammad.org/en/latest/manage-text-modules.html>`_."
 msgid ""
 "Administrators can learn more about S/MIME :admin-docs:`in the admin "
 "documentation </system/integrations/smime/index.html>`, if you're an agent "
@@ -4973,9 +4683,6 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:705
 #, fuzzy
-#| msgid ""
-#| "Administrators can learn more about customizing text modules `here "
-#| "<https://admin-docs.zammad.org/en/latest/manage-text-modules.html>`_."
 msgid ""
 "Administrators can learn more about tags :admin-docs:`here </manage/tags."
 "html>`. Agents can learn more about this function on this page: :doc:`/"
@@ -5004,9 +4711,6 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:719
 #, fuzzy
-#| msgid ""
-#| "Administrators can learn more about customizing text modules `here "
-#| "<https://admin-docs.zammad.org/en/latest/manage-text-modules.html>`_."
 msgid ""
 "Administrators can learn more about text modules :admin-docs:`here </manage/"
 "text-modules.html>`. Agents can learn more about this function on this "
@@ -5017,7 +4721,6 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:729
 #, fuzzy
-#| msgid "Ticket Templates"
 msgid "(Ticket) Template"
 msgstr "Bilet Şablonları"
 
@@ -5042,7 +4745,6 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:741
 #, fuzzy
-#| msgid "Ticket Actions"
 msgid "Ticket hook"
 msgstr "Bilet Hareketleri"
 
@@ -5072,7 +4774,6 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:757
 #, fuzzy
-#| msgid "Users"
 msgid "User"
 msgstr "Kullanıcılar"
 
@@ -5139,11 +4840,6 @@ msgstr "**Telefon** panelinden arama kayıtlarını görüntüleyin ve yönetin.
 
 #: ../extras/caller-log.rst:6
 #, fuzzy
-#| msgid ""
-#| "This feature is **optional**; if you don’t see it in the main menu, that "
-#| "means your administrator hasn’t enabled it yet. Administrators can learn "
-#| "more `here <https://admin-docs.zammad.org/en/latest/system-integrations."
-#| "html#integrations-for-phone-systems>`_."
 msgid ""
 "This feature is **optional**; if you don't see it in the main menu, that "
 "means your administrator hasn't enabled it yet. Administrators can learn "
@@ -5166,9 +4862,6 @@ msgstr ""
 
 #: ../extras/caller-log.rst:18
 #, fuzzy
-#| msgid ""
-#| "🏢 The caller log shows all incoming and outgoing calls **for the entire "
-#| "team**."
 msgid ""
 "🏢 The caller log shows all incoming and outgoing calls **for the entire "
 "instance**. The number of entries shown depends on the configuration your "
@@ -5184,7 +4877,6 @@ msgstr ""
 
 #: ../extras/caller-log.rst:34
 #, fuzzy
-#| msgid "New tickets"
 msgid "New Ticket dialog"
 msgstr "Yeni biletler"
 
@@ -5261,10 +4953,6 @@ msgstr ""
 
 #: ../extras/caller-log.rst:64
 #, fuzzy
-#| msgid ""
-#| "👤 Click on unrecognized numbers in the caller log to **create a new "
-#| "customer and ticket**. (Unrecognized phone numbers cannot be added to "
-#| "existing customers in this way.)"
 msgid ""
 "👤 Click on unrecognized numbers to **create a new customer** or maybe "
 "entries to **update an existing customer**."
@@ -5295,10 +4983,6 @@ msgstr "**Müşteri sohbeti** panelinden gerçek zamanda müşteriler ile konuş
 
 #: ../extras/chat.rst:6
 #, fuzzy
-#| msgid ""
-#| "This feature is **optional**; if you don’t see it in the main menu, that "
-#| "means your administrator hasn’t enabled it yet. Administrators can learn "
-#| "more `here <https://admin-docs.zammad.org/en/latest/channels-chat.html>`_."
 msgid ""
 "This feature is **optional**; if you don't see it in the main menu, that "
 "means your administrator hasn't enabled it yet. Administrators can learn "
@@ -5414,9 +5098,6 @@ msgstr ""
 
 #: ../extras/chat.rst:49
 #, fuzzy
-#| msgid ""
-#| "⌨️ Live chat supports `text modules <https://admin-docs.zammad.org/en/"
-#| "latest/manage-text-modules.html>`_."
 msgid ""
 "⌨️ Live chat supports :admin-docs:`text modules </manage-text-modules.html>`."
 msgstr ""
@@ -5425,9 +5106,6 @@ msgstr ""
 
 #: ../extras/chat.rst:50
 #, fuzzy
-#| msgid ""
-#| "📝 Chats can be **renamed** or **tagged**, and record technical details "
-#| "about the customer’s connection."
 msgid ""
 "📝 Chats can be **renamed** or **tagged**, and record technical details "
 "about the customer's connection."
@@ -5480,7 +5158,6 @@ msgstr "Müşteriler"
 
 #: ../extras/customers.rst:4
 #, fuzzy
-#| msgid "Use the **ticket pane** to manage customer profiles."
 msgid "Use the **ticket pane** to view and manage customer profiles."
 msgstr "Müşteri profillerini yönetmek için **bilet paneli**ni kullanın."
 
@@ -5490,7 +5167,6 @@ msgstr ""
 
 #: ../extras/customers.rst:13
 #, fuzzy
-#| msgid "Click the 👨 tab in the ticket pane to see the customer’s profile."
 msgid "Click the 👨 tab in the ticket pane to see the customer's profile."
 msgstr ""
 "Müşterinin profilini görmek için bilet panelindeki 👨 sekmesine tıklayın."
@@ -5507,9 +5183,6 @@ msgstr ""
 
 #: ../extras/customers.rst:23
 #, fuzzy
-#| msgid ""
-#| "Hover over the **open/closed** labels to see a summary of the customer’s "
-#| "other tickets."
 msgid ""
 "Hover over the **open/closed** labels to see a summary of the customer's "
 "other tickets."
@@ -5523,7 +5196,6 @@ msgstr "Müşteriyi Düzenlemek"
 
 #: ../extras/customers.rst:29
 #, fuzzy
-#| msgid "To edit the customer’s profile, use the **customer submenu**:"
 msgid ""
 "To edit the customer's profile, use the **customer submenu** and select "
 "\"Edit Customer\":"
@@ -5540,7 +5212,6 @@ msgstr "Ek işlemlere erişmek için **Müşteri ▾** başlığına tıklayın.
 
 #: ../extras/customers.rst:46
 #, fuzzy
-#| msgid "The edit customer dialog."
 msgid "Customer edit dialog"
 msgstr "Müşteri diyaloğu düzenlemek."
 
@@ -5570,7 +5241,6 @@ msgstr ""
 
 #: ../extras/customers.rst:0
 #, fuzzy
-#| msgid "Organizations"
 msgid "Secondary Organizations"
 msgstr "Organizasyonlar"
 
@@ -5586,11 +5256,6 @@ msgstr "VIP"
 
 #: ../extras/customers.rst:63
 #, fuzzy
-#| msgid ""
-#| "Like :doc:`ticket priority </basics/service-ticket/settings/priority>`, "
-#| "**VIP status** doesn’t actually do anything out-of-the-box, but an admin "
-#| "*can* set up automated system hooks based on this value, or use it as a "
-#| "filter for :doc:`custom overviews </basics/find-ticket/browse>`."
 msgid ""
 "Like :doc:`ticket priority </basics/service-ticket/settings/priority>`, "
 "**VIP status** doesn't actually do anything out-of-the-box, but an admin "
@@ -5605,9 +5270,6 @@ msgstr ""
 
 #: ../extras/customers.rst:68
 #, fuzzy
-#| msgid ""
-#| "**Ask your administrator** about how she’d like you to use this attribute "
-#| "(or just leave it alone)."
 msgid ""
 "**Ask your administrator** about how she'd like you to use this attribute "
 "(or just leave it alone)."
@@ -5648,7 +5310,6 @@ msgstr "Efsane"
 
 #: ../extras/dashboard.rst:18
 #, fuzzy
-#| msgid "**1. Waiting Time Today**"
 msgid "**1. ∅ Waiting Time Today**"
 msgstr "**1. Bugün Bekleme Süresi**"
 
@@ -5698,7 +5359,6 @@ msgstr ""
 
 #: ../extras/dashboard.rst:30
 #, fuzzy
-#| msgid "**5. Your Tickets in Process**"
 msgid "**5. My Tickets in Process**"
 msgstr "**5. İşlemdeki Biletlerin**"
 
@@ -5741,11 +5401,6 @@ msgstr ""
 
 #: ../extras/github-gitlab-integration.rst:7
 #, fuzzy
-#| msgid ""
-#| "This feature is **optional**; if you don’t see it in the ticket pane, "
-#| "that means your administrator hasn’t enabled it yet. Administrators can "
-#| "learn more `here <https://admin-docs.zammad.org/en/latest/system/"
-#| "integrations.html#integrations-for-issue-trackers>`_."
 msgid ""
 "This feature is **optional**; if you don't see it in the ticket pane, that "
 "means your administrator hasn't enabled it yet. Administrators can learn "
@@ -5807,9 +5462,6 @@ msgstr "Yeni bir sorun bağlayın"
 
 #: ../extras/github-gitlab-integration.rst:30
 #, fuzzy
-#| msgid ""
-#| "At the top of the ticket pane, select **GitHub / GitLab > Link Issue**, "
-#| "then enter a valid issue URL."
 msgid ""
 "At the top of the ticket pane, select **GitHub / GitLab > Link Issue**, then "
 "enter a valid issue URL. Please note that linking a new issue can be slow "
@@ -5833,17 +5485,11 @@ msgstr ""
 
 #: ../extras/i-doit-track-company-property.rst:2
 #, fuzzy
-#| msgid "i-doit: Use Tickets to Track Company Property"
 msgid "i-doit: Track Company Property"
 msgstr "i-doit: Kuruluş Varlıklarını İzlemek için Biletleri Kullanın"
 
 #: ../extras/i-doit-track-company-property.rst:4
 #, fuzzy
-#| msgid ""
-#| "With `i-doit <https://www.i-doit.com/>`_ integration, you can list which "
-#| "pieces of your company’s property are related to any given ticket. That "
-#| "includes both physical and digital infrastructure, from servers to "
-#| "meeting rooms to virtual machines to software licenses."
 msgid ""
 "With `i-doit <https://www.i-doit.com/>`_ integration, you can list which "
 "pieces of your company's property are related to any given ticket. That "
@@ -5857,11 +5503,6 @@ msgstr ""
 
 #: ../extras/i-doit-track-company-property.rst:10
 #, fuzzy
-#| msgid ""
-#| "This feature is **optional**; if you don’t see it in the ticket view, "
-#| "that means your administrator hasn’t enabled it yet. Administrators can "
-#| "learn more `here <https://admin-docs.zammad.org/en/latest/system/"
-#| "integrations/i-doit.html>`_."
 msgid ""
 "This feature is **optional**; if you don't see it in the ticket view, that "
 "means your administrator hasn't enabled it yet. Administrators can learn "
@@ -5874,10 +5515,6 @@ msgstr ""
 
 #: ../extras/i-doit-track-company-property.rst:14
 #, fuzzy
-#| msgid ""
-#| "Ask your administrator / IT personnel to give you a tour—otherwise, the "
-#| "directions below might not make much sense. (And if your organization "
-#| "isn’t already using i-doit, this guide is not for you.)"
 msgid ""
 "If your company is using i-doit, ask your administrator / IT personnel to "
 "give you a tour. If your organization isn't already using i-doit, this guide "
@@ -5893,8 +5530,6 @@ msgstr ""
 
 #: ../extras/i-doit-track-company-property.rst:23
 #, fuzzy
-#| msgid ""
-#| "Use the 🖨 **printer** tab to view or manage a ticket’s assets from i-doit."
 msgid ""
 "Use the 🖨 **printer** tab to view or manage a ticket's assets from i-doit."
 msgstr ""
@@ -5915,11 +5550,6 @@ msgstr ""
 
 #: ../extras/i-doit-track-company-property.rst:32
 #, fuzzy
-#| msgid ""
-#| "It’s also a great way to document quirks in the company’s belongings: Why "
-#| "haven’t we upgraded this system from Windows Vista yet? What did we "
-#| "decide to do about that faulty network switch? And why does the coffee "
-#| "maker keep shutting off before it’s finished? 🤬"
 msgid ""
 "It's also a great way to document quirks in the company's belongings: Why "
 "haven't we upgraded this system from Windows Vista yet? What did we decide "
@@ -5991,9 +5621,6 @@ msgstr ""
 
 #: ../extras/i-doit-track-company-property.rst:69
 #, fuzzy
-#| msgid ""
-#| "Click the 💬 in the toolbar to list an asset’s tickets. Use the **🔗 Open "
-#| "in ticketsystem** button to open the ticket in Zammad."
 msgid ""
 "Click the 💬 in the toolbar to list an asset's tickets. Use the **🔗 Open in "
 "ticketsystem** button to open the ticket in Zammad."
@@ -6004,9 +5631,6 @@ msgstr ""
 
 #: ../extras/i-doit-track-company-property.rst:72
 #, fuzzy
-#| msgid ""
-#| "You can even launch Zammad’s new ticket dialog directly from i-doit, with "
-#| "the asset already linked for you:"
 msgid ""
 "You can even launch Zammad's new ticket dialog directly from i-doit, with "
 "the asset already linked for you:"
@@ -6059,11 +5683,6 @@ msgstr ""
 
 #: ../extras/knowledge-base.rst:7
 #, fuzzy
-#| msgid ""
-#| "This feature is **optional**; if you don’t see it in the main menu, that "
-#| "means your administrator hasn’t enabled it yet. Administrators can learn "
-#| "more `here <https://admin-docs.zammad.org/en/latest/manage/knowledge-base."
-#| "html>`_."
 msgid ""
 "This feature is **optional**; if you don't see it in the main menu, that "
 "means your administrator hasn't enabled it yet. Administrators can learn "
@@ -6251,9 +5870,6 @@ msgstr ""
 
 #: ../extras/knowledge-base.rst:130
 #, fuzzy
-#| msgid ""
-#| "📁 If you relocate a category using the **Parent** menu, all of its "
-#| "articles and sub-categories will be relocated with it."
 msgid ""
 "You can relocate a category using the **Parent** menu. Doing so, all of its "
 "articles and sub-categories will be relocated with it."
@@ -6263,9 +5879,6 @@ msgstr ""
 
 #: ../extras/knowledge-base.rst:133
 #, fuzzy
-#| msgid ""
-#| "🗑️ Categories can only be deleted once **all of their articles and sub-"
-#| "categories** have been deleted or relocated."
 msgid ""
 "You can delete categories by clicking on the 🗑️ **Delete** button. Categories "
 "can only be deleted once **all of their articles and sub-categories** have "
@@ -6411,10 +6024,6 @@ msgstr ""
 
 #: ../extras/knowledge-base.rst:206
 #, fuzzy
-#| msgid ""
-#| "🙈 Set the **visibility** of an answer to control who can see an article, "
-#| "or schedule it to be published at a later date. Articles are **color-"
-#| "coded** according to their visibility:"
 msgid ""
 "Set the **visibility** of an answer to control who can see an article, or "
 "schedule it to be published at a later date. Articles are **color-coded** "
@@ -6524,7 +6133,6 @@ msgstr ""
 
 #: ../extras/mobile-view.rst:39
 #, fuzzy
-#| msgid "Overview"
 msgid "Search & Overview"
 msgstr "Genel Bakış"
 
@@ -6534,25 +6142,21 @@ msgstr ""
 
 #: ../extras/mobile-view.rst:47
 #, fuzzy
-#| msgid "Search for Tickets"
 msgid "Search Results"
 msgstr "Biletlere göre Arama"
 
 #: ../extras/mobile-view.rst:0
 #, fuzzy
-#| msgid "open a ticket overview;"
 msgid "Mobile View Ticket Overview"
 msgstr "bir bilet genel bakışı aç;"
 
 #: ../extras/mobile-view.rst:55
 #, fuzzy
-#| msgid "Overview"
 msgid "Ticket Overview"
 msgstr "Genel Bakış"
 
 #: ../extras/mobile-view.rst:61
 #, fuzzy
-#| msgid "Ticket Settings"
 msgid "Ticket Details"
 msgstr "Bilet Ayarları"
 
@@ -6562,7 +6166,6 @@ msgstr ""
 
 #: ../extras/mobile-view.rst:69
 #, fuzzy
-#| msgid "Ticket Settings"
 msgid "Ticket Detail View"
 msgstr "Bilet Ayarları"
 
@@ -6572,19 +6175,16 @@ msgstr ""
 
 #: ../extras/mobile-view.rst:77
 #, fuzzy
-#| msgid "Ticket Actions"
 msgid "Ticket Information"
 msgstr "Bilet Hareketleri"
 
 #: ../extras/mobile-view.rst:83
 #, fuzzy
-#| msgid "Notifications"
 msgid "Notifications & Account"
 msgstr "Bildirimler"
 
 #: ../extras/mobile-view.rst:0
 #, fuzzy
-#| msgid "Notifications"
 msgid "Mobile View Notifications"
 msgstr "Bildirimler"
 
@@ -6594,7 +6194,6 @@ msgstr ""
 
 #: ../extras/mobile-view.rst:99
 #, fuzzy
-#| msgid "Overview"
 msgid "Account Overview"
 msgstr "Genel Bakış"
 
@@ -6617,13 +6216,11 @@ msgstr ""
 
 #: ../extras/mobile-view.rst:117
 #, fuzzy
-#| msgid "open a ticket overview;"
 msgid "Manage & use your ticket overviews"
 msgstr "bir bilet genel bakışı aç;"
 
 #: ../extras/mobile-view.rst:118
 #, fuzzy
-#| msgid "Search for Tickets"
 msgid "Search for existing records"
 msgstr "Biletlere göre Arama"
 
@@ -6633,19 +6230,16 @@ msgstr ""
 
 #: ../extras/mobile-view.rst:121
 #, fuzzy
-#| msgid "Ticket attributes"
 msgid "Modify ticket attributes"
 msgstr "Bilet nitelikleri"
 
 #: ../extras/mobile-view.rst:122
 #, fuzzy
-#| msgid "Ticket attributes"
 msgid "Modify customer attributes"
 msgstr "Bilet nitelikleri"
 
 #: ../extras/mobile-view.rst:123
 #, fuzzy
-#| msgid "Organization Profiles"
 msgid "Modify organization attributes"
 msgstr "Organizasyon Profilleri"
 
@@ -6671,7 +6265,6 @@ msgstr ""
 
 #: ../extras/mobile-view.rst:133
 #, fuzzy
-#| msgid "Notifications"
 msgid "Limitations"
 msgstr "Bildirimler"
 
@@ -6683,7 +6276,6 @@ msgstr ""
 
 #: ../extras/mobile-view.rst:138
 #, fuzzy
-#| msgid "Time Accounting"
 msgid "Ticket Article Time Accounting"
 msgstr "Zaman Hesaplama"
 
@@ -6697,13 +6289,11 @@ msgstr ""
 
 #: ../extras/mobile-view.rst:141
 #, fuzzy
-#| msgid "Ticket Actions"
 msgid "Ticket Macros"
 msgstr "Bilet Hareketleri"
 
 #: ../extras/mobile-view.rst:142
 #, fuzzy
-#| msgid "History"
 msgid "Ticket History"
 msgstr "Geçmiş"
 
@@ -6736,7 +6326,6 @@ msgstr ""
 
 #: ../extras/mobile-view.rst:156
 #, fuzzy
-#| msgid "Token Access"
 msgid "Access"
 msgstr "Jeton Erişimi"
 
@@ -6787,11 +6376,6 @@ msgstr ""
 
 #: ../extras/organizations.rst:4
 #, fuzzy
-#| msgid ""
-#| "Tickets track communication between individuals, but oftentimes, your "
-#| "company’s real client is **another company** (or **organization**). "
-#| "Customers can be grouped into organizations to monitor their activity as "
-#| "a whole."
 msgid ""
 "Tickets track communication between individuals, but often your company's "
 "real client is **another company** (or **organization**). Customers can be "
@@ -6808,7 +6392,6 @@ msgstr "Organizasyon Profilleri"
 
 #: ../extras/organizations.rst:12
 #, fuzzy
-#| msgid "Use the **ticket pane** to manage organization profiles."
 msgid "Use the **ticket pane** to view and manage organization profiles."
 msgstr "Organizasyon profillerini yönetmek için **bilet paneli**ni kullanın."
 
@@ -6818,16 +6401,12 @@ msgstr ""
 
 #: ../extras/organizations.rst:18
 #, fuzzy
-#| msgid ""
-#| "Click the 👪 tab in the ticket pane to see the organization’s profile."
 msgid "Click the 👪 tab in the ticket pane to see the organization's profile."
 msgstr ""
 "Organizasyonun profilini görmek için bilet panelindeki 👪 sekmesine tıklayın."
 
 #: ../extras/organizations.rst:20
 #, fuzzy
-#| msgid ""
-#| "To edit the organization’s profile, use the **organization submenu**:"
 msgid "To edit the organization's profile, use the **organization submenu**:"
 msgstr ""
 "Organizasyonun profilini düzenlemek için, **organizasyon altmenüsü**nü "
@@ -6843,7 +6422,6 @@ msgstr "Ek eylemlere erişmek için **Organizasyon ▾** başlığına tıklayı
 
 #: ../extras/organizations.rst:35
 #, fuzzy
-#| msgid "Organization Stats"
 msgid "Organization edit dialog"
 msgstr "Organizasyon İstatistikleri"
 
@@ -6877,9 +6455,6 @@ msgstr "\"Bu şirketteki en eski açık bilet kaç yaşında?\""
 
 #: ../extras/organizations.rst:51
 #, fuzzy
-#| msgid ""
-#| "Click the 🏢 button in the ticket pane to see a detailed breakdown of the "
-#| "organization’s stats."
 msgid ""
 "Click the 🏢 button in the ticket pane to see a detailed breakdown of the "
 "organization's stats."
@@ -6893,9 +6468,6 @@ msgstr "Profil ve Ayarlar"
 
 #: ../extras/profile-and-settings.rst:4
 #, fuzzy
-#| msgid ""
-#| "Click on your avatar at the bottom of the main menu to access your "
-#| "**profile and settings**."
 msgid ""
 "Click on your avatar or initials at the bottom of the main menu to access "
 "your **profile and settings**."
@@ -6913,7 +6485,6 @@ msgstr ""
 
 #: ../extras/profile-and-settings.rst:17
 #, fuzzy
-#| msgid "Users"
 msgid "User Menu"
 msgstr "Kullanıcılar"
 
@@ -6953,15 +6524,11 @@ msgstr ""
 
 #: ../extras/profile-and-settings.rst:36
 #, fuzzy
-#| msgid "Keyboard Shortcuts"
 msgid "Keyboard shortcuts"
 msgstr "Klavye Kısayolları"
 
 #: ../extras/profile-and-settings.rst:36
 #, fuzzy
-#| msgid ""
-#| "Use the built-in :doc:`keyboard shortcuts </advanced/keyboard-shortcuts>` "
-#| "to apply rich text formatting."
 msgid ""
 ":doc:`Opens the keyboard shortcut section </advanced/keyboard-shortcuts>`."
 msgstr ""
@@ -6970,7 +6537,6 @@ msgstr ""
 
 #: ../extras/profile-and-settings.rst:41
 #, fuzzy
-#| msgid "Profile Settings"
 msgid "Profile"
 msgstr "Profil Ayarları"
 
@@ -7051,19 +6617,16 @@ msgstr "Sistem görüntüleme dilini ayarlayın."
 
 #: ../extras/profile-and-settings.rst:82
 #, fuzzy
-#| msgid "Upload an avatar."
 msgid "Upload an avatar image."
 msgstr "Bir avatar yükleyin."
 
 #: ../extras/profile-and-settings.rst:0
 #, fuzzy
-#| msgid "Password"
 msgid "Password & Auth"
 msgstr "Parola"
 
 #: ../extras/profile-and-settings.rst:86
 #, fuzzy
-#| msgid "Change your login password (may be disabled by system admin)."
 msgid ""
 "Change your login password and manage your two-factor authentication methods "
 "(both may be disabled by system admin)."
@@ -7080,9 +6643,6 @@ msgstr ""
 
 #: ../extras/profile-and-settings.rst:97
 #, fuzzy
-#| msgid ""
-#| "Select where, when, and for which groups you want to receive "
-#| "notifications, or choose a new notification sound."
 msgid ""
 "Select where, when, and for which groups you want to receive notifications, "
 "or choose a new notification sound. Notifications are available to agents "
@@ -7108,17 +6668,11 @@ msgstr ""
 
 #: ../extras/profile-and-settings.rst:130
 #, fuzzy
-#| msgid "Group"
 msgid "Limit Groups"
 msgstr "Grup"
 
 #: ../extras/profile-and-settings.rst:117
 #, fuzzy
-#| msgid ""
-#| "By default, you will receive notifications for all tickets on every group "
-#| "you belong to—even for tickets that are assigned to other agents. Use the "
-#| "**Limit Groups** box to disable such notifications on a per-group basis. "
-#| "(You will continue to receive notifications for your own tickets.)"
 msgid ""
 "By default, you will receive notifications for all tickets in every group "
 "you belong to - even for tickets that are assigned to other agents. Use the "
@@ -7146,10 +6700,6 @@ msgstr ""
 
 #: ../extras/profile-and-settings.rst:132
 #, fuzzy
-#| msgid ""
-#| "The contents of these email notifications can be customized on self-"
-#| "hosted installations. Administrators can learn more `here <https://admin-"
-#| "docs.zammad.org/en/latest/manage/trigger/system-notifications.html>`_."
 msgid ""
 "The contents of these email notifications can be customized on self-hosted "
 "installations. Administrators can learn more :admin-docs:`here </manage/"
@@ -7164,9 +6714,6 @@ msgstr "Ofis Dışında"
 
 #: ../extras/profile-and-settings.rst:139
 #, fuzzy
-#| msgid ""
-#| "Schedule out-of-office periods in advance, and designate a substitute to "
-#| "handle your tickets while you’re gone."
 msgid ""
 "Schedule absence periods in advance, and designate a substitute to handle "
 "your tickets while you're gone."
@@ -7186,9 +6733,6 @@ msgstr ""
 
 #: ../extras/profile-and-settings.rst:146
 #, fuzzy
-#| msgid ""
-#| "🔔 You **will** continue to receive notifications while you are out-of-"
-#| "office!"
 msgid "You will reveive notifications while you are absent."
 msgstr ""
 "🔔 Ofis dışında olduğunuz zaman bildirimler almaya devam **edeceksiniz**!"
@@ -7230,9 +6774,6 @@ msgstr "Takvim"
 
 #: ../extras/profile-and-settings.rst:171
 #, fuzzy
-#| msgid ""
-#| "Add your ticket deadlines to your own favorite calendar app with the ICAL "
-#| "link listed at this settings panel."
 msgid ""
 "Add your ticket deadlines to your own favorite calendar app with the ICAL "
 "link listed at this setting's panel."
@@ -7246,9 +6787,6 @@ msgstr "Cihazlar"
 
 #: ../extras/profile-and-settings.rst:176
 #, fuzzy
-#| msgid ""
-#| "See a list of all devices logged in to your Zammad account (and revoke "
-#| "access, if necessary)."
 msgid ""
 "See a list of all devices logged into your Zammad account (and revoke "
 "access, if necessary)."
@@ -7262,9 +6800,6 @@ msgstr "Jeton Erişimi"
 
 #: ../extras/profile-and-settings.rst:181
 #, fuzzy
-#| msgid ""
-#| "Generate personal access tokens for third-party applications to use the "
-#| "Zammad API."
 msgid ""
 "Generate personal access tokens for third party applications to use the "
 "Zammad API."
@@ -7288,9 +6823,6 @@ msgstr "Bağlı Hesaplar"
 
 #: ../extras/profile-and-settings.rst:191
 #, fuzzy
-#| msgid ""
-#| "See a list of third-party services (*e.g.,* Facebook or Twitter) linked "
-#| "to your Zammad account."
 msgid ""
 "See a list of third party services (*e.g.,* Facebook or Twitter) linked to "
 "your Zammad account."
@@ -7304,7 +6836,6 @@ msgstr "Güvenli E-posta"
 
 #: ../extras/secure-email.rst:4
 #, fuzzy
-#| msgid "Zammad supports S/MIME for high-security email communication."
 msgid "Zammad supports two systems of high-security email communication:"
 msgstr "Zammad, yüksek seviyeli e-posta topluluğu için S/MIME'ı destekler."
 
@@ -7322,9 +6853,6 @@ msgstr ""
 
 #: ../extras/secure-email.rst:14
 #, fuzzy
-#| msgid ""
-#| "Use the 🔒 **Encrypt** and ✅ **Sign** buttons to turn on encryption and "
-#| "signing for outgoing emails."
 msgid ""
 "Use the 🔒 **Encrypt** and ✅ **Sign** buttons to turn on encryption and "
 "signing of outgoing emails."
@@ -7338,10 +6866,6 @@ msgstr ""
 
 #: ../extras/secure-email.rst:20
 #, fuzzy
-#| msgid ""
-#| "This feature is **optional**; if you don’t see it in the main menu, that "
-#| "means your administrator hasn’t enabled it yet. Administrators can learn "
-#| "more `here <https://admin-docs.zammad.org/en/latest/channels-chat.html>`_."
 msgid ""
 "Both feature are **optional**; if you don't see the 🔒 **Encrypt** and ✅ "
 "**Sign** buttons in the ticket composer, that means your administrator "
@@ -7366,16 +6890,11 @@ msgstr ""
 
 #: ../extras/secure-email.rst:29
 #, fuzzy
-#| msgid "🤝 **S/MIME only works if the other party is using it, too.**"
 msgid "PGP and S/MIME are only working if the other party is using them too."
 msgstr "🤝 **S/MIME yalnızca diğer taraf da kullanıyorsa çalışır.**"
 
 #: ../extras/secure-email.rst:34
 #, fuzzy
-#| msgid ""
-#| "S/MIME is the most widely-supported method for secure email "
-#| "communication. With S/MIME, you can exchange **signed** and **encrypted** "
-#| "messages with others."
 msgid ""
 "PGP and S/MIME are the most widely-supported methods for secure email "
 "communication. With each of the systems, you can exchange **signed** and "
@@ -7409,9 +6928,6 @@ msgstr "İmzalamak"
 
 #: ../extras/secure-email.rst:52
 #, fuzzy
-#| msgid ""
-#| "is proof that a message hasn’t been tampered with or sent by an "
-#| "impersonator."
 msgid "is a proof that a message hasn't been manipulated on its way."
 msgstr ""
 "bir mesajın bir taklitçi tarafından değiştirilmediğinin veya "
@@ -7419,9 +6935,6 @@ msgstr ""
 
 #: ../extras/secure-email.rst:54
 #, fuzzy
-#| msgid ""
-#| "In other words, it guarantees a message’s **integrity** and "
-#| "**authenticity**."
 msgid ""
 "In other words, it guarantees message **integrity** and **authenticity**."
 msgstr ""
@@ -7442,16 +6955,12 @@ msgstr ""
 
 #: ../extras/secure-email.rst:60
 #, fuzzy
-#| msgid "In other words, it guarantees **privacy** and **data security**."
 msgid ""
 "In other words, it guarantees message **privacy** and **data security**."
 msgstr "Başka bir deyişle, **gizliliği** ve **veri güvenliği**ni garanti eder."
 
 #: ../extras/secure-email.rst:62
 #, fuzzy
-#| msgid ""
-#| "Your administrator is responsible for adding all the necessary "
-#| "certificates in Zammad’s admin panel."
 msgid ""
 "Your administrator is responsible for adding all the necessary certificates "
 "and keys in Zammad's admin panel."
@@ -7465,8 +6974,6 @@ msgstr "📬 Gelen"
 
 #: ../extras/secure-email.rst:68
 #, fuzzy
-#| msgid ""
-#| "The 🔒 and ✅ icons at the top of a message indicate its S/MIME status."
 msgid ""
 "The 🔒 and ✅ icons at the top of a message indicate its encryption and "
 "signing status."
@@ -7480,9 +6987,6 @@ msgstr ""
 
 #: ../extras/secure-email.rst:76
 #, fuzzy
-#| msgid ""
-#| "Click on an incoming message to expand its details. Hover over the "
-#| "security status to show a certificate/CA summary."
 msgid ""
 "Click on an incoming message to expand its details. Hover over the security "
 "status to show more information."
@@ -7508,9 +7012,6 @@ msgstr "Bu mesaj **sizin için şifrelendi**."
 
 #: ../extras/secure-email.rst:85
 #, fuzzy
-#| msgid ""
-#| "Even if it was intercepted by a third party (hacker, gov’t agency, etc.), "
-#| "they won’t be able to read it."
 msgid ""
 "Even if it was intercepted by a third party (hacker, gov't agency, etc.), "
 "they won't be able to read it."
@@ -7520,19 +7021,16 @@ msgstr ""
 
 #: ../extras/secure-email.rst:88
 #, fuzzy
-#| msgid "Encryption"
 msgid "|encryption-error|"
 msgstr "Şifreleme"
 
 #: ../extras/secure-email.rst:151
 #, fuzzy
-#| msgid "Encryption"
 msgid "encryption-error"
 msgstr "Şifreleme"
 
 #: ../extras/secure-email.rst:89
 #, fuzzy
-#| msgid "This message is **not encrypted**."
 msgid "This message can **not be decrypted**."
 msgstr "Bu mesaj **şifrelenmedi**."
 
@@ -7546,15 +7044,11 @@ msgstr ""
 
 #: ../extras/secure-email.rst:92
 #, fuzzy
-#| msgid "This message’s signature has been **successfully verified**."
 msgid "This message's signature has been **successfully verified**."
 msgstr "Bu mesajın imzası **başarıyla doğrulandı**."
 
 #: ../extras/secure-email.rst:94
 #, fuzzy
-#| msgid ""
-#| "You can be confident that it’s authentic and that the contents have not "
-#| "been modified."
 msgid ""
 "You can be confident that it's authentic and that the content has not been "
 "modified."
@@ -7599,9 +7093,6 @@ msgstr ""
 
 #: ../extras/secure-email.rst:114
 #, fuzzy
-#| msgid ""
-#| "🔒 **Encrypt** and ✅ **Sign** buttons are present on both new tickets "
-#| "and replies. Hover over the buttons to show a certificate/CA summary."
 msgid ""
 "🔒 **Encrypt** and ✅ **Sign** buttons are present on both new tickets and "
 "replies. Hover over the buttons to show details."
@@ -7620,9 +7111,6 @@ msgstr "Bu mesaj **şifrelenecektir**."
 
 #: ../extras/secure-email.rst:123
 #, fuzzy
-#| msgid ""
-#| "Even if it was intercepted by a third party (hacker, gov’t agency, etc.), "
-#| "they won’t be able to read it."
 msgid ""
 "Even if it's intercepted by a third party (hacker, gov't agency, etc.), they "
 "won't be able to read it."
@@ -7648,9 +7136,6 @@ msgstr "Bu mesaj **imzalanacaktır**."
 
 #: ../extras/secure-email.rst:132
 #, fuzzy
-#| msgid ""
-#| "Recipients using S/MIME can verify that it came from you and that the "
-#| "contents have not been modified."
 msgid ""
 "Recipients can verify that it came from you and that the content has not "
 "been modified."
@@ -7677,18 +7162,12 @@ msgstr ""
 
 #: ../extras/secure-email.rst:166
 #, fuzzy
-#| msgid ""
-#| "Without the sender’s certificate, Zammad cannot verify the message "
-#| "signature."
 msgid ""
 "Without the sender's certificate, Zammad cannot verify the message signature."
 msgstr "Gönderen sertifikası olmadan, Zammad mesaj imzasını doğrulayamaz."
 
 #: ../extras/secure-email.rst:168
 #, fuzzy
-#| msgid ""
-#| "Ask your administrator to add the sender’s certificate to Zammad’s "
-#| "certificate store."
 msgid ""
 "Ask your administrator to add the sender's certificate to Zammad's "
 "certificate store."
@@ -7702,10 +7181,6 @@ msgstr "🕵️ **HER ZAMAN sertifikaları şahsen veya telefonla doğrulayın!*
 
 #: ../extras/secure-email.rst:172
 #, fuzzy
-#| msgid ""
-#| "The whole point of signature verification is to alert you when someone is "
-#| "trying to pretend to be someone they’re not. Never accept a certificate "
-#| "from someone online without verifying it first."
 msgid ""
 "The whole point of signature verification is to alert you when someone is "
 "trying to pretend to be someone they're not. Never accept a certificate from "
@@ -7729,10 +7204,6 @@ msgstr ""
 
 #: ../extras/secure-email.rst:184
 #, fuzzy
-#| msgid ""
-#| "Ask your administrator to verify your organization’s private key in "
-#| "Zammad’s certificate store, and ask the sender to double-check the public "
-#| "key they used to encrypt the message."
 msgid ""
 "Ask your administrator to verify your organization's private key in Zammad's "
 "certificate store, and ask the sender to double-check the public key they "
@@ -7748,9 +7219,6 @@ msgstr "📢 **Herkese açık anahtarınız herkesle güvenle paylaşılabilir.*
 
 #: ../extras/secure-email.rst:189
 #, fuzzy
-#| msgid ""
-#| "(But if they’re smart, they’ll take extra precautions to make sure it "
-#| "really belongs to you.)"
 msgid ""
 "(But if they're smart, they'll take extra precautions to make sure it really "
 "belongs to you.)"
@@ -7764,9 +7232,6 @@ msgstr "🔒 **Şifrele** butonu devre dışı bırakıldı"
 
 #: ../extras/secure-email.rst:196
 #, fuzzy
-#| msgid ""
-#| "Ask your administrator to add the recipient’s certificate to Zammad’s "
-#| "certificate store."
 msgid ""
 "Ask your administrator to add the recipient's certificate to Zammad's "
 "certificate store."
@@ -7780,9 +7245,6 @@ msgstr "✅ **İmzala** butonu devre dışı bırakıldı"
 
 #: ../extras/secure-email.rst:199
 #, fuzzy
-#| msgid ""
-#| "Ask your administrator to verify your organization’s private key in "
-#| "Zammad’s certificate store."
 msgid ""
 "Ask your administrator to verify your organization's private key in Zammad's "
 "certificate store."
@@ -7802,10 +7264,6 @@ msgstr ""
 
 #: ../extras/shared-drafts.rst:10
 #, fuzzy
-#| msgid ""
-#| "This feature is **optional**; if you don’t see it in the main menu, that "
-#| "means your administrator hasn’t enabled it yet. Administrators can learn "
-#| "more `here <https://admin-docs.zammad.org/en/latest/channels-chat.html>`_."
 msgid ""
 "This feature is **optional**; if you don't see it in the menu, that means "
 "your administrator disabled this function. Administrators can learn more in "
@@ -7871,7 +7329,6 @@ msgstr ""
 
 #: ../extras/shared-drafts.rst:54
 #, fuzzy
-#| msgid "New tickets"
 msgid "New Ticket dialogue"
 msgstr "Yeni biletler"
 
@@ -7890,7 +7347,6 @@ msgstr ""
 
 #: ../extras/shared-drafts.rst:64
 #, fuzzy
-#| msgid "Existing tickets"
 msgid "Existing tickets (Ticket zoom)"
 msgstr "Mevcut biletler"
 
@@ -7932,13 +7388,11 @@ msgstr ""
 
 #: ../extras/shared-drafts.rst:97
 #, fuzzy
-#| msgid "New tickets"
 msgid "New ticket"
 msgstr "Yeni biletler"
 
 #: ../extras/shared-drafts.rst:87
 #, fuzzy
-#| msgid "Adding New Messages/Notes"
 msgid "Adding new drafts"
 msgstr "Yeni Mesajlar/Notlar Eklemek"
 
@@ -7980,7 +7434,6 @@ msgstr ""
 
 #: ../extras/shared-drafts.rst:109
 #, fuzzy
-#| msgid "Existing tickets"
 msgid "Existing ticket"
 msgstr "Mevcut biletler"
 
@@ -8022,10 +7475,6 @@ msgstr ""
 
 #: ../extras/two-factor-authentication.rst:11
 #, fuzzy
-#| msgid ""
-#| "The contents of these email notifications can be customized on self-"
-#| "hosted installations. Administrators can learn more `here <https://admin-"
-#| "docs.zammad.org/en/latest/manage/trigger/system-notifications.html>`_."
 msgid ""
 "Two-Factor Authentication is an **optional feature**. Administrators can "
 "learn more :admin-docs:`here </settings/security/two-factor.html>`."
@@ -8437,7 +7886,6 @@ msgstr ""
 #: ../extras/two-factor-authentication/security-keys-setup.rst:50
 #: ../extras/two-factor-authentication/security-keys-setup.rst:None
 #, fuzzy
-#| msgid "Editing Categories"
 msgid "Editing Security Keys"
 msgstr "Kategorileri Düzenlemek"
 
@@ -8514,7 +7962,6 @@ msgstr "Ekstralar"
 
 #: ../index.rst:2
 #, fuzzy
-#| msgid "Zammad Agent Documentation"
 msgid "Zammad User Documentation"
 msgstr "Zammad Aracı Dokümantasyonu"
 
@@ -8528,8 +7975,20 @@ msgstr ""
 "index.html>` ve :admin-docs:`administration manuals </index.html>` da "
 "mevcuttur."
 
+#: ../basics/zammad-glossary.rst:618
 #, fuzzy
-#~| msgid "State"
+msgid "Bottom section:"
+msgstr "Bildirimler"
+
+#: ../basics/zammad-glossary.rst:732
+msgid ""
+"The title of a ticket is different based on the channel it came in. You can "
+"find the title in the sidebar and in the top area in the ticket view. If the "
+"title is not very meaningful, you can change it by clicking on the title in "
+"a ticket view."
+msgstr ""
+
+#, fuzzy
 #~ msgid "Status"
 #~ msgstr "Durum"
 
@@ -8646,9 +8105,6 @@ msgstr ""
 #~ msgstr "**🤔 Pardon? \"Zaman Hesaplama\" diyaloğunu göremedim...**"
 
 #, fuzzy
-#~| msgid ""
-#~| "This way, you can share correspondences with people who don’t have "
-#~| "Zammad (like a third-party supplier)."
 #~ msgid ""
 #~ "This way, you can share correspondences with people who don't have Zammad "
 #~ "(like a third-party supplier)."
@@ -8665,7 +8121,6 @@ msgstr ""
 #~ "tıklayın."
 
 #, fuzzy
-#~| msgid "**🙅 I’m working here!**"
 #~ msgid "**🙅 I'm working here!**"
 #~ msgstr "**🙅 Burada çalışıyorum!**"
 
@@ -8693,7 +8148,6 @@ msgstr ""
 #~ msgstr "⌛ **Yeni bir sorun bağlamak bazen yavaş olabilir.**"
 
 #, fuzzy
-#~| msgid "**🤔 Huh? I don’t see a 🖨 printer tab...**"
 #~ msgid "**🤔 Huh? I don't see a 🖨 printer tab...**"
 #~ msgstr "**🤔 Pardon? 🖨 Yazıcı sekmesini görmüyorum...**"
 
@@ -8728,7 +8182,6 @@ msgstr ""
 #~ msgstr "🚧 **Bir sayfa henüz seçilen dile çevrilmediğinde ne olur?**"
 
 #, fuzzy
-#~| msgid "**🤔 Huh? I don’t see an “Edit” button...**"
 #~ msgid "**🤔 Huh? I don’t see an “RSS” button...**"
 #~ msgstr "**🤔 Pardon? “Düzenle” butonunu göremedim...**"
 
@@ -8736,16 +8189,11 @@ msgstr ""
 #~ msgstr "Dahili bildirimler devre dışı bırakılamaz."
 
 #, fuzzy
-#~| msgid ""
-#~| "🔔 You **will** continue to receive notifications while you are out-of-"
-#~| "office!"
 #~ msgid "(You will continue to receive notifications for your own tickets.)"
 #~ msgstr ""
 #~ "🔔 Ofis dışında olduğunuz zaman bildirimler almaya devam **edeceksiniz**!"
 
 #, fuzzy
-#~| msgid ""
-#~| "**🤔 Huh? I don’t see “Sign” or “Encrypt” options in the ticket view...**"
 #~ msgid ""
 #~ "**🤔 Huh? I don't see “Sign” or “Encrypt” options in the ticket view...**"
 #~ msgstr ""
@@ -8753,7 +8201,6 @@ msgstr ""
 #~ "göremedim...**"
 
 #, fuzzy
-#~| msgid "**🤔 Huh? I don’t see an “Edit” button...**"
 #~ msgid "**🤔 Huh? I don't see “Share Draft” option...**"
 #~ msgstr "**🤔 Pardon? “Düzenle” butonunu göremedim...**"
 
@@ -8771,11 +8218,6 @@ msgstr ""
 #~ msgstr "Hepsi birden"
 
 #, fuzzy
-#~| msgid ""
-#~| "This feature is **optional**; if you don’t see it in the main menu, that "
-#~| "means your administrator hasn’t enabled it yet. Administrators can learn "
-#~| "more `here <https://admin-docs.zammad.org/en/latest/channels-chat."
-#~| "html>`_."
 #~ msgid ""
 #~ "This feature is **optional**; if you don’t see it in the main menu, that "
 #~ "means your administrator hasn’t enabled it yet. Administrators can learn "

--- a/locale/zh_Hans/LC_MESSAGES/user-docs.po
+++ b/locale/zh_Hans/LC_MESSAGES/user-docs.po
@@ -25,9 +25,6 @@ msgstr "快捷键"
 
 #: ../advanced/keyboard-shortcuts.rst:6
 #, fuzzy
-#| msgid ""
-#| "Zammad supports a wide array of keyboard shortcuts to expedite your "
-#| "workflow as an expert user."
 msgid ""
 "Zammad supports a wide array of keyboard shortcuts to expedite your workflow "
 "as an expert user. But don't be afraid, you don't have to remember all of "
@@ -52,21 +49,16 @@ msgstr "用户子菜单"
 
 #: ../advanced/keyboard-shortcuts.rst:20
 #, fuzzy
-#| msgid ""
-#| "Alternately, bring it up with one of the shortcuts below (shortcut-"
-#| "ception!)"
 msgid "Alternatively, open it with one of the shortcuts below:"
 msgstr "或者，使用下面的快捷键（快捷方式）调出："
 
 #: ../advanced/keyboard-shortcuts.rst:22
 #, fuzzy
-#| msgid "``Ctrl`` + ``Shift`` + ``H`` (on Windows)"
 msgid "``ctrl`` + ``shift`` + ``h`` (on Linux and Windows)"
 msgstr "``Ctrl`` + ``Shift`` + ``H`` (在 Windows 下)"
 
 #: ../advanced/keyboard-shortcuts.rst:23
 #, fuzzy
-#| msgid "``Cmd`` + ``Ctrl`` + ``Shift`` + ``H`` (on macOS)"
 msgid "``cmd`` + ``ctrl`` + ``shift`` + ``h`` (on macOS)"
 msgstr "``Cmd`` + ``Ctrl`` + ``Shift`` + ``H`` (在 macOS 下)"
 
@@ -82,19 +74,16 @@ msgstr "键盘快捷键参考清单"
 
 #: ../advanced/keyboard-shortcuts.rst:33
 #, fuzzy
-#| msgid "Keyboard shortcut cheat sheet"
 msgid "The keyboard shortcut cheat sheet."
 msgstr "键盘快捷键参考清单"
 
 #: ../advanced/keyboard-shortcuts.rst:37
 #, fuzzy
-#| msgid "Keyboard Shortcuts"
 msgid "List of Available Keyboard Shortcuts"
 msgstr "快捷键"
 
 #: ../advanced/keyboard-shortcuts.rst:40
 #, fuzzy
-#| msgid "organization"
 msgid "Navigation"
 msgstr "组织"
 
@@ -184,7 +173,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:54
 #, fuzzy
-#| msgid "``Cmd`` + ``Ctrl`` + ``Shift`` + ``H`` (on macOS)"
 msgid "``shift`` + ``ctrl`` + ``shift+tab``"
 msgstr "``Cmd`` + ``Ctrl`` + ``Shift`` + ``H`` (在 macOS 下)"
 
@@ -250,7 +238,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:66
 #, fuzzy
-#| msgid "organization"
 msgid "Translations"
 msgstr "组织"
 
@@ -317,7 +304,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:95
 #, fuzzy
-#| msgid "``Cmd`` + ``Ctrl`` + ``Shift`` + ``H`` (on macOS)"
 msgid "``shift`` + ``ctrl`` + ``←`` / ``→``"
 msgstr "``Cmd`` + ``Ctrl`` + ``Shift`` + ``H`` (在 macOS 下)"
 
@@ -367,7 +353,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:109
 #, fuzzy
-#| msgid "Press ``Cmd`` + ``I`` to enter Italics mode,"
 msgid "Press ``cmd`` + ``i`` to enter *italics* mode,"
 msgstr "按下 ``Cmd`` + ``I`` 组合键进入斜体模式,"
 
@@ -377,7 +362,6 @@ msgstr "输入您想要的文本，然后"
 
 #: ../advanced/keyboard-shortcuts.rst:111
 #, fuzzy
-#| msgid "press ``Cmd`` + ``I`` again to return to normal text mode."
 msgid "press ``cmd`` + ``i`` again to return to normal text mode."
 msgstr "再次按下 ``Cmd`` + ``I`` 组合键返回正常模式."
 
@@ -395,7 +379,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:117
 #, fuzzy
-#| msgid "Press ``Cmd`` + ``I`` to enter Italics mode,"
 msgid "press ``cmd`` + ``i`` to set the text in *italics*."
 msgstr "按下 ``Cmd`` + ``I`` 组合键进入斜体模式,"
 
@@ -445,7 +428,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:128
 #, fuzzy
-#| msgid "``Ctrl`` + ``Shift`` + ``H`` (on Linux)"
 msgid "``ctrl`` + ``shift`` + ``v``"
 msgstr "``Ctrl`` + ``Shift`` + ``H`` (在 Linux 下)"
 
@@ -459,7 +441,6 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:129
 #, fuzzy
-#| msgid "Formatting Text"
 msgid "Remove formatting of text"
 msgstr "格式化文本"
 
@@ -546,10 +527,6 @@ msgstr ""
 
 #: ../advanced/macros.rst:10
 #, fuzzy
-#| msgid ""
-#| "You don’t – that’s the `administrator’s job <https://admin-docs.zammad."
-#| "org/en/latest/manage/macros.html>`_. If you have an idea for a macro "
-#| "you’d like to use, your Zammad admin can probably make it happen."
 msgid ""
 "Macros can be created by your :admin-docs:`administrator </manage/macros."
 "html>`. If you have an idea for a macro you'd like to use, your Zammad admin "
@@ -561,8 +538,6 @@ msgstr ""
 
 #: ../advanced/macros.rst:14
 #, fuzzy
-#| msgid ""
-#| "Macros can be applied in one of two ways: on a single ticket, or in bulk."
 msgid "Macros can be applied in two ways: on a single ticket, or in bulk."
 msgstr "宏可以通过两种方式应用：在单个工单上，或者批量应用。"
 
@@ -572,9 +547,6 @@ msgstr "在单个工单上"
 
 #: ../advanced/macros.rst:19
 #, fuzzy
-#| msgid ""
-#| "The simplest way to apply a macro is to select it from the **Update ᐱ** "
-#| "submenu in the Ticket View:"
 msgid ""
 "The simplest way to apply a macro is to select it from the **Update ^** "
 "submenu in the Ticket View:"
@@ -590,10 +562,6 @@ msgstr "💾 **宏 = 更新**"
 
 #: ../advanced/macros.rst:29
 #, fuzzy
-#| msgid ""
-#| "If you’ve made changes to any other :ref:`settings on the ticket "
-#| "<ticket_settings>` (including typing up a reply to the customer), "
-#| "applying a macro will save them, too."
 msgid ""
 "If you've made changes to any other :ref:`settings on the ticket "
 "<ticket_settings>` (including typing up a reply to the customer), applying a "
@@ -604,10 +572,6 @@ msgstr ""
 
 #: ../advanced/macros.rst:34
 #, fuzzy
-#| msgid ""
-#| "⚠️ **But beware:** in the event of a conflict, the macro’s actions "
-#| "override any manual changes – including messages to the customer! When in "
-#| "doubt, apply your macro and your manual changes *separately.*"
 msgid ""
 "⚠️ **But beware:** in the event of a conflict, the macro's actions override "
 "any manual changes - including messages to the customer! When in doubt, "
@@ -676,10 +640,6 @@ msgstr "高级搜索"
 
 #: ../advanced/search.rst:4
 #, fuzzy
-#| msgid ""
-#| "With Zammad, you can limit your search to specific Information. This "
-#| "allows you to find e.g. Tickets with specific key words and states. Below "
-#| "information will help you to improve your search results."
 msgid ""
 "With Zammad, you can limit your search to specific attributes. This allows "
 "you to find e.g. tickets with specific key words and states. Below "
@@ -700,9 +660,6 @@ msgstr "或者："
 
 #: ../advanced/search.rst:18
 #, fuzzy
-#| msgid ""
-#| "If you want to run a more complex search you can use conditions with "
-#| "``()`` and ``AND``/``OR`` options::"
 msgid ""
 "If you want to run a more complex search, you can use conditions with ``()`` "
 "and ``AND``/``OR`` options::"
@@ -715,10 +672,6 @@ msgstr "可用属性"
 
 #: ../advanced/search.rst:28
 #, fuzzy
-#| msgid ""
-#| "For a more detailed list of available attributes please take a look into "
-#| "our `Zammad Admin-Documentation <https://docs.zammad.org/en/latest/"
-#| "install/elasticsearch/indexed-attributes.html>`_"
 msgid ""
 "For a more detailed list of available attributes please take a look into "
 "our :docs:`Zammad System Documentation </install/elasticsearch/indexed-"
@@ -1946,7 +1899,6 @@ msgstr ""
 
 #: ../advanced/time-accounting.rst:57
 #, fuzzy
-#| msgid "Screencast showing how to run a macro within a ticket view."
 msgid "Screenshot showing accounted times in ticket pane"
 msgstr "演示如何在工单视图中运行宏的屏幕录像。"
 
@@ -5809,7 +5761,6 @@ msgstr ""
 
 #: ../extras/organizations.rst:35
 #, fuzzy
-#| msgid "organization"
 msgid "Organization edit dialog"
 msgstr "组织"
 
@@ -5853,9 +5804,6 @@ msgstr ""
 
 #: ../extras/profile-and-settings.rst:4
 #, fuzzy
-#| msgid ""
-#| "Click on your avatar at the bottom of the main menu to access the "
-#| "**keyboard shortcuts cheat sheet**."
 msgid ""
 "Click on your avatar or initials at the bottom of the main menu to access "
 "your **profile and settings**."
@@ -5869,7 +5817,6 @@ msgstr ""
 
 #: ../extras/profile-and-settings.rst:17
 #, fuzzy
-#| msgid "User submenu"
 msgid "User Menu"
 msgstr "用户子菜单"
 
@@ -6002,7 +5949,6 @@ msgstr ""
 
 #: ../extras/profile-and-settings.rst:0
 #, fuzzy
-#| msgid "Password"
 msgid "Password & Auth"
 msgstr "密码"
 
@@ -7214,6 +7160,18 @@ msgid ""
 "You are currently reading the Zammad user documentation. There are also :"
 "docs:`system </index.html>` and :admin-docs:`administration manuals </index."
 "html>` available."
+msgstr ""
+
+#: ../basics/zammad-glossary.rst:618
+msgid "Bottom section:"
+msgstr ""
+
+#: ../basics/zammad-glossary.rst:732
+msgid ""
+"The title of a ticket is different based on the channel it came in. You can "
+"find the title in the sidebar and in the top area in the ticket view. If the "
+"title is not very meaningful, you can change it by clicking on the title in "
+"a ticket view."
 msgstr ""
 
 #~ msgid "🤔 **How do I make macros?**"


### PR DESCRIPTION
Translations update from [Zammad-Translations](https://translations.zammad.org) for [Documentation/User Documentation (pre-release)](https://translations.zammad.org/projects/documentations/user-documentation-pre-release/).



Current translation status:

![Weblate translation status](https://translations.zammad.org/widget/documentations/user-documentation-pre-release/horizontal-auto.svg)