### PR TITLE
Translations update from Zammad-Translations

### DIFF
--- a/locale/de/LC_MESSAGES/user-docs.po
+++ b/locale/de/LC_MESSAGES/user-docs.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-04-12 11:32+0200\n"
-"PO-Revision-Date: 2024-02-24 14:00+0000\n"
+"PO-Revision-Date: 2024-05-01 08:00+0000\n"
 "Last-Translator: Ralf Schmid <rsc@zammad.com>\n"
 "Language-Team: German <https://translations.zammad.org/projects/"
 "documentations/user-documentation-pre-release/de/>\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 5.3.1\n"
+"X-Generator: Weblate 5.5\n"
 
 #: ../advanced/keyboard-shortcuts.rst:4
 msgid "Keyboard Shortcuts"
@@ -5002,7 +5002,7 @@ msgstr "Ein oder mehrere offene Tickets"
 
 #: ../basics/zammad-glossary.rst:618
 msgid "Bootom section:"
-msgstr ""
+msgstr "Unterer Abschnitt:"
 
 #: ../basics/zammad-glossary.rst:622
 msgid "Admin settings"
@@ -5281,6 +5281,10 @@ msgid ""
 "title is not very meaningful, you can change it by clicking on the title in "
 "a ticket view."
 msgstr ""
+"Der Titel eines Tickets unterscheidet sich je nach Kanal, in dem es erstellt "
+"wurde. Sie finden den Titel in der Seitenleiste und im oberen Bereich in der "
+"Ticket-Ansicht. Wenn der Titel nicht wirklich aussagekräftig ist, können Sie "
+"ihn ändern, indem Sie in einer Ticket-Ansicht auf den Titel klicken."
 
 #: ../basics/zammad-glossary.rst:741
 msgid "Ticket hook"


### PR DESCRIPTION
Translations update from [Zammad-Translations](https://translations.zammad.org) for [Documentation/User Documentation (pre-release)](https://translations.zammad.org/projects/documentations/user-documentation-pre-release/).



Current translation status:

![Weblate translation status](https://translations.zammad.org/widget/documentations/user-documentation-pre-release/horizontal-auto.svg)