### PR TITLE
Translations update from Zammad-Translations

### DIFF
--- a/locale/cs/LC_MESSAGES/user-docs.po
+++ b/locale/cs/LC_MESSAGES/user-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-12 11:32+0200\n"
+"POT-Creation-Date: 2024-05-03 12:13+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -1262,7 +1262,7 @@ msgid ""
 msgstr ""
 
 #: ../snippets/ticket-state-type-circles.rst:4
-#: ../snippets/ticket-state-type-circles.rst:6 ../extras/knowledge-base.rst:211
+#: ../snippets/ticket-state-type-circles.rst:6 ../extras/knowledge-base.rst:214
 msgid "|grn|"
 msgstr ""
 
@@ -4008,7 +4008,7 @@ msgid "One or more open tickets"
 msgstr ""
 
 #: ../basics/zammad-glossary.rst:618
-msgid "Bootom section:"
+msgid "Bottom section:"
 msgstr ""
 
 #: ../basics/zammad-glossary.rst:622
@@ -4211,7 +4211,7 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:732
 msgid ""
-"The ticket of a ticket is different based on the channel it came in. You can "
+"The title of a ticket is different based on the channel it came in. You can "
 "find the title in the sidebar and in the top area in the ticket view. If the "
 "title is not very meaningful, you can change it by clicking on the title in "
 "a ticket view."
@@ -5214,23 +5214,7 @@ msgid ""
 "the information load for users that don't need the information."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:None
-msgid ""
-"Screencast showing the visibility option for categories for granular access "
-"permissions"
-msgstr ""
-
-#: ../extras/knowledge-base.rst:152
-msgid ""
-"In general, permissions of a parent category are inherited! If you want to "
-"grant edit permissions for a sub-category for a specific role for example, "
-"set the upper level to \"reader\" and the desired sub-category to "
-"\"editor\". The other way round is not possible (permissions can only be "
-"widened, not restricted). If you can't select permissions in the table, this "
-"could be the reason."
-msgstr ""
-
-#: ../extras/knowledge-base.rst:159
+#: ../extras/knowledge-base.rst:148
 msgid ""
 "The roles require **knowledge base reader permission**. Your administrator "
 "has to provide the relevant groups with reader permissions for the knowledge "
@@ -5239,18 +5223,38 @@ msgid ""
 "accordingly."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:166
+#: ../extras/knowledge-base.rst:None
+msgid ""
+"Screencast showing the visibility option for categories for granular access "
+"permissions"
+msgstr ""
+
+#: ../extras/knowledge-base.rst:158
+msgid ""
+"In general, permissions of a parent category are inherited! If you want to "
+"grant edit permissions for a sub-category for a specific role for example, "
+"set the upper level to \"reader\" and the desired sub-category to "
+"\"editor\". The same workflow applies to granting \"none\" permissions, "
+"effectively hiding a given sub-category. The other way round is not "
+"possible. A role with \"editor\" permission has full access to it's sub-"
+"categories, so it's pointless to limit it's permissions. \"None\" "
+"permissions also cannot be changed down the tree since there would be no "
+"path to access permitted sub-categories. If you can't select permissions in "
+"the table, this could be the reason."
+msgstr ""
+
+#: ../extras/knowledge-base.rst:169
 msgid "Be aware that public answers are always available!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:168
+#: ../extras/knowledge-base.rst:171
 msgid ""
 "Knowledge base reader permission means that affected users can see "
 "**internal answers**. This is a potential issue if you're not dividing "
 "carefully!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:173
+#: ../extras/knowledge-base.rst:176
 msgid "Editing Answers"
 msgstr ""
 
@@ -5258,7 +5262,7 @@ msgstr ""
 msgid "Edit answer"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:179
+#: ../extras/knowledge-base.rst:182
 msgid ""
 "The knowledge base editor comes equipped with the same **rich text editing "
 "capabilities** available in the Zammad ticket composer. That means you can "
@@ -5267,19 +5271,19 @@ msgid ""
 "attachments and links!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:203
+#: ../extras/knowledge-base.rst:206
 msgid "Different link types"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:187
+#: ../extras/knowledge-base.rst:190
 msgid "🔗 **Weblink**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:187
+#: ../extras/knowledge-base.rst:190
 msgid "URLs pointing to other websites."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:191
+#: ../extras/knowledge-base.rst:194
 msgid "💡 **Link Answer**"
 msgstr ""
 
@@ -5291,7 +5295,7 @@ msgstr ""
 msgid "(Will not break if destination URL changes.)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:195
+#: ../extras/knowledge-base.rst:198
 msgid "📋 **Linked Tickets**"
 msgstr ""
 
@@ -5303,7 +5307,7 @@ msgstr ""
 msgid "(Visible only in Preview and Edit Modes.)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:203
+#: ../extras/knowledge-base.rst:206
 msgid "🏷️ **Tags**"
 msgstr ""
 
@@ -5321,42 +5325,42 @@ msgstr ""
 msgid "Screencast showing tags on answers"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:228
+#: ../extras/knowledge-base.rst:231
 msgid "Visibility"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:206
+#: ../extras/knowledge-base.rst:209
 msgid ""
 "Set the **visibility** of an answer to control who can see an article, or "
 "schedule it to be published at a later date. Articles are **color-coded** "
 "according to their visibility:"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:211
+#: ../extras/knowledge-base.rst:214
 msgid "**Public** (visible to everyone)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:213
+#: ../extras/knowledge-base.rst:216
 msgid "|blu|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:213
+#: ../extras/knowledge-base.rst:216
 msgid "**Internal** (visible to agents & editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:215
+#: ../extras/knowledge-base.rst:218
 msgid "|gry|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:215
+#: ../extras/knowledge-base.rst:218
 msgid "**Draft/Scheduled/Archived** (visible to editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:231
+#: ../extras/knowledge-base.rst:234
 msgid "Using answers in ticket articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:233
+#: ../extras/knowledge-base.rst:236
 msgid ""
 "As soon as the knowledge base contains one or more answers, you can use "
 "these just like text modules. Instead of ``::`` just use ``??`` to open the "
@@ -5364,22 +5368,22 @@ msgid ""
 "all languages available."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:238
+#: ../extras/knowledge-base.rst:241
 msgid ""
 "If you've found what you've been looking for, simply hit your ENTER-Key to "
 "load the answer into the ticket article. This way you don't have to throw "
 "URLs at your customer and provide the answer right away."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:242
+#: ../extras/knowledge-base.rst:245
 msgid "Loading answers into articles *does not* replace article content."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:248
+#: ../extras/knowledge-base.rst:251
 msgid "Screencast showing how to insert KB answers into articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:248
+#: ../extras/knowledge-base.rst:251
 msgid "Use ``??`` to find and load knowledge base answers into ticket articles"
 msgstr ""
 
@@ -7084,16 +7088,4 @@ msgid ""
 "You are currently reading the Zammad user documentation. There are also :"
 "docs:`system </index.html>` and :admin-docs:`administration manuals </index."
 "html>` available."
-msgstr ""
-
-#: ../basics/zammad-glossary.rst:618
-msgid "Bottom section:"
-msgstr ""
-
-#: ../basics/zammad-glossary.rst:732
-msgid ""
-"The title of a ticket is different based on the channel it came in. You can "
-"find the title in the sidebar and in the top area in the ticket view. If the "
-"title is not very meaningful, you can change it by clicking on the title in "
-"a ticket view."
 msgstr ""

--- a/locale/da/LC_MESSAGES/user-docs.po
+++ b/locale/da/LC_MESSAGES/user-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-12 11:32+0200\n"
+"POT-Creation-Date: 2024-05-03 12:13+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -1262,7 +1262,7 @@ msgid ""
 msgstr ""
 
 #: ../snippets/ticket-state-type-circles.rst:4
-#: ../snippets/ticket-state-type-circles.rst:6 ../extras/knowledge-base.rst:211
+#: ../snippets/ticket-state-type-circles.rst:6 ../extras/knowledge-base.rst:214
 msgid "|grn|"
 msgstr ""
 
@@ -4008,7 +4008,7 @@ msgid "One or more open tickets"
 msgstr ""
 
 #: ../basics/zammad-glossary.rst:618
-msgid "Bootom section:"
+msgid "Bottom section:"
 msgstr ""
 
 #: ../basics/zammad-glossary.rst:622
@@ -4211,7 +4211,7 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:732
 msgid ""
-"The ticket of a ticket is different based on the channel it came in. You can "
+"The title of a ticket is different based on the channel it came in. You can "
 "find the title in the sidebar and in the top area in the ticket view. If the "
 "title is not very meaningful, you can change it by clicking on the title in "
 "a ticket view."
@@ -5214,23 +5214,7 @@ msgid ""
 "the information load for users that don't need the information."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:None
-msgid ""
-"Screencast showing the visibility option for categories for granular access "
-"permissions"
-msgstr ""
-
-#: ../extras/knowledge-base.rst:152
-msgid ""
-"In general, permissions of a parent category are inherited! If you want to "
-"grant edit permissions for a sub-category for a specific role for example, "
-"set the upper level to \"reader\" and the desired sub-category to "
-"\"editor\". The other way round is not possible (permissions can only be "
-"widened, not restricted). If you can't select permissions in the table, this "
-"could be the reason."
-msgstr ""
-
-#: ../extras/knowledge-base.rst:159
+#: ../extras/knowledge-base.rst:148
 msgid ""
 "The roles require **knowledge base reader permission**. Your administrator "
 "has to provide the relevant groups with reader permissions for the knowledge "
@@ -5239,18 +5223,38 @@ msgid ""
 "accordingly."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:166
+#: ../extras/knowledge-base.rst:None
+msgid ""
+"Screencast showing the visibility option for categories for granular access "
+"permissions"
+msgstr ""
+
+#: ../extras/knowledge-base.rst:158
+msgid ""
+"In general, permissions of a parent category are inherited! If you want to "
+"grant edit permissions for a sub-category for a specific role for example, "
+"set the upper level to \"reader\" and the desired sub-category to "
+"\"editor\". The same workflow applies to granting \"none\" permissions, "
+"effectively hiding a given sub-category. The other way round is not "
+"possible. A role with \"editor\" permission has full access to it's sub-"
+"categories, so it's pointless to limit it's permissions. \"None\" "
+"permissions also cannot be changed down the tree since there would be no "
+"path to access permitted sub-categories. If you can't select permissions in "
+"the table, this could be the reason."
+msgstr ""
+
+#: ../extras/knowledge-base.rst:169
 msgid "Be aware that public answers are always available!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:168
+#: ../extras/knowledge-base.rst:171
 msgid ""
 "Knowledge base reader permission means that affected users can see "
 "**internal answers**. This is a potential issue if you're not dividing "
 "carefully!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:173
+#: ../extras/knowledge-base.rst:176
 msgid "Editing Answers"
 msgstr ""
 
@@ -5258,7 +5262,7 @@ msgstr ""
 msgid "Edit answer"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:179
+#: ../extras/knowledge-base.rst:182
 msgid ""
 "The knowledge base editor comes equipped with the same **rich text editing "
 "capabilities** available in the Zammad ticket composer. That means you can "
@@ -5267,19 +5271,19 @@ msgid ""
 "attachments and links!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:203
+#: ../extras/knowledge-base.rst:206
 msgid "Different link types"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:187
+#: ../extras/knowledge-base.rst:190
 msgid "🔗 **Weblink**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:187
+#: ../extras/knowledge-base.rst:190
 msgid "URLs pointing to other websites."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:191
+#: ../extras/knowledge-base.rst:194
 msgid "💡 **Link Answer**"
 msgstr ""
 
@@ -5291,7 +5295,7 @@ msgstr ""
 msgid "(Will not break if destination URL changes.)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:195
+#: ../extras/knowledge-base.rst:198
 msgid "📋 **Linked Tickets**"
 msgstr ""
 
@@ -5303,7 +5307,7 @@ msgstr ""
 msgid "(Visible only in Preview and Edit Modes.)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:203
+#: ../extras/knowledge-base.rst:206
 msgid "🏷️ **Tags**"
 msgstr ""
 
@@ -5321,42 +5325,42 @@ msgstr ""
 msgid "Screencast showing tags on answers"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:228
+#: ../extras/knowledge-base.rst:231
 msgid "Visibility"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:206
+#: ../extras/knowledge-base.rst:209
 msgid ""
 "Set the **visibility** of an answer to control who can see an article, or "
 "schedule it to be published at a later date. Articles are **color-coded** "
 "according to their visibility:"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:211
+#: ../extras/knowledge-base.rst:214
 msgid "**Public** (visible to everyone)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:213
+#: ../extras/knowledge-base.rst:216
 msgid "|blu|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:213
+#: ../extras/knowledge-base.rst:216
 msgid "**Internal** (visible to agents & editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:215
+#: ../extras/knowledge-base.rst:218
 msgid "|gry|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:215
+#: ../extras/knowledge-base.rst:218
 msgid "**Draft/Scheduled/Archived** (visible to editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:231
+#: ../extras/knowledge-base.rst:234
 msgid "Using answers in ticket articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:233
+#: ../extras/knowledge-base.rst:236
 msgid ""
 "As soon as the knowledge base contains one or more answers, you can use "
 "these just like text modules. Instead of ``::`` just use ``??`` to open the "
@@ -5364,22 +5368,22 @@ msgid ""
 "all languages available."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:238
+#: ../extras/knowledge-base.rst:241
 msgid ""
 "If you've found what you've been looking for, simply hit your ENTER-Key to "
 "load the answer into the ticket article. This way you don't have to throw "
 "URLs at your customer and provide the answer right away."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:242
+#: ../extras/knowledge-base.rst:245
 msgid "Loading answers into articles *does not* replace article content."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:248
+#: ../extras/knowledge-base.rst:251
 msgid "Screencast showing how to insert KB answers into articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:248
+#: ../extras/knowledge-base.rst:251
 msgid "Use ``??`` to find and load knowledge base answers into ticket articles"
 msgstr ""
 
@@ -7084,16 +7088,4 @@ msgid ""
 "You are currently reading the Zammad user documentation. There are also :"
 "docs:`system </index.html>` and :admin-docs:`administration manuals </index."
 "html>` available."
-msgstr ""
-
-#: ../basics/zammad-glossary.rst:618
-msgid "Bottom section:"
-msgstr ""
-
-#: ../basics/zammad-glossary.rst:732
-msgid ""
-"The title of a ticket is different based on the channel it came in. You can "
-"find the title in the sidebar and in the top area in the ticket view. If the "
-"title is not very meaningful, you can change it by clicking on the title in "
-"a ticket view."
 msgstr ""

--- a/locale/de/LC_MESSAGES/user-docs.po
+++ b/locale/de/LC_MESSAGES/user-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-12 11:32+0200\n"
+"POT-Creation-Date: 2024-05-03 12:13+0200\n"
 "PO-Revision-Date: 2024-05-01 08:00+0000\n"
 "Last-Translator: Ralf Schmid <rsc@zammad.com>\n"
 "Language-Team: German <https://translations.zammad.org/projects/"
@@ -1442,7 +1442,7 @@ msgstr ""
 "**Farbcodes:**"
 
 #: ../snippets/ticket-state-type-circles.rst:4
-#: ../snippets/ticket-state-type-circles.rst:6 ../extras/knowledge-base.rst:211
+#: ../snippets/ticket-state-type-circles.rst:6 ../extras/knowledge-base.rst:214
 msgid "|grn|"
 msgstr "|grn|"
 
@@ -5001,7 +5001,7 @@ msgid "One or more open tickets"
 msgstr "Ein oder mehrere offene Tickets"
 
 #: ../basics/zammad-glossary.rst:618
-msgid "Bootom section:"
+msgid "Bottom section:"
 msgstr "Unterer Abschnitt:"
 
 #: ../basics/zammad-glossary.rst:622
@@ -5276,7 +5276,7 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:732
 msgid ""
-"The ticket of a ticket is different based on the channel it came in. You can "
+"The title of a ticket is different based on the channel it came in. You can "
 "find the title in the sidebar and in the top area in the ticket view. If the "
 "title is not very meaningful, you can change it by clicking on the title in "
 "a ticket view."
@@ -6537,32 +6537,7 @@ msgstr ""
 "Das erlaubt Ihnen beispielsweise Benutzergruppen nach Vertragstyp zu trennen "
 "um die Informationsflut auf das Relevante zu beschränken."
 
-#: ../extras/knowledge-base.rst:None
-msgid ""
-"Screencast showing the visibility option for categories for granular access "
-"permissions"
-msgstr ""
-"Bildschirmaufzeichnung zeigt die Sichtbarkeitseinstellungen für Kategorien "
-"für differenzierte Kategorieberechtigungen"
-
-#: ../extras/knowledge-base.rst:152
-msgid ""
-"In general, permissions of a parent category are inherited! If you want to "
-"grant edit permissions for a sub-category for a specific role for example, "
-"set the upper level to \"reader\" and the desired sub-category to "
-"\"editor\". The other way round is not possible (permissions can only be "
-"widened, not restricted). If you can't select permissions in the table, this "
-"could be the reason."
-msgstr ""
-"Im Allgemeinen werden die Rechte einer übergeordneten Kategorie vererbt! "
-"Wenn Sie z.B. einer bestimmten Rolle Bearbeitungsrechte für eine "
-"Unterkategorie erteilen wollen, setzen Sie die übergeordnete Ebene auf "
-"\"Reader\" und die gewünschte Unterkategorie auf \"Editor\". Der umgekehrte "
-"Weg ist nicht möglich (Berechtigungen können nur erweitert, nicht "
-"eingeschränkt werden). Wenn Sie in der Tabelle keine Berechtigungen "
-"auswählen können, könnte dies der Grund dafür sein."
-
-#: ../extras/knowledge-base.rst:159
+#: ../extras/knowledge-base.rst:148
 msgid ""
 "The roles require **knowledge base reader permission**. Your administrator "
 "has to provide the relevant groups with reader permissions for the knowledge "
@@ -6576,11 +6551,48 @@ msgstr ""
 "Administrator, die :admin-docs:`Rollenberechtigungen </manage/roles/agent-"
 "permissions.html>` entsprechend zu konfigurieren."
 
-#: ../extras/knowledge-base.rst:166
+#: ../extras/knowledge-base.rst:None
+msgid ""
+"Screencast showing the visibility option for categories for granular access "
+"permissions"
+msgstr ""
+"Bildschirmaufzeichnung zeigt die Sichtbarkeitseinstellungen für Kategorien "
+"für differenzierte Kategorieberechtigungen"
+
+#: ../extras/knowledge-base.rst:158
+#, fuzzy
+#| msgid ""
+#| "In general, permissions of a parent category are inherited! If you want "
+#| "to grant edit permissions for a sub-category for a specific role for "
+#| "example, set the upper level to \"reader\" and the desired sub-category "
+#| "to \"editor\". The other way round is not possible (permissions can only "
+#| "be widened, not restricted). If you can't select permissions in the "
+#| "table, this could be the reason."
+msgid ""
+"In general, permissions of a parent category are inherited! If you want to "
+"grant edit permissions for a sub-category for a specific role for example, "
+"set the upper level to \"reader\" and the desired sub-category to "
+"\"editor\". The same workflow applies to granting \"none\" permissions, "
+"effectively hiding a given sub-category. The other way round is not "
+"possible. A role with \"editor\" permission has full access to it's sub-"
+"categories, so it's pointless to limit it's permissions. \"None\" "
+"permissions also cannot be changed down the tree since there would be no "
+"path to access permitted sub-categories. If you can't select permissions in "
+"the table, this could be the reason."
+msgstr ""
+"Im Allgemeinen werden die Rechte einer übergeordneten Kategorie vererbt! "
+"Wenn Sie z.B. einer bestimmten Rolle Bearbeitungsrechte für eine "
+"Unterkategorie erteilen wollen, setzen Sie die übergeordnete Ebene auf "
+"\"Reader\" und die gewünschte Unterkategorie auf \"Editor\". Der umgekehrte "
+"Weg ist nicht möglich (Berechtigungen können nur erweitert, nicht "
+"eingeschränkt werden). Wenn Sie in der Tabelle keine Berechtigungen "
+"auswählen können, könnte dies der Grund dafür sein."
+
+#: ../extras/knowledge-base.rst:169
 msgid "Be aware that public answers are always available!"
 msgstr "Öffentliche Antworten sind immer verfügbar!"
 
-#: ../extras/knowledge-base.rst:168
+#: ../extras/knowledge-base.rst:171
 msgid ""
 "Knowledge base reader permission means that affected users can see "
 "**internal answers**. This is a potential issue if you're not dividing "
@@ -6590,7 +6602,7 @@ msgstr ""
 "Antworten**. Das ist ein mögliches Risiko falls Sie nicht umsichtig "
 "aufteilen!"
 
-#: ../extras/knowledge-base.rst:173
+#: ../extras/knowledge-base.rst:176
 msgid "Editing Answers"
 msgstr "Antworten bearbeiten"
 
@@ -6598,7 +6610,7 @@ msgstr "Antworten bearbeiten"
 msgid "Edit answer"
 msgstr "Antwort editieren"
 
-#: ../extras/knowledge-base.rst:179
+#: ../extras/knowledge-base.rst:182
 msgid ""
 "The knowledge base editor comes equipped with the same **rich text editing "
 "capabilities** available in the Zammad ticket composer. That means you can "
@@ -6613,19 +6625,19 @@ msgstr ""
 "Text-Formatierungen, Aufzählungszeichen und mehr einzubinden. Es können "
 "sogar Dateianhänge und Links hinzugefügt werden!"
 
-#: ../extras/knowledge-base.rst:203
+#: ../extras/knowledge-base.rst:206
 msgid "Different link types"
 msgstr "Verschiedene Link-Typen"
 
-#: ../extras/knowledge-base.rst:187
+#: ../extras/knowledge-base.rst:190
 msgid "🔗 **Weblink**"
 msgstr "🔗 **Weblink**"
 
-#: ../extras/knowledge-base.rst:187
+#: ../extras/knowledge-base.rst:190
 msgid "URLs pointing to other websites."
 msgstr "URLs, die auf andere Websites verweisen."
 
-#: ../extras/knowledge-base.rst:191
+#: ../extras/knowledge-base.rst:194
 msgid "💡 **Link Answer**"
 msgstr "💡 **Link zu einer Antwort**"
 
@@ -6637,7 +6649,7 @@ msgstr "Interne Verweise auf andere Antworten der Wissensdatenbank."
 msgid "(Will not break if destination URL changes.)"
 msgstr "(Wird nicht ungültig, wenn sich die Ziel-URL ändert.)"
 
-#: ../extras/knowledge-base.rst:195
+#: ../extras/knowledge-base.rst:198
 msgid "📋 **Linked Tickets**"
 msgstr "📋 **Verlinkte Tickets**"
 
@@ -6649,7 +6661,7 @@ msgstr "Interne Verweise auf Zammad-Tickets."
 msgid "(Visible only in Preview and Edit Modes.)"
 msgstr "(Nur im Vorschau- und Bearbeitungsmodus sichtbar.)"
 
-#: ../extras/knowledge-base.rst:203
+#: ../extras/knowledge-base.rst:206
 msgid "🏷️ **Tags**"
 msgstr "🏷️ **Schlagworte**"
 
@@ -6671,11 +6683,11 @@ msgstr ""
 msgid "Screencast showing tags on answers"
 msgstr "Screencast zeigt Tags an Antworten"
 
-#: ../extras/knowledge-base.rst:228
+#: ../extras/knowledge-base.rst:231
 msgid "Visibility"
 msgstr "Sichtbarkeit"
 
-#: ../extras/knowledge-base.rst:206
+#: ../extras/knowledge-base.rst:209
 msgid ""
 "Set the **visibility** of an answer to control who can see an article, or "
 "schedule it to be published at a later date. Articles are **color-coded** "
@@ -6686,31 +6698,31 @@ msgstr ""
 "späteren Zeitpunkt. Artikel sind entsprechend ihrer Sichtbarkeit **farblich "
 "gekennzeichnet**:"
 
-#: ../extras/knowledge-base.rst:211
+#: ../extras/knowledge-base.rst:214
 msgid "**Public** (visible to everyone)"
 msgstr "**Öffentlich** (für jeden sichtbar)"
 
-#: ../extras/knowledge-base.rst:213
+#: ../extras/knowledge-base.rst:216
 msgid "|blu|"
 msgstr "|blu|"
 
-#: ../extras/knowledge-base.rst:213
+#: ../extras/knowledge-base.rst:216
 msgid "**Internal** (visible to agents & editors only)"
 msgstr "**Intern** (nur sichtbar für Agenten und Bearbeiter)"
 
-#: ../extras/knowledge-base.rst:215
+#: ../extras/knowledge-base.rst:218
 msgid "|gry|"
 msgstr "|gry|"
 
-#: ../extras/knowledge-base.rst:215
+#: ../extras/knowledge-base.rst:218
 msgid "**Draft/Scheduled/Archived** (visible to editors only)"
 msgstr "**Entwurf / geplant / archiviert** (sichtbar nur für Bearbeiter)"
 
-#: ../extras/knowledge-base.rst:231
+#: ../extras/knowledge-base.rst:234
 msgid "Using answers in ticket articles"
 msgstr "Antworten in Ticket-Artikeln benutzen"
 
-#: ../extras/knowledge-base.rst:233
+#: ../extras/knowledge-base.rst:236
 msgid ""
 "As soon as the knowledge base contains one or more answers, you can use "
 "these just like text modules. Instead of ``::`` just use ``??`` to open the "
@@ -6722,7 +6734,7 @@ msgstr ""
 "``??`` um den Suchdialog zu öffnen. Die Suche sucht Volltext in dem Body und "
 "Titel aller verfügbaren Sprachen der Antwort."
 
-#: ../extras/knowledge-base.rst:238
+#: ../extras/knowledge-base.rst:241
 msgid ""
 "If you've found what you've been looking for, simply hit your ENTER-Key to "
 "load the answer into the ticket article. This way you don't have to throw "
@@ -6732,17 +6744,17 @@ msgstr ""
 "Taste, um die Antwort direkt in den Ticket-Artikel zu laden. So müssen Sie "
 "Ihrem Kunden keinen Link zuwerfen und liefern die Antwort direkt."
 
-#: ../extras/knowledge-base.rst:242
+#: ../extras/knowledge-base.rst:245
 msgid "Loading answers into articles *does not* replace article content."
 msgstr "Das Laden von Antworten in Artikel *ersetzt nicht* den Artikel-Inhalt."
 
-#: ../extras/knowledge-base.rst:248
+#: ../extras/knowledge-base.rst:251
 msgid "Screencast showing how to insert KB answers into articles"
 msgstr ""
 "Bildschirmaufzeichnung zeigt wie man Wissensdatenbankantworten in Artikeln "
 "einfügt"
 
-#: ../extras/knowledge-base.rst:248
+#: ../extras/knowledge-base.rst:251
 msgid "Use ``??`` to find and load knowledge base answers into ticket articles"
 msgstr ""
 "Benutzen Sie ``??`` um Knowledge Base Antworten zu finden und in Artikel zu "
@@ -8884,21 +8896,20 @@ msgstr ""
 "docs:`System- </index.html>` und :admin-docs:`Admin-Dokumentationen </index."
 "html>` verfügbar."
 
-#: ../basics/zammad-glossary.rst:618
-msgid "Bottom section:"
-msgstr "Unterer Abschnitt:"
+#~ msgid "Bootom section:"
+#~ msgstr "Unterer Abschnitt:"
 
-#: ../basics/zammad-glossary.rst:732
-msgid ""
-"The title of a ticket is different based on the channel it came in. You can "
-"find the title in the sidebar and in the top area in the ticket view. If the "
-"title is not very meaningful, you can change it by clicking on the title in "
-"a ticket view."
-msgstr ""
-"Der Titel eines Tickets unterscheidet sich je nach Kanal, in dem es erstellt "
-"wurde. Sie finden den Titel in der Seitenleiste und im oberen Bereich in der "
-"Ticket-Ansicht. Wenn der Titel nicht wirklich aussagekräftig ist, können Sie "
-"ihn ändern, indem Sie in einer Ticket-Ansicht auf den Titel klicken."
+#~ msgid ""
+#~ "The ticket of a ticket is different based on the channel it came in. You "
+#~ "can find the title in the sidebar and in the top area in the ticket view. "
+#~ "If the title is not very meaningful, you can change it by clicking on the "
+#~ "title in a ticket view."
+#~ msgstr ""
+#~ "Der Titel eines Tickets unterscheidet sich je nach Kanal, in dem es "
+#~ "erstellt wurde. Sie finden den Titel in der Seitenleiste und im oberen "
+#~ "Bereich in der Ticket-Ansicht. Wenn der Titel nicht wirklich "
+#~ "aussagekräftig ist, können Sie ihn ändern, indem Sie in einer Ticket-"
+#~ "Ansicht auf den Titel klicken."
 
 #~ msgid "Status"
 #~ msgstr "Status"

--- a/locale/es/LC_MESSAGES/user-docs.po
+++ b/locale/es/LC_MESSAGES/user-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-12 11:32+0200\n"
+"POT-Creation-Date: 2024-05-03 12:13+0200\n"
 "PO-Revision-Date: 2023-09-20 14:18+0000\n"
 "Last-Translator: Arturo <r2r0@posteo.de>\n"
 "Language-Team: Spanish <https://translations.zammad.org/projects/"
@@ -1363,7 +1363,7 @@ msgid ""
 msgstr ""
 
 #: ../snippets/ticket-state-type-circles.rst:4
-#: ../snippets/ticket-state-type-circles.rst:6 ../extras/knowledge-base.rst:211
+#: ../snippets/ticket-state-type-circles.rst:6 ../extras/knowledge-base.rst:214
 msgid "|grn|"
 msgstr ""
 
@@ -4114,7 +4114,7 @@ msgid "One or more open tickets"
 msgstr ""
 
 #: ../basics/zammad-glossary.rst:618
-msgid "Bootom section:"
+msgid "Bottom section:"
 msgstr ""
 
 #: ../basics/zammad-glossary.rst:622
@@ -4318,7 +4318,7 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:732
 msgid ""
-"The ticket of a ticket is different based on the channel it came in. You can "
+"The title of a ticket is different based on the channel it came in. You can "
 "find the title in the sidebar and in the top area in the ticket view. If the "
 "title is not very meaningful, you can change it by clicking on the title in "
 "a ticket view."
@@ -5323,23 +5323,7 @@ msgid ""
 "the information load for users that don't need the information."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:None
-msgid ""
-"Screencast showing the visibility option for categories for granular access "
-"permissions"
-msgstr ""
-
-#: ../extras/knowledge-base.rst:152
-msgid ""
-"In general, permissions of a parent category are inherited! If you want to "
-"grant edit permissions for a sub-category for a specific role for example, "
-"set the upper level to \"reader\" and the desired sub-category to "
-"\"editor\". The other way round is not possible (permissions can only be "
-"widened, not restricted). If you can't select permissions in the table, this "
-"could be the reason."
-msgstr ""
-
-#: ../extras/knowledge-base.rst:159
+#: ../extras/knowledge-base.rst:148
 msgid ""
 "The roles require **knowledge base reader permission**. Your administrator "
 "has to provide the relevant groups with reader permissions for the knowledge "
@@ -5348,18 +5332,38 @@ msgid ""
 "accordingly."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:166
+#: ../extras/knowledge-base.rst:None
+msgid ""
+"Screencast showing the visibility option for categories for granular access "
+"permissions"
+msgstr ""
+
+#: ../extras/knowledge-base.rst:158
+msgid ""
+"In general, permissions of a parent category are inherited! If you want to "
+"grant edit permissions for a sub-category for a specific role for example, "
+"set the upper level to \"reader\" and the desired sub-category to "
+"\"editor\". The same workflow applies to granting \"none\" permissions, "
+"effectively hiding a given sub-category. The other way round is not "
+"possible. A role with \"editor\" permission has full access to it's sub-"
+"categories, so it's pointless to limit it's permissions. \"None\" "
+"permissions also cannot be changed down the tree since there would be no "
+"path to access permitted sub-categories. If you can't select permissions in "
+"the table, this could be the reason."
+msgstr ""
+
+#: ../extras/knowledge-base.rst:169
 msgid "Be aware that public answers are always available!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:168
+#: ../extras/knowledge-base.rst:171
 msgid ""
 "Knowledge base reader permission means that affected users can see "
 "**internal answers**. This is a potential issue if you're not dividing "
 "carefully!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:173
+#: ../extras/knowledge-base.rst:176
 msgid "Editing Answers"
 msgstr ""
 
@@ -5367,7 +5371,7 @@ msgstr ""
 msgid "Edit answer"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:179
+#: ../extras/knowledge-base.rst:182
 msgid ""
 "The knowledge base editor comes equipped with the same **rich text editing "
 "capabilities** available in the Zammad ticket composer. That means you can "
@@ -5376,19 +5380,19 @@ msgid ""
 "attachments and links!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:203
+#: ../extras/knowledge-base.rst:206
 msgid "Different link types"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:187
+#: ../extras/knowledge-base.rst:190
 msgid "🔗 **Weblink**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:187
+#: ../extras/knowledge-base.rst:190
 msgid "URLs pointing to other websites."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:191
+#: ../extras/knowledge-base.rst:194
 msgid "💡 **Link Answer**"
 msgstr ""
 
@@ -5400,7 +5404,7 @@ msgstr ""
 msgid "(Will not break if destination URL changes.)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:195
+#: ../extras/knowledge-base.rst:198
 msgid "📋 **Linked Tickets**"
 msgstr ""
 
@@ -5412,7 +5416,7 @@ msgstr ""
 msgid "(Visible only in Preview and Edit Modes.)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:203
+#: ../extras/knowledge-base.rst:206
 msgid "🏷️ **Tags**"
 msgstr ""
 
@@ -5430,42 +5434,42 @@ msgstr ""
 msgid "Screencast showing tags on answers"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:228
+#: ../extras/knowledge-base.rst:231
 msgid "Visibility"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:206
+#: ../extras/knowledge-base.rst:209
 msgid ""
 "Set the **visibility** of an answer to control who can see an article, or "
 "schedule it to be published at a later date. Articles are **color-coded** "
 "according to their visibility:"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:211
+#: ../extras/knowledge-base.rst:214
 msgid "**Public** (visible to everyone)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:213
+#: ../extras/knowledge-base.rst:216
 msgid "|blu|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:213
+#: ../extras/knowledge-base.rst:216
 msgid "**Internal** (visible to agents & editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:215
+#: ../extras/knowledge-base.rst:218
 msgid "|gry|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:215
+#: ../extras/knowledge-base.rst:218
 msgid "**Draft/Scheduled/Archived** (visible to editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:231
+#: ../extras/knowledge-base.rst:234
 msgid "Using answers in ticket articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:233
+#: ../extras/knowledge-base.rst:236
 msgid ""
 "As soon as the knowledge base contains one or more answers, you can use "
 "these just like text modules. Instead of ``::`` just use ``??`` to open the "
@@ -5473,22 +5477,22 @@ msgid ""
 "all languages available."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:238
+#: ../extras/knowledge-base.rst:241
 msgid ""
 "If you've found what you've been looking for, simply hit your ENTER-Key to "
 "load the answer into the ticket article. This way you don't have to throw "
 "URLs at your customer and provide the answer right away."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:242
+#: ../extras/knowledge-base.rst:245
 msgid "Loading answers into articles *does not* replace article content."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:248
+#: ../extras/knowledge-base.rst:251
 msgid "Screencast showing how to insert KB answers into articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:248
+#: ../extras/knowledge-base.rst:251
 msgid "Use ``??`` to find and load knowledge base answers into ticket articles"
 msgstr ""
 
@@ -7229,18 +7233,6 @@ msgid ""
 "You are currently reading the Zammad user documentation. There are also :"
 "docs:`system </index.html>` and :admin-docs:`administration manuals </index."
 "html>` available."
-msgstr ""
-
-#: ../basics/zammad-glossary.rst:618
-msgid "Bottom section:"
-msgstr ""
-
-#: ../basics/zammad-glossary.rst:732
-msgid ""
-"The title of a ticket is different based on the channel it came in. You can "
-"find the title in the sidebar and in the top area in the ticket view. If the "
-"title is not very meaningful, you can change it by clicking on the title in "
-"a ticket view."
 msgstr ""
 
 #~ msgid "🤔 **How do I make macros?**"

--- a/locale/es_CO/LC_MESSAGES/user-docs.po
+++ b/locale/es_CO/LC_MESSAGES/user-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-12 11:32+0200\n"
+"POT-Creation-Date: 2024-05-03 12:13+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -1262,7 +1262,7 @@ msgid ""
 msgstr ""
 
 #: ../snippets/ticket-state-type-circles.rst:4
-#: ../snippets/ticket-state-type-circles.rst:6 ../extras/knowledge-base.rst:211
+#: ../snippets/ticket-state-type-circles.rst:6 ../extras/knowledge-base.rst:214
 msgid "|grn|"
 msgstr ""
 
@@ -4008,7 +4008,7 @@ msgid "One or more open tickets"
 msgstr ""
 
 #: ../basics/zammad-glossary.rst:618
-msgid "Bootom section:"
+msgid "Bottom section:"
 msgstr ""
 
 #: ../basics/zammad-glossary.rst:622
@@ -4211,7 +4211,7 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:732
 msgid ""
-"The ticket of a ticket is different based on the channel it came in. You can "
+"The title of a ticket is different based on the channel it came in. You can "
 "find the title in the sidebar and in the top area in the ticket view. If the "
 "title is not very meaningful, you can change it by clicking on the title in "
 "a ticket view."
@@ -5214,23 +5214,7 @@ msgid ""
 "the information load for users that don't need the information."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:None
-msgid ""
-"Screencast showing the visibility option for categories for granular access "
-"permissions"
-msgstr ""
-
-#: ../extras/knowledge-base.rst:152
-msgid ""
-"In general, permissions of a parent category are inherited! If you want to "
-"grant edit permissions for a sub-category for a specific role for example, "
-"set the upper level to \"reader\" and the desired sub-category to "
-"\"editor\". The other way round is not possible (permissions can only be "
-"widened, not restricted). If you can't select permissions in the table, this "
-"could be the reason."
-msgstr ""
-
-#: ../extras/knowledge-base.rst:159
+#: ../extras/knowledge-base.rst:148
 msgid ""
 "The roles require **knowledge base reader permission**. Your administrator "
 "has to provide the relevant groups with reader permissions for the knowledge "
@@ -5239,18 +5223,38 @@ msgid ""
 "accordingly."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:166
+#: ../extras/knowledge-base.rst:None
+msgid ""
+"Screencast showing the visibility option for categories for granular access "
+"permissions"
+msgstr ""
+
+#: ../extras/knowledge-base.rst:158
+msgid ""
+"In general, permissions of a parent category are inherited! If you want to "
+"grant edit permissions for a sub-category for a specific role for example, "
+"set the upper level to \"reader\" and the desired sub-category to "
+"\"editor\". The same workflow applies to granting \"none\" permissions, "
+"effectively hiding a given sub-category. The other way round is not "
+"possible. A role with \"editor\" permission has full access to it's sub-"
+"categories, so it's pointless to limit it's permissions. \"None\" "
+"permissions also cannot be changed down the tree since there would be no "
+"path to access permitted sub-categories. If you can't select permissions in "
+"the table, this could be the reason."
+msgstr ""
+
+#: ../extras/knowledge-base.rst:169
 msgid "Be aware that public answers are always available!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:168
+#: ../extras/knowledge-base.rst:171
 msgid ""
 "Knowledge base reader permission means that affected users can see "
 "**internal answers**. This is a potential issue if you're not dividing "
 "carefully!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:173
+#: ../extras/knowledge-base.rst:176
 msgid "Editing Answers"
 msgstr ""
 
@@ -5258,7 +5262,7 @@ msgstr ""
 msgid "Edit answer"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:179
+#: ../extras/knowledge-base.rst:182
 msgid ""
 "The knowledge base editor comes equipped with the same **rich text editing "
 "capabilities** available in the Zammad ticket composer. That means you can "
@@ -5267,19 +5271,19 @@ msgid ""
 "attachments and links!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:203
+#: ../extras/knowledge-base.rst:206
 msgid "Different link types"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:187
+#: ../extras/knowledge-base.rst:190
 msgid "🔗 **Weblink**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:187
+#: ../extras/knowledge-base.rst:190
 msgid "URLs pointing to other websites."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:191
+#: ../extras/knowledge-base.rst:194
 msgid "💡 **Link Answer**"
 msgstr ""
 
@@ -5291,7 +5295,7 @@ msgstr ""
 msgid "(Will not break if destination URL changes.)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:195
+#: ../extras/knowledge-base.rst:198
 msgid "📋 **Linked Tickets**"
 msgstr ""
 
@@ -5303,7 +5307,7 @@ msgstr ""
 msgid "(Visible only in Preview and Edit Modes.)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:203
+#: ../extras/knowledge-base.rst:206
 msgid "🏷️ **Tags**"
 msgstr ""
 
@@ -5321,42 +5325,42 @@ msgstr ""
 msgid "Screencast showing tags on answers"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:228
+#: ../extras/knowledge-base.rst:231
 msgid "Visibility"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:206
+#: ../extras/knowledge-base.rst:209
 msgid ""
 "Set the **visibility** of an answer to control who can see an article, or "
 "schedule it to be published at a later date. Articles are **color-coded** "
 "according to their visibility:"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:211
+#: ../extras/knowledge-base.rst:214
 msgid "**Public** (visible to everyone)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:213
+#: ../extras/knowledge-base.rst:216
 msgid "|blu|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:213
+#: ../extras/knowledge-base.rst:216
 msgid "**Internal** (visible to agents & editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:215
+#: ../extras/knowledge-base.rst:218
 msgid "|gry|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:215
+#: ../extras/knowledge-base.rst:218
 msgid "**Draft/Scheduled/Archived** (visible to editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:231
+#: ../extras/knowledge-base.rst:234
 msgid "Using answers in ticket articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:233
+#: ../extras/knowledge-base.rst:236
 msgid ""
 "As soon as the knowledge base contains one or more answers, you can use "
 "these just like text modules. Instead of ``::`` just use ``??`` to open the "
@@ -5364,22 +5368,22 @@ msgid ""
 "all languages available."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:238
+#: ../extras/knowledge-base.rst:241
 msgid ""
 "If you've found what you've been looking for, simply hit your ENTER-Key to "
 "load the answer into the ticket article. This way you don't have to throw "
 "URLs at your customer and provide the answer right away."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:242
+#: ../extras/knowledge-base.rst:245
 msgid "Loading answers into articles *does not* replace article content."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:248
+#: ../extras/knowledge-base.rst:251
 msgid "Screencast showing how to insert KB answers into articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:248
+#: ../extras/knowledge-base.rst:251
 msgid "Use ``??`` to find and load knowledge base answers into ticket articles"
 msgstr ""
 
@@ -7084,16 +7088,4 @@ msgid ""
 "You are currently reading the Zammad user documentation. There are also :"
 "docs:`system </index.html>` and :admin-docs:`administration manuals </index."
 "html>` available."
-msgstr ""
-
-#: ../basics/zammad-glossary.rst:618
-msgid "Bottom section:"
-msgstr ""
-
-#: ../basics/zammad-glossary.rst:732
-msgid ""
-"The title of a ticket is different based on the channel it came in. You can "
-"find the title in the sidebar and in the top area in the ticket view. If the "
-"title is not very meaningful, you can change it by clicking on the title in "
-"a ticket view."
 msgstr ""

--- a/locale/es_MX/LC_MESSAGES/user-docs.po
+++ b/locale/es_MX/LC_MESSAGES/user-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-12 11:32+0200\n"
+"POT-Creation-Date: 2024-05-03 12:13+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -1262,7 +1262,7 @@ msgid ""
 msgstr ""
 
 #: ../snippets/ticket-state-type-circles.rst:4
-#: ../snippets/ticket-state-type-circles.rst:6 ../extras/knowledge-base.rst:211
+#: ../snippets/ticket-state-type-circles.rst:6 ../extras/knowledge-base.rst:214
 msgid "|grn|"
 msgstr ""
 
@@ -4008,7 +4008,7 @@ msgid "One or more open tickets"
 msgstr ""
 
 #: ../basics/zammad-glossary.rst:618
-msgid "Bootom section:"
+msgid "Bottom section:"
 msgstr ""
 
 #: ../basics/zammad-glossary.rst:622
@@ -4211,7 +4211,7 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:732
 msgid ""
-"The ticket of a ticket is different based on the channel it came in. You can "
+"The title of a ticket is different based on the channel it came in. You can "
 "find the title in the sidebar and in the top area in the ticket view. If the "
 "title is not very meaningful, you can change it by clicking on the title in "
 "a ticket view."
@@ -5214,23 +5214,7 @@ msgid ""
 "the information load for users that don't need the information."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:None
-msgid ""
-"Screencast showing the visibility option for categories for granular access "
-"permissions"
-msgstr ""
-
-#: ../extras/knowledge-base.rst:152
-msgid ""
-"In general, permissions of a parent category are inherited! If you want to "
-"grant edit permissions for a sub-category for a specific role for example, "
-"set the upper level to \"reader\" and the desired sub-category to "
-"\"editor\". The other way round is not possible (permissions can only be "
-"widened, not restricted). If you can't select permissions in the table, this "
-"could be the reason."
-msgstr ""
-
-#: ../extras/knowledge-base.rst:159
+#: ../extras/knowledge-base.rst:148
 msgid ""
 "The roles require **knowledge base reader permission**. Your administrator "
 "has to provide the relevant groups with reader permissions for the knowledge "
@@ -5239,18 +5223,38 @@ msgid ""
 "accordingly."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:166
+#: ../extras/knowledge-base.rst:None
+msgid ""
+"Screencast showing the visibility option for categories for granular access "
+"permissions"
+msgstr ""
+
+#: ../extras/knowledge-base.rst:158
+msgid ""
+"In general, permissions of a parent category are inherited! If you want to "
+"grant edit permissions for a sub-category for a specific role for example, "
+"set the upper level to \"reader\" and the desired sub-category to "
+"\"editor\". The same workflow applies to granting \"none\" permissions, "
+"effectively hiding a given sub-category. The other way round is not "
+"possible. A role with \"editor\" permission has full access to it's sub-"
+"categories, so it's pointless to limit it's permissions. \"None\" "
+"permissions also cannot be changed down the tree since there would be no "
+"path to access permitted sub-categories. If you can't select permissions in "
+"the table, this could be the reason."
+msgstr ""
+
+#: ../extras/knowledge-base.rst:169
 msgid "Be aware that public answers are always available!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:168
+#: ../extras/knowledge-base.rst:171
 msgid ""
 "Knowledge base reader permission means that affected users can see "
 "**internal answers**. This is a potential issue if you're not dividing "
 "carefully!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:173
+#: ../extras/knowledge-base.rst:176
 msgid "Editing Answers"
 msgstr ""
 
@@ -5258,7 +5262,7 @@ msgstr ""
 msgid "Edit answer"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:179
+#: ../extras/knowledge-base.rst:182
 msgid ""
 "The knowledge base editor comes equipped with the same **rich text editing "
 "capabilities** available in the Zammad ticket composer. That means you can "
@@ -5267,19 +5271,19 @@ msgid ""
 "attachments and links!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:203
+#: ../extras/knowledge-base.rst:206
 msgid "Different link types"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:187
+#: ../extras/knowledge-base.rst:190
 msgid "🔗 **Weblink**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:187
+#: ../extras/knowledge-base.rst:190
 msgid "URLs pointing to other websites."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:191
+#: ../extras/knowledge-base.rst:194
 msgid "💡 **Link Answer**"
 msgstr ""
 
@@ -5291,7 +5295,7 @@ msgstr ""
 msgid "(Will not break if destination URL changes.)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:195
+#: ../extras/knowledge-base.rst:198
 msgid "📋 **Linked Tickets**"
 msgstr ""
 
@@ -5303,7 +5307,7 @@ msgstr ""
 msgid "(Visible only in Preview and Edit Modes.)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:203
+#: ../extras/knowledge-base.rst:206
 msgid "🏷️ **Tags**"
 msgstr ""
 
@@ -5321,42 +5325,42 @@ msgstr ""
 msgid "Screencast showing tags on answers"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:228
+#: ../extras/knowledge-base.rst:231
 msgid "Visibility"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:206
+#: ../extras/knowledge-base.rst:209
 msgid ""
 "Set the **visibility** of an answer to control who can see an article, or "
 "schedule it to be published at a later date. Articles are **color-coded** "
 "according to their visibility:"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:211
+#: ../extras/knowledge-base.rst:214
 msgid "**Public** (visible to everyone)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:213
+#: ../extras/knowledge-base.rst:216
 msgid "|blu|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:213
+#: ../extras/knowledge-base.rst:216
 msgid "**Internal** (visible to agents & editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:215
+#: ../extras/knowledge-base.rst:218
 msgid "|gry|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:215
+#: ../extras/knowledge-base.rst:218
 msgid "**Draft/Scheduled/Archived** (visible to editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:231
+#: ../extras/knowledge-base.rst:234
 msgid "Using answers in ticket articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:233
+#: ../extras/knowledge-base.rst:236
 msgid ""
 "As soon as the knowledge base contains one or more answers, you can use "
 "these just like text modules. Instead of ``::`` just use ``??`` to open the "
@@ -5364,22 +5368,22 @@ msgid ""
 "all languages available."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:238
+#: ../extras/knowledge-base.rst:241
 msgid ""
 "If you've found what you've been looking for, simply hit your ENTER-Key to "
 "load the answer into the ticket article. This way you don't have to throw "
 "URLs at your customer and provide the answer right away."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:242
+#: ../extras/knowledge-base.rst:245
 msgid "Loading answers into articles *does not* replace article content."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:248
+#: ../extras/knowledge-base.rst:251
 msgid "Screencast showing how to insert KB answers into articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:248
+#: ../extras/knowledge-base.rst:251
 msgid "Use ``??`` to find and load knowledge base answers into ticket articles"
 msgstr ""
 
@@ -7084,16 +7088,4 @@ msgid ""
 "You are currently reading the Zammad user documentation. There are also :"
 "docs:`system </index.html>` and :admin-docs:`administration manuals </index."
 "html>` available."
-msgstr ""
-
-#: ../basics/zammad-glossary.rst:618
-msgid "Bottom section:"
-msgstr ""
-
-#: ../basics/zammad-glossary.rst:732
-msgid ""
-"The title of a ticket is different based on the channel it came in. You can "
-"find the title in the sidebar and in the top area in the ticket view. If the "
-"title is not very meaningful, you can change it by clicking on the title in "
-"a ticket view."
 msgstr ""

--- a/locale/fa/LC_MESSAGES/user-docs.po
+++ b/locale/fa/LC_MESSAGES/user-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-12 11:32+0200\n"
+"POT-Creation-Date: 2024-05-03 12:13+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -1262,7 +1262,7 @@ msgid ""
 msgstr ""
 
 #: ../snippets/ticket-state-type-circles.rst:4
-#: ../snippets/ticket-state-type-circles.rst:6 ../extras/knowledge-base.rst:211
+#: ../snippets/ticket-state-type-circles.rst:6 ../extras/knowledge-base.rst:214
 msgid "|grn|"
 msgstr ""
 
@@ -4008,7 +4008,7 @@ msgid "One or more open tickets"
 msgstr ""
 
 #: ../basics/zammad-glossary.rst:618
-msgid "Bootom section:"
+msgid "Bottom section:"
 msgstr ""
 
 #: ../basics/zammad-glossary.rst:622
@@ -4211,7 +4211,7 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:732
 msgid ""
-"The ticket of a ticket is different based on the channel it came in. You can "
+"The title of a ticket is different based on the channel it came in. You can "
 "find the title in the sidebar and in the top area in the ticket view. If the "
 "title is not very meaningful, you can change it by clicking on the title in "
 "a ticket view."
@@ -5214,23 +5214,7 @@ msgid ""
 "the information load for users that don't need the information."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:None
-msgid ""
-"Screencast showing the visibility option for categories for granular access "
-"permissions"
-msgstr ""
-
-#: ../extras/knowledge-base.rst:152
-msgid ""
-"In general, permissions of a parent category are inherited! If you want to "
-"grant edit permissions for a sub-category for a specific role for example, "
-"set the upper level to \"reader\" and the desired sub-category to "
-"\"editor\". The other way round is not possible (permissions can only be "
-"widened, not restricted). If you can't select permissions in the table, this "
-"could be the reason."
-msgstr ""
-
-#: ../extras/knowledge-base.rst:159
+#: ../extras/knowledge-base.rst:148
 msgid ""
 "The roles require **knowledge base reader permission**. Your administrator "
 "has to provide the relevant groups with reader permissions for the knowledge "
@@ -5239,18 +5223,38 @@ msgid ""
 "accordingly."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:166
+#: ../extras/knowledge-base.rst:None
+msgid ""
+"Screencast showing the visibility option for categories for granular access "
+"permissions"
+msgstr ""
+
+#: ../extras/knowledge-base.rst:158
+msgid ""
+"In general, permissions of a parent category are inherited! If you want to "
+"grant edit permissions for a sub-category for a specific role for example, "
+"set the upper level to \"reader\" and the desired sub-category to "
+"\"editor\". The same workflow applies to granting \"none\" permissions, "
+"effectively hiding a given sub-category. The other way round is not "
+"possible. A role with \"editor\" permission has full access to it's sub-"
+"categories, so it's pointless to limit it's permissions. \"None\" "
+"permissions also cannot be changed down the tree since there would be no "
+"path to access permitted sub-categories. If you can't select permissions in "
+"the table, this could be the reason."
+msgstr ""
+
+#: ../extras/knowledge-base.rst:169
 msgid "Be aware that public answers are always available!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:168
+#: ../extras/knowledge-base.rst:171
 msgid ""
 "Knowledge base reader permission means that affected users can see "
 "**internal answers**. This is a potential issue if you're not dividing "
 "carefully!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:173
+#: ../extras/knowledge-base.rst:176
 msgid "Editing Answers"
 msgstr ""
 
@@ -5258,7 +5262,7 @@ msgstr ""
 msgid "Edit answer"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:179
+#: ../extras/knowledge-base.rst:182
 msgid ""
 "The knowledge base editor comes equipped with the same **rich text editing "
 "capabilities** available in the Zammad ticket composer. That means you can "
@@ -5267,19 +5271,19 @@ msgid ""
 "attachments and links!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:203
+#: ../extras/knowledge-base.rst:206
 msgid "Different link types"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:187
+#: ../extras/knowledge-base.rst:190
 msgid "🔗 **Weblink**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:187
+#: ../extras/knowledge-base.rst:190
 msgid "URLs pointing to other websites."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:191
+#: ../extras/knowledge-base.rst:194
 msgid "💡 **Link Answer**"
 msgstr ""
 
@@ -5291,7 +5295,7 @@ msgstr ""
 msgid "(Will not break if destination URL changes.)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:195
+#: ../extras/knowledge-base.rst:198
 msgid "📋 **Linked Tickets**"
 msgstr ""
 
@@ -5303,7 +5307,7 @@ msgstr ""
 msgid "(Visible only in Preview and Edit Modes.)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:203
+#: ../extras/knowledge-base.rst:206
 msgid "🏷️ **Tags**"
 msgstr ""
 
@@ -5321,42 +5325,42 @@ msgstr ""
 msgid "Screencast showing tags on answers"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:228
+#: ../extras/knowledge-base.rst:231
 msgid "Visibility"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:206
+#: ../extras/knowledge-base.rst:209
 msgid ""
 "Set the **visibility** of an answer to control who can see an article, or "
 "schedule it to be published at a later date. Articles are **color-coded** "
 "according to their visibility:"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:211
+#: ../extras/knowledge-base.rst:214
 msgid "**Public** (visible to everyone)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:213
+#: ../extras/knowledge-base.rst:216
 msgid "|blu|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:213
+#: ../extras/knowledge-base.rst:216
 msgid "**Internal** (visible to agents & editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:215
+#: ../extras/knowledge-base.rst:218
 msgid "|gry|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:215
+#: ../extras/knowledge-base.rst:218
 msgid "**Draft/Scheduled/Archived** (visible to editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:231
+#: ../extras/knowledge-base.rst:234
 msgid "Using answers in ticket articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:233
+#: ../extras/knowledge-base.rst:236
 msgid ""
 "As soon as the knowledge base contains one or more answers, you can use "
 "these just like text modules. Instead of ``::`` just use ``??`` to open the "
@@ -5364,22 +5368,22 @@ msgid ""
 "all languages available."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:238
+#: ../extras/knowledge-base.rst:241
 msgid ""
 "If you've found what you've been looking for, simply hit your ENTER-Key to "
 "load the answer into the ticket article. This way you don't have to throw "
 "URLs at your customer and provide the answer right away."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:242
+#: ../extras/knowledge-base.rst:245
 msgid "Loading answers into articles *does not* replace article content."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:248
+#: ../extras/knowledge-base.rst:251
 msgid "Screencast showing how to insert KB answers into articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:248
+#: ../extras/knowledge-base.rst:251
 msgid "Use ``??`` to find and load knowledge base answers into ticket articles"
 msgstr ""
 
@@ -7084,16 +7088,4 @@ msgid ""
 "You are currently reading the Zammad user documentation. There are also :"
 "docs:`system </index.html>` and :admin-docs:`administration manuals </index."
 "html>` available."
-msgstr ""
-
-#: ../basics/zammad-glossary.rst:618
-msgid "Bottom section:"
-msgstr ""
-
-#: ../basics/zammad-glossary.rst:732
-msgid ""
-"The title of a ticket is different based on the channel it came in. You can "
-"find the title in the sidebar and in the top area in the ticket view. If the "
-"title is not very meaningful, you can change it by clicking on the title in "
-"a ticket view."
 msgstr ""

--- a/locale/fr/LC_MESSAGES/user-docs.po
+++ b/locale/fr/LC_MESSAGES/user-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-12 11:32+0200\n"
+"POT-Creation-Date: 2024-05-03 12:13+0200\n"
 "PO-Revision-Date: 2024-04-24 23:00+0000\n"
 "Last-Translator: Misha <misha@association-enoria.org>\n"
 "Language-Team: French <https://translations.zammad.org/projects/"
@@ -240,7 +240,8 @@ msgstr "Traductions"
 
 #: ../advanced/keyboard-shortcuts.rst:67
 msgid "Note: you need to have admin permissions to use this."
-msgstr "Note : vous devez avoir les permissions administrateur pour faire cela."
+msgstr ""
+"Note : vous devez avoir les permissions administrateur pour faire cela."
 
 #: ../advanced/keyboard-shortcuts.rst:72
 msgid "``shift`` + ``ctrl`` + ``t``"
@@ -320,7 +321,8 @@ msgstr "``??``"
 
 #: ../advanced/keyboard-shortcuts.rst:97
 msgid "Insert knowledge base article (while composing an article)"
-msgstr "Insérer un article de la base de connaissance (en composant un article)"
+msgstr ""
+"Insérer un article de la base de connaissance (en composant un article)"
 
 #: ../advanced/keyboard-shortcuts.rst:98
 msgid "``@@``"
@@ -549,8 +551,8 @@ msgid ""
 "The simplest way to apply a macro is to select it from the **Update ^** "
 "submenu in the Ticket View:"
 msgstr ""
-"Pour appliquer simplement une macro est de la choisir depuis le sous-menu **"
-"Mise à jour ^** disponible lors de la visualisation d'un ticket :"
+"Pour appliquer simplement une macro est de la choisir depuis le sous-menu "
+"**Mise à jour ^** disponible lors de la visualisation d'un ticket :"
 
 #: ../advanced/macros.rst:None
 msgid "Screencast showing how to run a macro within a ticket view."
@@ -998,7 +1000,8 @@ msgstr "first_response_at : horodatage"
 
 #: ../advanced/search.rst:84
 msgid "first_response_in_min: integer (business min till first response)"
-msgstr "first_response_in_min : entier (minutes ouvrées avant première réponse)"
+msgstr ""
+"first_response_in_min : entier (minutes ouvrées avant première réponse)"
 
 #: ../advanced/search.rst:85
 msgid "close_at: timestamp"
@@ -1101,8 +1104,8 @@ msgid ""
 "in two </advanced/ticket-actions/split>`, then assign each ticket to its "
 "respective “group” (department)."
 msgstr ""
-"Si un ticket concerne vraiment deux problèmes différents, vous pouvez :doc:`"
-"le diviser en deux</advanced/ticket-actions/split>`, et assigner ensuite "
+"Si un ticket concerne vraiment deux problèmes différents, vous pouvez :doc:"
+"`le diviser en deux</advanced/ticket-actions/split>`, et assigner ensuite "
 "chaque ticket dans son \"groupe\" respectif (département)."
 
 #: ../advanced/suggested-workflows.rst:16
@@ -1258,8 +1261,8 @@ msgstr ""
 #: ../advanced/suggested-workflows.rst:90
 msgid "**Can't see a ticket, in which a colleague @mentioned you?**"
 msgstr ""
-"**Vous ne pouvez pas voir un ticket, dans lequel un collègue vous à @"
-"mentionné ?**"
+"**Vous ne pouvez pas voir un ticket, dans lequel un collègue vous à "
+"@mentionné ?**"
 
 #: ../advanced/suggested-workflows.rst:92
 msgid ""
@@ -1429,7 +1432,7 @@ msgstr ""
 "**codés par couleur :**"
 
 #: ../snippets/ticket-state-type-circles.rst:4
-#: ../snippets/ticket-state-type-circles.rst:6 ../extras/knowledge-base.rst:211
+#: ../snippets/ticket-state-type-circles.rst:6 ../extras/knowledge-base.rst:214
 msgid "|grn|"
 msgstr "|grn|"
 
@@ -1597,8 +1600,8 @@ msgstr "Modules de texte manquants ?"
 #: ../advanced/text-modules.rst:23
 msgid "You noticed that some text modules don't always appear?"
 msgstr ""
-"Comment se fait-il que certains modules de texte n'apparaissent pas toujours "
-"?"
+"Comment se fait-il que certains modules de texte n'apparaissent pas "
+"toujours ?"
 
 #: ../advanced/text-modules.rst:25
 msgid ""
@@ -3183,8 +3186,8 @@ msgid ""
 "⏱️ Tickets in a *pending* state do not accumulate time toward their SLA "
 "limits."
 msgstr ""
-"⏱️ Les tickets dans un état d'**attente** ne consomme pas de temps dans "
-"leurs limites du SLA."
+"⏱️ Les tickets dans un état d'**attente** ne consomme pas de temps dans leurs "
+"limites du SLA."
 
 #: ../basics/service-ticket/settings/state.rst:47
 #, fuzzy
@@ -4476,8 +4479,8 @@ msgid "One or more open tickets"
 msgstr "Parcourir les tickets"
 
 #: ../basics/zammad-glossary.rst:618
-msgid "Bootom section:"
-msgstr ""
+msgid "Bottom section:"
+msgstr "Notifications :"
 
 #: ../basics/zammad-glossary.rst:622
 #, fuzzy
@@ -4683,7 +4686,7 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:732
 msgid ""
-"The ticket of a ticket is different based on the channel it came in. You can "
+"The title of a ticket is different based on the channel it came in. You can "
 "find the title in the sidebar and in the top area in the ticket view. If the "
 "title is not very meaningful, you can change it by clicking on the title in "
 "a ticket view."
@@ -4899,9 +4902,10 @@ msgid ""
 "👤 Click on unrecognized numbers to **create a new customer** or maybe "
 "entries to **update an existing customer**."
 msgstr ""
-"👤 Cliquez sur les numéros non reconnus dans le journal d'appels pour **"
-"créer un nouvel client et ticket**. (Les numéros de téléphones non reconnus "
-"ne peuvent pas être ajoutés de cette manière à des clients existants.)."
+"👤 Cliquez sur les numéros non reconnus dans le journal d'appels pour "
+"**créer un nouvel client et ticket**. (Les numéros de téléphones non "
+"reconnus ne peuvent pas être ajoutés de cette manière à des clients "
+"existants.)."
 
 #: ../extras/caller-log.rst:67
 msgid ""
@@ -5783,23 +5787,7 @@ msgid ""
 "the information load for users that don't need the information."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:None
-msgid ""
-"Screencast showing the visibility option for categories for granular access "
-"permissions"
-msgstr ""
-
-#: ../extras/knowledge-base.rst:152
-msgid ""
-"In general, permissions of a parent category are inherited! If you want to "
-"grant edit permissions for a sub-category for a specific role for example, "
-"set the upper level to \"reader\" and the desired sub-category to "
-"\"editor\". The other way round is not possible (permissions can only be "
-"widened, not restricted). If you can't select permissions in the table, this "
-"could be the reason."
-msgstr ""
-
-#: ../extras/knowledge-base.rst:159
+#: ../extras/knowledge-base.rst:148
 msgid ""
 "The roles require **knowledge base reader permission**. Your administrator "
 "has to provide the relevant groups with reader permissions for the knowledge "
@@ -5808,18 +5796,38 @@ msgid ""
 "accordingly."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:166
+#: ../extras/knowledge-base.rst:None
+msgid ""
+"Screencast showing the visibility option for categories for granular access "
+"permissions"
+msgstr ""
+
+#: ../extras/knowledge-base.rst:158
+msgid ""
+"In general, permissions of a parent category are inherited! If you want to "
+"grant edit permissions for a sub-category for a specific role for example, "
+"set the upper level to \"reader\" and the desired sub-category to "
+"\"editor\". The same workflow applies to granting \"none\" permissions, "
+"effectively hiding a given sub-category. The other way round is not "
+"possible. A role with \"editor\" permission has full access to it's sub-"
+"categories, so it's pointless to limit it's permissions. \"None\" "
+"permissions also cannot be changed down the tree since there would be no "
+"path to access permitted sub-categories. If you can't select permissions in "
+"the table, this could be the reason."
+msgstr ""
+
+#: ../extras/knowledge-base.rst:169
 msgid "Be aware that public answers are always available!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:168
+#: ../extras/knowledge-base.rst:171
 msgid ""
 "Knowledge base reader permission means that affected users can see "
 "**internal answers**. This is a potential issue if you're not dividing "
 "carefully!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:173
+#: ../extras/knowledge-base.rst:176
 msgid "Editing Answers"
 msgstr "Éditer des réponses"
 
@@ -5827,7 +5835,7 @@ msgstr "Éditer des réponses"
 msgid "Edit answer"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:179
+#: ../extras/knowledge-base.rst:182
 msgid ""
 "The knowledge base editor comes equipped with the same **rich text editing "
 "capabilities** available in the Zammad ticket composer. That means you can "
@@ -5842,19 +5850,19 @@ msgstr ""
 "listes à puce, et plus encore. Vous pouvez même ajouter des pièces jointes "
 "et des liens!"
 
-#: ../extras/knowledge-base.rst:203
+#: ../extras/knowledge-base.rst:206
 msgid "Different link types"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:187
+#: ../extras/knowledge-base.rst:190
 msgid "🔗 **Weblink**"
 msgstr "🔗 **liens web**"
 
-#: ../extras/knowledge-base.rst:187
+#: ../extras/knowledge-base.rst:190
 msgid "URLs pointing to other websites."
 msgstr "URLs qui pointent vers d'autres sites web."
 
-#: ../extras/knowledge-base.rst:191
+#: ../extras/knowledge-base.rst:194
 msgid "💡 **Link Answer**"
 msgstr "💡 **Lien réponse**"
 
@@ -5866,7 +5874,7 @@ msgstr "Références internes vers d'autres réponses de la base de connaissance
 msgid "(Will not break if destination URL changes.)"
 msgstr "(qui ne casseront pas si l'URL de destination change.)"
 
-#: ../extras/knowledge-base.rst:195
+#: ../extras/knowledge-base.rst:198
 msgid "📋 **Linked Tickets**"
 msgstr "📋 **Tickets liés**"
 
@@ -5878,7 +5886,7 @@ msgstr "Références internes vers des tickets Zammad."
 msgid "(Visible only in Preview and Edit Modes.)"
 msgstr "(visibles seulement dans les modes prévisualisation et édition.)"
 
-#: ../extras/knowledge-base.rst:203
+#: ../extras/knowledge-base.rst:206
 msgid "🏷️ **Tags**"
 msgstr ""
 
@@ -5896,11 +5904,11 @@ msgstr ""
 msgid "Screencast showing tags on answers"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:228
+#: ../extras/knowledge-base.rst:231
 msgid "Visibility"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:206
+#: ../extras/knowledge-base.rst:209
 #, fuzzy
 msgid ""
 "Set the **visibility** of an answer to control who can see an article, or "
@@ -5911,31 +5919,31 @@ msgstr ""
 "un article ou planifier sa publication à une date ultérieure. Les articles "
 "ont des **codes couleurs** en fonction de leur visibilité:"
 
-#: ../extras/knowledge-base.rst:211
+#: ../extras/knowledge-base.rst:214
 msgid "**Public** (visible to everyone)"
 msgstr "**Public** (visible pour tout le monde)"
 
-#: ../extras/knowledge-base.rst:213
+#: ../extras/knowledge-base.rst:216
 msgid "|blu|"
 msgstr "|blu|"
 
-#: ../extras/knowledge-base.rst:213
+#: ../extras/knowledge-base.rst:216
 msgid "**Internal** (visible to agents & editors only)"
 msgstr "**Interne** (visible seulement pour les opérateurs & rédacteurs)"
 
-#: ../extras/knowledge-base.rst:215
+#: ../extras/knowledge-base.rst:218
 msgid "|gry|"
 msgstr "|gry|"
 
-#: ../extras/knowledge-base.rst:215
+#: ../extras/knowledge-base.rst:218
 msgid "**Draft/Scheduled/Archived** (visible to editors only)"
 msgstr "**Brouillon/planifié/archivé** (visible seulement pour les rédacteurs)"
 
-#: ../extras/knowledge-base.rst:231
+#: ../extras/knowledge-base.rst:234
 msgid "Using answers in ticket articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:233
+#: ../extras/knowledge-base.rst:236
 msgid ""
 "As soon as the knowledge base contains one or more answers, you can use "
 "these just like text modules. Instead of ``::`` just use ``??`` to open the "
@@ -5943,22 +5951,22 @@ msgid ""
 "all languages available."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:238
+#: ../extras/knowledge-base.rst:241
 msgid ""
 "If you've found what you've been looking for, simply hit your ENTER-Key to "
 "load the answer into the ticket article. This way you don't have to throw "
 "URLs at your customer and provide the answer right away."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:242
+#: ../extras/knowledge-base.rst:245
 msgid "Loading answers into articles *does not* replace article content."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:248
+#: ../extras/knowledge-base.rst:251
 msgid "Screencast showing how to insert KB answers into articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:248
+#: ../extras/knowledge-base.rst:251
 msgid "Use ``??`` to find and load knowledge base answers into ticket articles"
 msgstr ""
 
@@ -7753,18 +7761,6 @@ msgid ""
 "You are currently reading the Zammad user documentation. There are also :"
 "docs:`system </index.html>` and :admin-docs:`administration manuals </index."
 "html>` available."
-msgstr ""
-
-#: ../basics/zammad-glossary.rst:618
-msgid "Bottom section:"
-msgstr "Notifications :"
-
-#: ../basics/zammad-glossary.rst:732
-msgid ""
-"The title of a ticket is different based on the channel it came in. You can "
-"find the title in the sidebar and in the top area in the ticket view. If the "
-"title is not very meaningful, you can change it by clicking on the title in "
-"a ticket view."
 msgstr ""
 
 #, fuzzy

--- a/locale/fr_CA/LC_MESSAGES/user-docs.po
+++ b/locale/fr_CA/LC_MESSAGES/user-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-12 11:32+0200\n"
+"POT-Creation-Date: 2024-05-03 12:13+0200\n"
 "PO-Revision-Date: 2022-04-16 15:56+0000\n"
 "Last-Translator: Marcel Herrguth <github@thehomeofanime.de>\n"
 "Language-Team: French (Canada) <https://translations.zammad.org/projects/"
@@ -1348,7 +1348,7 @@ msgid ""
 msgstr ":doc:`Ticket states ` sont **color-coded:**"
 
 #: ../snippets/ticket-state-type-circles.rst:4
-#: ../snippets/ticket-state-type-circles.rst:6 ../extras/knowledge-base.rst:211
+#: ../snippets/ticket-state-type-circles.rst:6 ../extras/knowledge-base.rst:214
 msgid "|grn|"
 msgstr "|grn|"
 
@@ -4189,7 +4189,7 @@ msgid "One or more open tickets"
 msgstr "Recherche de billets"
 
 #: ../basics/zammad-glossary.rst:618
-msgid "Bootom section:"
+msgid "Bottom section:"
 msgstr ""
 
 #: ../basics/zammad-glossary.rst:622
@@ -4395,7 +4395,7 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:732
 msgid ""
-"The ticket of a ticket is different based on the channel it came in. You can "
+"The title of a ticket is different based on the channel it came in. You can "
 "find the title in the sidebar and in the top area in the ticket view. If the "
 "title is not very meaningful, you can change it by clicking on the title in "
 "a ticket view."
@@ -5404,23 +5404,7 @@ msgid ""
 "the information load for users that don't need the information."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:None
-msgid ""
-"Screencast showing the visibility option for categories for granular access "
-"permissions"
-msgstr ""
-
-#: ../extras/knowledge-base.rst:152
-msgid ""
-"In general, permissions of a parent category are inherited! If you want to "
-"grant edit permissions for a sub-category for a specific role for example, "
-"set the upper level to \"reader\" and the desired sub-category to "
-"\"editor\". The other way round is not possible (permissions can only be "
-"widened, not restricted). If you can't select permissions in the table, this "
-"could be the reason."
-msgstr ""
-
-#: ../extras/knowledge-base.rst:159
+#: ../extras/knowledge-base.rst:148
 msgid ""
 "The roles require **knowledge base reader permission**. Your administrator "
 "has to provide the relevant groups with reader permissions for the knowledge "
@@ -5429,18 +5413,38 @@ msgid ""
 "accordingly."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:166
+#: ../extras/knowledge-base.rst:None
+msgid ""
+"Screencast showing the visibility option for categories for granular access "
+"permissions"
+msgstr ""
+
+#: ../extras/knowledge-base.rst:158
+msgid ""
+"In general, permissions of a parent category are inherited! If you want to "
+"grant edit permissions for a sub-category for a specific role for example, "
+"set the upper level to \"reader\" and the desired sub-category to "
+"\"editor\". The same workflow applies to granting \"none\" permissions, "
+"effectively hiding a given sub-category. The other way round is not "
+"possible. A role with \"editor\" permission has full access to it's sub-"
+"categories, so it's pointless to limit it's permissions. \"None\" "
+"permissions also cannot be changed down the tree since there would be no "
+"path to access permitted sub-categories. If you can't select permissions in "
+"the table, this could be the reason."
+msgstr ""
+
+#: ../extras/knowledge-base.rst:169
 msgid "Be aware that public answers are always available!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:168
+#: ../extras/knowledge-base.rst:171
 msgid ""
 "Knowledge base reader permission means that affected users can see "
 "**internal answers**. This is a potential issue if you're not dividing "
 "carefully!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:173
+#: ../extras/knowledge-base.rst:176
 msgid "Editing Answers"
 msgstr ""
 
@@ -5448,7 +5452,7 @@ msgstr ""
 msgid "Edit answer"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:179
+#: ../extras/knowledge-base.rst:182
 msgid ""
 "The knowledge base editor comes equipped with the same **rich text editing "
 "capabilities** available in the Zammad ticket composer. That means you can "
@@ -5457,19 +5461,19 @@ msgid ""
 "attachments and links!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:203
+#: ../extras/knowledge-base.rst:206
 msgid "Different link types"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:187
+#: ../extras/knowledge-base.rst:190
 msgid "🔗 **Weblink**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:187
+#: ../extras/knowledge-base.rst:190
 msgid "URLs pointing to other websites."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:191
+#: ../extras/knowledge-base.rst:194
 msgid "💡 **Link Answer**"
 msgstr ""
 
@@ -5481,7 +5485,7 @@ msgstr ""
 msgid "(Will not break if destination URL changes.)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:195
+#: ../extras/knowledge-base.rst:198
 msgid "📋 **Linked Tickets**"
 msgstr ""
 
@@ -5493,7 +5497,7 @@ msgstr ""
 msgid "(Visible only in Preview and Edit Modes.)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:203
+#: ../extras/knowledge-base.rst:206
 msgid "🏷️ **Tags**"
 msgstr ""
 
@@ -5511,42 +5515,42 @@ msgstr ""
 msgid "Screencast showing tags on answers"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:228
+#: ../extras/knowledge-base.rst:231
 msgid "Visibility"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:206
+#: ../extras/knowledge-base.rst:209
 msgid ""
 "Set the **visibility** of an answer to control who can see an article, or "
 "schedule it to be published at a later date. Articles are **color-coded** "
 "according to their visibility:"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:211
+#: ../extras/knowledge-base.rst:214
 msgid "**Public** (visible to everyone)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:213
+#: ../extras/knowledge-base.rst:216
 msgid "|blu|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:213
+#: ../extras/knowledge-base.rst:216
 msgid "**Internal** (visible to agents & editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:215
+#: ../extras/knowledge-base.rst:218
 msgid "|gry|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:215
+#: ../extras/knowledge-base.rst:218
 msgid "**Draft/Scheduled/Archived** (visible to editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:231
+#: ../extras/knowledge-base.rst:234
 msgid "Using answers in ticket articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:233
+#: ../extras/knowledge-base.rst:236
 msgid ""
 "As soon as the knowledge base contains one or more answers, you can use "
 "these just like text modules. Instead of ``::`` just use ``??`` to open the "
@@ -5554,22 +5558,22 @@ msgid ""
 "all languages available."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:238
+#: ../extras/knowledge-base.rst:241
 msgid ""
 "If you've found what you've been looking for, simply hit your ENTER-Key to "
 "load the answer into the ticket article. This way you don't have to throw "
 "URLs at your customer and provide the answer right away."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:242
+#: ../extras/knowledge-base.rst:245
 msgid "Loading answers into articles *does not* replace article content."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:248
+#: ../extras/knowledge-base.rst:251
 msgid "Screencast showing how to insert KB answers into articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:248
+#: ../extras/knowledge-base.rst:251
 msgid "Use ``??`` to find and load knowledge base answers into ticket articles"
 msgstr ""
 
@@ -7297,18 +7301,6 @@ msgid ""
 "You are currently reading the Zammad user documentation. There are also :"
 "docs:`system </index.html>` and :admin-docs:`administration manuals </index."
 "html>` available."
-msgstr ""
-
-#: ../basics/zammad-glossary.rst:618
-msgid "Bottom section:"
-msgstr ""
-
-#: ../basics/zammad-glossary.rst:732
-msgid ""
-"The title of a ticket is different based on the channel it came in. You can "
-"find the title in the sidebar and in the top area in the ticket view. If the "
-"title is not very meaningful, you can change it by clicking on the title in "
-"a ticket view."
 msgstr ""
 
 #~ msgid ""

--- a/locale/hr/LC_MESSAGES/user-docs.po
+++ b/locale/hr/LC_MESSAGES/user-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-12 11:32+0200\n"
+"POT-Creation-Date: 2024-05-03 12:13+0200\n"
 "PO-Revision-Date: 2022-06-15 14:40+0000\n"
 "Last-Translator: Ivan Perovic <ip@zammad.com>\n"
 "Language-Team: Croatian <https://translations.zammad.org/projects/"
@@ -1365,7 +1365,7 @@ msgid ""
 msgstr ""
 
 #: ../snippets/ticket-state-type-circles.rst:4
-#: ../snippets/ticket-state-type-circles.rst:6 ../extras/knowledge-base.rst:211
+#: ../snippets/ticket-state-type-circles.rst:6 ../extras/knowledge-base.rst:214
 msgid "|grn|"
 msgstr ""
 
@@ -4113,7 +4113,7 @@ msgid "One or more open tickets"
 msgstr ""
 
 #: ../basics/zammad-glossary.rst:618
-msgid "Bootom section:"
+msgid "Bottom section:"
 msgstr ""
 
 #: ../basics/zammad-glossary.rst:622
@@ -4316,7 +4316,7 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:732
 msgid ""
-"The ticket of a ticket is different based on the channel it came in. You can "
+"The title of a ticket is different based on the channel it came in. You can "
 "find the title in the sidebar and in the top area in the ticket view. If the "
 "title is not very meaningful, you can change it by clicking on the title in "
 "a ticket view."
@@ -5322,23 +5322,7 @@ msgid ""
 "the information load for users that don't need the information."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:None
-msgid ""
-"Screencast showing the visibility option for categories for granular access "
-"permissions"
-msgstr ""
-
-#: ../extras/knowledge-base.rst:152
-msgid ""
-"In general, permissions of a parent category are inherited! If you want to "
-"grant edit permissions for a sub-category for a specific role for example, "
-"set the upper level to \"reader\" and the desired sub-category to "
-"\"editor\". The other way round is not possible (permissions can only be "
-"widened, not restricted). If you can't select permissions in the table, this "
-"could be the reason."
-msgstr ""
-
-#: ../extras/knowledge-base.rst:159
+#: ../extras/knowledge-base.rst:148
 msgid ""
 "The roles require **knowledge base reader permission**. Your administrator "
 "has to provide the relevant groups with reader permissions for the knowledge "
@@ -5347,18 +5331,38 @@ msgid ""
 "accordingly."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:166
+#: ../extras/knowledge-base.rst:None
+msgid ""
+"Screencast showing the visibility option for categories for granular access "
+"permissions"
+msgstr ""
+
+#: ../extras/knowledge-base.rst:158
+msgid ""
+"In general, permissions of a parent category are inherited! If you want to "
+"grant edit permissions for a sub-category for a specific role for example, "
+"set the upper level to \"reader\" and the desired sub-category to "
+"\"editor\". The same workflow applies to granting \"none\" permissions, "
+"effectively hiding a given sub-category. The other way round is not "
+"possible. A role with \"editor\" permission has full access to it's sub-"
+"categories, so it's pointless to limit it's permissions. \"None\" "
+"permissions also cannot be changed down the tree since there would be no "
+"path to access permitted sub-categories. If you can't select permissions in "
+"the table, this could be the reason."
+msgstr ""
+
+#: ../extras/knowledge-base.rst:169
 msgid "Be aware that public answers are always available!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:168
+#: ../extras/knowledge-base.rst:171
 msgid ""
 "Knowledge base reader permission means that affected users can see "
 "**internal answers**. This is a potential issue if you're not dividing "
 "carefully!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:173
+#: ../extras/knowledge-base.rst:176
 msgid "Editing Answers"
 msgstr ""
 
@@ -5366,7 +5370,7 @@ msgstr ""
 msgid "Edit answer"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:179
+#: ../extras/knowledge-base.rst:182
 msgid ""
 "The knowledge base editor comes equipped with the same **rich text editing "
 "capabilities** available in the Zammad ticket composer. That means you can "
@@ -5375,19 +5379,19 @@ msgid ""
 "attachments and links!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:203
+#: ../extras/knowledge-base.rst:206
 msgid "Different link types"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:187
+#: ../extras/knowledge-base.rst:190
 msgid "🔗 **Weblink**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:187
+#: ../extras/knowledge-base.rst:190
 msgid "URLs pointing to other websites."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:191
+#: ../extras/knowledge-base.rst:194
 msgid "💡 **Link Answer**"
 msgstr ""
 
@@ -5399,7 +5403,7 @@ msgstr ""
 msgid "(Will not break if destination URL changes.)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:195
+#: ../extras/knowledge-base.rst:198
 msgid "📋 **Linked Tickets**"
 msgstr ""
 
@@ -5411,7 +5415,7 @@ msgstr ""
 msgid "(Visible only in Preview and Edit Modes.)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:203
+#: ../extras/knowledge-base.rst:206
 msgid "🏷️ **Tags**"
 msgstr ""
 
@@ -5429,42 +5433,42 @@ msgstr ""
 msgid "Screencast showing tags on answers"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:228
+#: ../extras/knowledge-base.rst:231
 msgid "Visibility"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:206
+#: ../extras/knowledge-base.rst:209
 msgid ""
 "Set the **visibility** of an answer to control who can see an article, or "
 "schedule it to be published at a later date. Articles are **color-coded** "
 "according to their visibility:"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:211
+#: ../extras/knowledge-base.rst:214
 msgid "**Public** (visible to everyone)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:213
+#: ../extras/knowledge-base.rst:216
 msgid "|blu|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:213
+#: ../extras/knowledge-base.rst:216
 msgid "**Internal** (visible to agents & editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:215
+#: ../extras/knowledge-base.rst:218
 msgid "|gry|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:215
+#: ../extras/knowledge-base.rst:218
 msgid "**Draft/Scheduled/Archived** (visible to editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:231
+#: ../extras/knowledge-base.rst:234
 msgid "Using answers in ticket articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:233
+#: ../extras/knowledge-base.rst:236
 msgid ""
 "As soon as the knowledge base contains one or more answers, you can use "
 "these just like text modules. Instead of ``::`` just use ``??`` to open the "
@@ -5472,22 +5476,22 @@ msgid ""
 "all languages available."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:238
+#: ../extras/knowledge-base.rst:241
 msgid ""
 "If you've found what you've been looking for, simply hit your ENTER-Key to "
 "load the answer into the ticket article. This way you don't have to throw "
 "URLs at your customer and provide the answer right away."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:242
+#: ../extras/knowledge-base.rst:245
 msgid "Loading answers into articles *does not* replace article content."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:248
+#: ../extras/knowledge-base.rst:251
 msgid "Screencast showing how to insert KB answers into articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:248
+#: ../extras/knowledge-base.rst:251
 msgid "Use ``??`` to find and load knowledge base answers into ticket articles"
 msgstr ""
 
@@ -7204,18 +7208,6 @@ msgid ""
 "You are currently reading the Zammad user documentation. There are also :"
 "docs:`system </index.html>` and :admin-docs:`administration manuals </index."
 "html>` available."
-msgstr ""
-
-#: ../basics/zammad-glossary.rst:618
-msgid "Bottom section:"
-msgstr ""
-
-#: ../basics/zammad-glossary.rst:732
-msgid ""
-"The title of a ticket is different based on the channel it came in. You can "
-"find the title in the sidebar and in the top area in the ticket view. If the "
-"title is not very meaningful, you can change it by clicking on the title in "
-"a ticket view."
 msgstr ""
 
 #~ msgid "🤔 **How do I make macros?**"

--- a/locale/hu/LC_MESSAGES/user-docs.po
+++ b/locale/hu/LC_MESSAGES/user-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-12 11:32+0200\n"
+"POT-Creation-Date: 2024-05-03 12:13+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -1262,7 +1262,7 @@ msgid ""
 msgstr ""
 
 #: ../snippets/ticket-state-type-circles.rst:4
-#: ../snippets/ticket-state-type-circles.rst:6 ../extras/knowledge-base.rst:211
+#: ../snippets/ticket-state-type-circles.rst:6 ../extras/knowledge-base.rst:214
 msgid "|grn|"
 msgstr ""
 
@@ -4008,7 +4008,7 @@ msgid "One or more open tickets"
 msgstr ""
 
 #: ../basics/zammad-glossary.rst:618
-msgid "Bootom section:"
+msgid "Bottom section:"
 msgstr ""
 
 #: ../basics/zammad-glossary.rst:622
@@ -4211,7 +4211,7 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:732
 msgid ""
-"The ticket of a ticket is different based on the channel it came in. You can "
+"The title of a ticket is different based on the channel it came in. You can "
 "find the title in the sidebar and in the top area in the ticket view. If the "
 "title is not very meaningful, you can change it by clicking on the title in "
 "a ticket view."
@@ -5214,23 +5214,7 @@ msgid ""
 "the information load for users that don't need the information."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:None
-msgid ""
-"Screencast showing the visibility option for categories for granular access "
-"permissions"
-msgstr ""
-
-#: ../extras/knowledge-base.rst:152
-msgid ""
-"In general, permissions of a parent category are inherited! If you want to "
-"grant edit permissions for a sub-category for a specific role for example, "
-"set the upper level to \"reader\" and the desired sub-category to "
-"\"editor\". The other way round is not possible (permissions can only be "
-"widened, not restricted). If you can't select permissions in the table, this "
-"could be the reason."
-msgstr ""
-
-#: ../extras/knowledge-base.rst:159
+#: ../extras/knowledge-base.rst:148
 msgid ""
 "The roles require **knowledge base reader permission**. Your administrator "
 "has to provide the relevant groups with reader permissions for the knowledge "
@@ -5239,18 +5223,38 @@ msgid ""
 "accordingly."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:166
+#: ../extras/knowledge-base.rst:None
+msgid ""
+"Screencast showing the visibility option for categories for granular access "
+"permissions"
+msgstr ""
+
+#: ../extras/knowledge-base.rst:158
+msgid ""
+"In general, permissions of a parent category are inherited! If you want to "
+"grant edit permissions for a sub-category for a specific role for example, "
+"set the upper level to \"reader\" and the desired sub-category to "
+"\"editor\". The same workflow applies to granting \"none\" permissions, "
+"effectively hiding a given sub-category. The other way round is not "
+"possible. A role with \"editor\" permission has full access to it's sub-"
+"categories, so it's pointless to limit it's permissions. \"None\" "
+"permissions also cannot be changed down the tree since there would be no "
+"path to access permitted sub-categories. If you can't select permissions in "
+"the table, this could be the reason."
+msgstr ""
+
+#: ../extras/knowledge-base.rst:169
 msgid "Be aware that public answers are always available!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:168
+#: ../extras/knowledge-base.rst:171
 msgid ""
 "Knowledge base reader permission means that affected users can see "
 "**internal answers**. This is a potential issue if you're not dividing "
 "carefully!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:173
+#: ../extras/knowledge-base.rst:176
 msgid "Editing Answers"
 msgstr ""
 
@@ -5258,7 +5262,7 @@ msgstr ""
 msgid "Edit answer"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:179
+#: ../extras/knowledge-base.rst:182
 msgid ""
 "The knowledge base editor comes equipped with the same **rich text editing "
 "capabilities** available in the Zammad ticket composer. That means you can "
@@ -5267,19 +5271,19 @@ msgid ""
 "attachments and links!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:203
+#: ../extras/knowledge-base.rst:206
 msgid "Different link types"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:187
+#: ../extras/knowledge-base.rst:190
 msgid "🔗 **Weblink**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:187
+#: ../extras/knowledge-base.rst:190
 msgid "URLs pointing to other websites."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:191
+#: ../extras/knowledge-base.rst:194
 msgid "💡 **Link Answer**"
 msgstr ""
 
@@ -5291,7 +5295,7 @@ msgstr ""
 msgid "(Will not break if destination URL changes.)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:195
+#: ../extras/knowledge-base.rst:198
 msgid "📋 **Linked Tickets**"
 msgstr ""
 
@@ -5303,7 +5307,7 @@ msgstr ""
 msgid "(Visible only in Preview and Edit Modes.)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:203
+#: ../extras/knowledge-base.rst:206
 msgid "🏷️ **Tags**"
 msgstr ""
 
@@ -5321,42 +5325,42 @@ msgstr ""
 msgid "Screencast showing tags on answers"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:228
+#: ../extras/knowledge-base.rst:231
 msgid "Visibility"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:206
+#: ../extras/knowledge-base.rst:209
 msgid ""
 "Set the **visibility** of an answer to control who can see an article, or "
 "schedule it to be published at a later date. Articles are **color-coded** "
 "according to their visibility:"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:211
+#: ../extras/knowledge-base.rst:214
 msgid "**Public** (visible to everyone)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:213
+#: ../extras/knowledge-base.rst:216
 msgid "|blu|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:213
+#: ../extras/knowledge-base.rst:216
 msgid "**Internal** (visible to agents & editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:215
+#: ../extras/knowledge-base.rst:218
 msgid "|gry|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:215
+#: ../extras/knowledge-base.rst:218
 msgid "**Draft/Scheduled/Archived** (visible to editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:231
+#: ../extras/knowledge-base.rst:234
 msgid "Using answers in ticket articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:233
+#: ../extras/knowledge-base.rst:236
 msgid ""
 "As soon as the knowledge base contains one or more answers, you can use "
 "these just like text modules. Instead of ``::`` just use ``??`` to open the "
@@ -5364,22 +5368,22 @@ msgid ""
 "all languages available."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:238
+#: ../extras/knowledge-base.rst:241
 msgid ""
 "If you've found what you've been looking for, simply hit your ENTER-Key to "
 "load the answer into the ticket article. This way you don't have to throw "
 "URLs at your customer and provide the answer right away."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:242
+#: ../extras/knowledge-base.rst:245
 msgid "Loading answers into articles *does not* replace article content."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:248
+#: ../extras/knowledge-base.rst:251
 msgid "Screencast showing how to insert KB answers into articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:248
+#: ../extras/knowledge-base.rst:251
 msgid "Use ``??`` to find and load knowledge base answers into ticket articles"
 msgstr ""
 
@@ -7084,16 +7088,4 @@ msgid ""
 "You are currently reading the Zammad user documentation. There are also :"
 "docs:`system </index.html>` and :admin-docs:`administration manuals </index."
 "html>` available."
-msgstr ""
-
-#: ../basics/zammad-glossary.rst:618
-msgid "Bottom section:"
-msgstr ""
-
-#: ../basics/zammad-glossary.rst:732
-msgid ""
-"The title of a ticket is different based on the channel it came in. You can "
-"find the title in the sidebar and in the top area in the ticket view. If the "
-"title is not very meaningful, you can change it by clicking on the title in "
-"a ticket view."
 msgstr ""

--- a/locale/it/LC_MESSAGES/user-docs.po
+++ b/locale/it/LC_MESSAGES/user-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-12 11:32+0200\n"
+"POT-Creation-Date: 2024-05-03 12:13+0200\n"
 "PO-Revision-Date: 2023-07-28 09:18+0000\n"
 "Last-Translator: crnfpp <crnfpp@unife.it>\n"
 "Language-Team: Italian <https://translations.zammad.org/projects/"
@@ -1318,7 +1318,7 @@ msgstr ""
 "**identificato da un colore:**"
 
 #: ../snippets/ticket-state-type-circles.rst:4
-#: ../snippets/ticket-state-type-circles.rst:6 ../extras/knowledge-base.rst:211
+#: ../snippets/ticket-state-type-circles.rst:6 ../extras/knowledge-base.rst:214
 msgid "|grn|"
 msgstr "|grn|"
 
@@ -4326,7 +4326,7 @@ msgid "One or more open tickets"
 msgstr "Navigazione dei Ticket"
 
 #: ../basics/zammad-glossary.rst:618
-msgid "Bootom section:"
+msgid "Bottom section:"
 msgstr ""
 
 #: ../basics/zammad-glossary.rst:622
@@ -4531,7 +4531,7 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:732
 msgid ""
-"The ticket of a ticket is different based on the channel it came in. You can "
+"The title of a ticket is different based on the channel it came in. You can "
 "find the title in the sidebar and in the top area in the ticket view. If the "
 "title is not very meaningful, you can change it by clicking on the title in "
 "a ticket view."
@@ -5581,23 +5581,7 @@ msgid ""
 "the information load for users that don't need the information."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:None
-msgid ""
-"Screencast showing the visibility option for categories for granular access "
-"permissions"
-msgstr ""
-
-#: ../extras/knowledge-base.rst:152
-msgid ""
-"In general, permissions of a parent category are inherited! If you want to "
-"grant edit permissions for a sub-category for a specific role for example, "
-"set the upper level to \"reader\" and the desired sub-category to "
-"\"editor\". The other way round is not possible (permissions can only be "
-"widened, not restricted). If you can't select permissions in the table, this "
-"could be the reason."
-msgstr ""
-
-#: ../extras/knowledge-base.rst:159
+#: ../extras/knowledge-base.rst:148
 msgid ""
 "The roles require **knowledge base reader permission**. Your administrator "
 "has to provide the relevant groups with reader permissions for the knowledge "
@@ -5606,18 +5590,38 @@ msgid ""
 "accordingly."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:166
+#: ../extras/knowledge-base.rst:None
+msgid ""
+"Screencast showing the visibility option for categories for granular access "
+"permissions"
+msgstr ""
+
+#: ../extras/knowledge-base.rst:158
+msgid ""
+"In general, permissions of a parent category are inherited! If you want to "
+"grant edit permissions for a sub-category for a specific role for example, "
+"set the upper level to \"reader\" and the desired sub-category to "
+"\"editor\". The same workflow applies to granting \"none\" permissions, "
+"effectively hiding a given sub-category. The other way round is not "
+"possible. A role with \"editor\" permission has full access to it's sub-"
+"categories, so it's pointless to limit it's permissions. \"None\" "
+"permissions also cannot be changed down the tree since there would be no "
+"path to access permitted sub-categories. If you can't select permissions in "
+"the table, this could be the reason."
+msgstr ""
+
+#: ../extras/knowledge-base.rst:169
 msgid "Be aware that public answers are always available!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:168
+#: ../extras/knowledge-base.rst:171
 msgid ""
 "Knowledge base reader permission means that affected users can see "
 "**internal answers**. This is a potential issue if you're not dividing "
 "carefully!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:173
+#: ../extras/knowledge-base.rst:176
 msgid "Editing Answers"
 msgstr ""
 
@@ -5625,7 +5629,7 @@ msgstr ""
 msgid "Edit answer"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:179
+#: ../extras/knowledge-base.rst:182
 msgid ""
 "The knowledge base editor comes equipped with the same **rich text editing "
 "capabilities** available in the Zammad ticket composer. That means you can "
@@ -5634,19 +5638,19 @@ msgid ""
 "attachments and links!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:203
+#: ../extras/knowledge-base.rst:206
 msgid "Different link types"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:187
+#: ../extras/knowledge-base.rst:190
 msgid "🔗 **Weblink**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:187
+#: ../extras/knowledge-base.rst:190
 msgid "URLs pointing to other websites."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:191
+#: ../extras/knowledge-base.rst:194
 msgid "💡 **Link Answer**"
 msgstr ""
 
@@ -5658,7 +5662,7 @@ msgstr ""
 msgid "(Will not break if destination URL changes.)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:195
+#: ../extras/knowledge-base.rst:198
 msgid "📋 **Linked Tickets**"
 msgstr ""
 
@@ -5670,7 +5674,7 @@ msgstr ""
 msgid "(Visible only in Preview and Edit Modes.)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:203
+#: ../extras/knowledge-base.rst:206
 msgid "🏷️ **Tags**"
 msgstr ""
 
@@ -5688,42 +5692,42 @@ msgstr ""
 msgid "Screencast showing tags on answers"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:228
+#: ../extras/knowledge-base.rst:231
 msgid "Visibility"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:206
+#: ../extras/knowledge-base.rst:209
 msgid ""
 "Set the **visibility** of an answer to control who can see an article, or "
 "schedule it to be published at a later date. Articles are **color-coded** "
 "according to their visibility:"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:211
+#: ../extras/knowledge-base.rst:214
 msgid "**Public** (visible to everyone)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:213
+#: ../extras/knowledge-base.rst:216
 msgid "|blu|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:213
+#: ../extras/knowledge-base.rst:216
 msgid "**Internal** (visible to agents & editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:215
+#: ../extras/knowledge-base.rst:218
 msgid "|gry|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:215
+#: ../extras/knowledge-base.rst:218
 msgid "**Draft/Scheduled/Archived** (visible to editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:231
+#: ../extras/knowledge-base.rst:234
 msgid "Using answers in ticket articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:233
+#: ../extras/knowledge-base.rst:236
 msgid ""
 "As soon as the knowledge base contains one or more answers, you can use "
 "these just like text modules. Instead of ``::`` just use ``??`` to open the "
@@ -5731,22 +5735,22 @@ msgid ""
 "all languages available."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:238
+#: ../extras/knowledge-base.rst:241
 msgid ""
 "If you've found what you've been looking for, simply hit your ENTER-Key to "
 "load the answer into the ticket article. This way you don't have to throw "
 "URLs at your customer and provide the answer right away."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:242
+#: ../extras/knowledge-base.rst:245
 msgid "Loading answers into articles *does not* replace article content."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:248
+#: ../extras/knowledge-base.rst:251
 msgid "Screencast showing how to insert KB answers into articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:248
+#: ../extras/knowledge-base.rst:251
 msgid "Use ``??`` to find and load knowledge base answers into ticket articles"
 msgstr ""
 
@@ -7492,18 +7496,6 @@ msgid ""
 "You are currently reading the Zammad user documentation. There are also :"
 "docs:`system </index.html>` and :admin-docs:`administration manuals </index."
 "html>` available."
-msgstr ""
-
-#: ../basics/zammad-glossary.rst:618
-msgid "Bottom section:"
-msgstr ""
-
-#: ../basics/zammad-glossary.rst:732
-msgid ""
-"The title of a ticket is different based on the channel it came in. You can "
-"find the title in the sidebar and in the top area in the ticket view. If the "
-"title is not very meaningful, you can change it by clicking on the title in "
-"a ticket view."
 msgstr ""
 
 #, fuzzy

--- a/locale/nl/LC_MESSAGES/user-docs.po
+++ b/locale/nl/LC_MESSAGES/user-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-12 11:32+0200\n"
+"POT-Creation-Date: 2024-05-03 12:13+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -1262,7 +1262,7 @@ msgid ""
 msgstr ""
 
 #: ../snippets/ticket-state-type-circles.rst:4
-#: ../snippets/ticket-state-type-circles.rst:6 ../extras/knowledge-base.rst:211
+#: ../snippets/ticket-state-type-circles.rst:6 ../extras/knowledge-base.rst:214
 msgid "|grn|"
 msgstr ""
 
@@ -4008,7 +4008,7 @@ msgid "One or more open tickets"
 msgstr ""
 
 #: ../basics/zammad-glossary.rst:618
-msgid "Bootom section:"
+msgid "Bottom section:"
 msgstr ""
 
 #: ../basics/zammad-glossary.rst:622
@@ -4211,7 +4211,7 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:732
 msgid ""
-"The ticket of a ticket is different based on the channel it came in. You can "
+"The title of a ticket is different based on the channel it came in. You can "
 "find the title in the sidebar and in the top area in the ticket view. If the "
 "title is not very meaningful, you can change it by clicking on the title in "
 "a ticket view."
@@ -5214,23 +5214,7 @@ msgid ""
 "the information load for users that don't need the information."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:None
-msgid ""
-"Screencast showing the visibility option for categories for granular access "
-"permissions"
-msgstr ""
-
-#: ../extras/knowledge-base.rst:152
-msgid ""
-"In general, permissions of a parent category are inherited! If you want to "
-"grant edit permissions for a sub-category for a specific role for example, "
-"set the upper level to \"reader\" and the desired sub-category to "
-"\"editor\". The other way round is not possible (permissions can only be "
-"widened, not restricted). If you can't select permissions in the table, this "
-"could be the reason."
-msgstr ""
-
-#: ../extras/knowledge-base.rst:159
+#: ../extras/knowledge-base.rst:148
 msgid ""
 "The roles require **knowledge base reader permission**. Your administrator "
 "has to provide the relevant groups with reader permissions for the knowledge "
@@ -5239,18 +5223,38 @@ msgid ""
 "accordingly."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:166
+#: ../extras/knowledge-base.rst:None
+msgid ""
+"Screencast showing the visibility option for categories for granular access "
+"permissions"
+msgstr ""
+
+#: ../extras/knowledge-base.rst:158
+msgid ""
+"In general, permissions of a parent category are inherited! If you want to "
+"grant edit permissions for a sub-category for a specific role for example, "
+"set the upper level to \"reader\" and the desired sub-category to "
+"\"editor\". The same workflow applies to granting \"none\" permissions, "
+"effectively hiding a given sub-category. The other way round is not "
+"possible. A role with \"editor\" permission has full access to it's sub-"
+"categories, so it's pointless to limit it's permissions. \"None\" "
+"permissions also cannot be changed down the tree since there would be no "
+"path to access permitted sub-categories. If you can't select permissions in "
+"the table, this could be the reason."
+msgstr ""
+
+#: ../extras/knowledge-base.rst:169
 msgid "Be aware that public answers are always available!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:168
+#: ../extras/knowledge-base.rst:171
 msgid ""
 "Knowledge base reader permission means that affected users can see "
 "**internal answers**. This is a potential issue if you're not dividing "
 "carefully!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:173
+#: ../extras/knowledge-base.rst:176
 msgid "Editing Answers"
 msgstr ""
 
@@ -5258,7 +5262,7 @@ msgstr ""
 msgid "Edit answer"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:179
+#: ../extras/knowledge-base.rst:182
 msgid ""
 "The knowledge base editor comes equipped with the same **rich text editing "
 "capabilities** available in the Zammad ticket composer. That means you can "
@@ -5267,19 +5271,19 @@ msgid ""
 "attachments and links!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:203
+#: ../extras/knowledge-base.rst:206
 msgid "Different link types"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:187
+#: ../extras/knowledge-base.rst:190
 msgid "🔗 **Weblink**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:187
+#: ../extras/knowledge-base.rst:190
 msgid "URLs pointing to other websites."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:191
+#: ../extras/knowledge-base.rst:194
 msgid "💡 **Link Answer**"
 msgstr ""
 
@@ -5291,7 +5295,7 @@ msgstr ""
 msgid "(Will not break if destination URL changes.)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:195
+#: ../extras/knowledge-base.rst:198
 msgid "📋 **Linked Tickets**"
 msgstr ""
 
@@ -5303,7 +5307,7 @@ msgstr ""
 msgid "(Visible only in Preview and Edit Modes.)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:203
+#: ../extras/knowledge-base.rst:206
 msgid "🏷️ **Tags**"
 msgstr ""
 
@@ -5321,42 +5325,42 @@ msgstr ""
 msgid "Screencast showing tags on answers"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:228
+#: ../extras/knowledge-base.rst:231
 msgid "Visibility"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:206
+#: ../extras/knowledge-base.rst:209
 msgid ""
 "Set the **visibility** of an answer to control who can see an article, or "
 "schedule it to be published at a later date. Articles are **color-coded** "
 "according to their visibility:"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:211
+#: ../extras/knowledge-base.rst:214
 msgid "**Public** (visible to everyone)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:213
+#: ../extras/knowledge-base.rst:216
 msgid "|blu|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:213
+#: ../extras/knowledge-base.rst:216
 msgid "**Internal** (visible to agents & editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:215
+#: ../extras/knowledge-base.rst:218
 msgid "|gry|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:215
+#: ../extras/knowledge-base.rst:218
 msgid "**Draft/Scheduled/Archived** (visible to editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:231
+#: ../extras/knowledge-base.rst:234
 msgid "Using answers in ticket articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:233
+#: ../extras/knowledge-base.rst:236
 msgid ""
 "As soon as the knowledge base contains one or more answers, you can use "
 "these just like text modules. Instead of ``::`` just use ``??`` to open the "
@@ -5364,22 +5368,22 @@ msgid ""
 "all languages available."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:238
+#: ../extras/knowledge-base.rst:241
 msgid ""
 "If you've found what you've been looking for, simply hit your ENTER-Key to "
 "load the answer into the ticket article. This way you don't have to throw "
 "URLs at your customer and provide the answer right away."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:242
+#: ../extras/knowledge-base.rst:245
 msgid "Loading answers into articles *does not* replace article content."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:248
+#: ../extras/knowledge-base.rst:251
 msgid "Screencast showing how to insert KB answers into articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:248
+#: ../extras/knowledge-base.rst:251
 msgid "Use ``??`` to find and load knowledge base answers into ticket articles"
 msgstr ""
 
@@ -7084,16 +7088,4 @@ msgid ""
 "You are currently reading the Zammad user documentation. There are also :"
 "docs:`system </index.html>` and :admin-docs:`administration manuals </index."
 "html>` available."
-msgstr ""
-
-#: ../basics/zammad-glossary.rst:618
-msgid "Bottom section:"
-msgstr ""
-
-#: ../basics/zammad-glossary.rst:732
-msgid ""
-"The title of a ticket is different based on the channel it came in. You can "
-"find the title in the sidebar and in the top area in the ticket view. If the "
-"title is not very meaningful, you can change it by clicking on the title in "
-"a ticket view."
 msgstr ""

--- a/locale/pl/LC_MESSAGES/user-docs.po
+++ b/locale/pl/LC_MESSAGES/user-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-12 11:32+0200\n"
+"POT-Creation-Date: 2024-05-03 12:13+0200\n"
 "PO-Revision-Date: 2023-09-29 11:18+0000\n"
 "Last-Translator: SamolJacek <samol.jacek@gmail.com>\n"
 "Language-Team: Polish <https://translations.zammad.org/projects/"
@@ -1407,7 +1407,7 @@ msgid ""
 msgstr ""
 
 #: ../snippets/ticket-state-type-circles.rst:4
-#: ../snippets/ticket-state-type-circles.rst:6 ../extras/knowledge-base.rst:211
+#: ../snippets/ticket-state-type-circles.rst:6 ../extras/knowledge-base.rst:214
 msgid "|grn|"
 msgstr ""
 
@@ -4167,7 +4167,7 @@ msgid "One or more open tickets"
 msgstr ""
 
 #: ../basics/zammad-glossary.rst:618
-msgid "Bootom section:"
+msgid "Bottom section:"
 msgstr ""
 
 #: ../basics/zammad-glossary.rst:622
@@ -4370,7 +4370,7 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:732
 msgid ""
-"The ticket of a ticket is different based on the channel it came in. You can "
+"The title of a ticket is different based on the channel it came in. You can "
 "find the title in the sidebar and in the top area in the ticket view. If the "
 "title is not very meaningful, you can change it by clicking on the title in "
 "a ticket view."
@@ -5373,23 +5373,7 @@ msgid ""
 "the information load for users that don't need the information."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:None
-msgid ""
-"Screencast showing the visibility option for categories for granular access "
-"permissions"
-msgstr ""
-
-#: ../extras/knowledge-base.rst:152
-msgid ""
-"In general, permissions of a parent category are inherited! If you want to "
-"grant edit permissions for a sub-category for a specific role for example, "
-"set the upper level to \"reader\" and the desired sub-category to "
-"\"editor\". The other way round is not possible (permissions can only be "
-"widened, not restricted). If you can't select permissions in the table, this "
-"could be the reason."
-msgstr ""
-
-#: ../extras/knowledge-base.rst:159
+#: ../extras/knowledge-base.rst:148
 msgid ""
 "The roles require **knowledge base reader permission**. Your administrator "
 "has to provide the relevant groups with reader permissions for the knowledge "
@@ -5398,18 +5382,38 @@ msgid ""
 "accordingly."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:166
+#: ../extras/knowledge-base.rst:None
+msgid ""
+"Screencast showing the visibility option for categories for granular access "
+"permissions"
+msgstr ""
+
+#: ../extras/knowledge-base.rst:158
+msgid ""
+"In general, permissions of a parent category are inherited! If you want to "
+"grant edit permissions for a sub-category for a specific role for example, "
+"set the upper level to \"reader\" and the desired sub-category to "
+"\"editor\". The same workflow applies to granting \"none\" permissions, "
+"effectively hiding a given sub-category. The other way round is not "
+"possible. A role with \"editor\" permission has full access to it's sub-"
+"categories, so it's pointless to limit it's permissions. \"None\" "
+"permissions also cannot be changed down the tree since there would be no "
+"path to access permitted sub-categories. If you can't select permissions in "
+"the table, this could be the reason."
+msgstr ""
+
+#: ../extras/knowledge-base.rst:169
 msgid "Be aware that public answers are always available!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:168
+#: ../extras/knowledge-base.rst:171
 msgid ""
 "Knowledge base reader permission means that affected users can see "
 "**internal answers**. This is a potential issue if you're not dividing "
 "carefully!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:173
+#: ../extras/knowledge-base.rst:176
 msgid "Editing Answers"
 msgstr ""
 
@@ -5417,7 +5421,7 @@ msgstr ""
 msgid "Edit answer"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:179
+#: ../extras/knowledge-base.rst:182
 msgid ""
 "The knowledge base editor comes equipped with the same **rich text editing "
 "capabilities** available in the Zammad ticket composer. That means you can "
@@ -5426,19 +5430,19 @@ msgid ""
 "attachments and links!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:203
+#: ../extras/knowledge-base.rst:206
 msgid "Different link types"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:187
+#: ../extras/knowledge-base.rst:190
 msgid "🔗 **Weblink**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:187
+#: ../extras/knowledge-base.rst:190
 msgid "URLs pointing to other websites."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:191
+#: ../extras/knowledge-base.rst:194
 msgid "💡 **Link Answer**"
 msgstr ""
 
@@ -5450,7 +5454,7 @@ msgstr ""
 msgid "(Will not break if destination URL changes.)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:195
+#: ../extras/knowledge-base.rst:198
 msgid "📋 **Linked Tickets**"
 msgstr ""
 
@@ -5462,7 +5466,7 @@ msgstr ""
 msgid "(Visible only in Preview and Edit Modes.)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:203
+#: ../extras/knowledge-base.rst:206
 msgid "🏷️ **Tags**"
 msgstr ""
 
@@ -5480,42 +5484,42 @@ msgstr ""
 msgid "Screencast showing tags on answers"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:228
+#: ../extras/knowledge-base.rst:231
 msgid "Visibility"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:206
+#: ../extras/knowledge-base.rst:209
 msgid ""
 "Set the **visibility** of an answer to control who can see an article, or "
 "schedule it to be published at a later date. Articles are **color-coded** "
 "according to their visibility:"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:211
+#: ../extras/knowledge-base.rst:214
 msgid "**Public** (visible to everyone)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:213
+#: ../extras/knowledge-base.rst:216
 msgid "|blu|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:213
+#: ../extras/knowledge-base.rst:216
 msgid "**Internal** (visible to agents & editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:215
+#: ../extras/knowledge-base.rst:218
 msgid "|gry|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:215
+#: ../extras/knowledge-base.rst:218
 msgid "**Draft/Scheduled/Archived** (visible to editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:231
+#: ../extras/knowledge-base.rst:234
 msgid "Using answers in ticket articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:233
+#: ../extras/knowledge-base.rst:236
 msgid ""
 "As soon as the knowledge base contains one or more answers, you can use "
 "these just like text modules. Instead of ``::`` just use ``??`` to open the "
@@ -5523,22 +5527,22 @@ msgid ""
 "all languages available."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:238
+#: ../extras/knowledge-base.rst:241
 msgid ""
 "If you've found what you've been looking for, simply hit your ENTER-Key to "
 "load the answer into the ticket article. This way you don't have to throw "
 "URLs at your customer and provide the answer right away."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:242
+#: ../extras/knowledge-base.rst:245
 msgid "Loading answers into articles *does not* replace article content."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:248
+#: ../extras/knowledge-base.rst:251
 msgid "Screencast showing how to insert KB answers into articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:248
+#: ../extras/knowledge-base.rst:251
 msgid "Use ``??`` to find and load knowledge base answers into ticket articles"
 msgstr ""
 
@@ -7248,18 +7252,6 @@ msgid ""
 "You are currently reading the Zammad user documentation. There are also :"
 "docs:`system </index.html>` and :admin-docs:`administration manuals </index."
 "html>` available."
-msgstr ""
-
-#: ../basics/zammad-glossary.rst:618
-msgid "Bottom section:"
-msgstr ""
-
-#: ../basics/zammad-glossary.rst:732
-msgid ""
-"The title of a ticket is different based on the channel it came in. You can "
-"find the title in the sidebar and in the top area in the ticket view. If the "
-"title is not very meaningful, you can change it by clicking on the title in "
-"a ticket view."
 msgstr ""
 
 #, fuzzy

--- a/locale/pt_BR/LC_MESSAGES/user-docs.po
+++ b/locale/pt_BR/LC_MESSAGES/user-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-12 11:32+0200\n"
+"POT-Creation-Date: 2024-05-03 12:13+0200\n"
 "PO-Revision-Date: 2022-08-01 14:09+0000\n"
 "Last-Translator: Erico Cesar <ericocesar@webck.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://translations.zammad.org/projects/"
@@ -1360,7 +1360,7 @@ msgstr ""
 "**representadas por cores:**"
 
 #: ../snippets/ticket-state-type-circles.rst:4
-#: ../snippets/ticket-state-type-circles.rst:6 ../extras/knowledge-base.rst:211
+#: ../snippets/ticket-state-type-circles.rst:6 ../extras/knowledge-base.rst:214
 msgid "|grn|"
 msgstr "|grn|"
 
@@ -4409,8 +4409,9 @@ msgid "One or more open tickets"
 msgstr "Navegar pelos chamados"
 
 #: ../basics/zammad-glossary.rst:618
-msgid "Bootom section:"
-msgstr ""
+#, fuzzy
+msgid "Bottom section:"
+msgstr "Notificações"
 
 #: ../basics/zammad-glossary.rst:622
 #, fuzzy
@@ -4616,7 +4617,7 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:732
 msgid ""
-"The ticket of a ticket is different based on the channel it came in. You can "
+"The title of a ticket is different based on the channel it came in. You can "
 "find the title in the sidebar and in the top area in the ticket view. If the "
 "title is not very meaningful, you can change it by clicking on the title in "
 "a ticket view."
@@ -5718,23 +5719,7 @@ msgid ""
 "the information load for users that don't need the information."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:None
-msgid ""
-"Screencast showing the visibility option for categories for granular access "
-"permissions"
-msgstr ""
-
-#: ../extras/knowledge-base.rst:152
-msgid ""
-"In general, permissions of a parent category are inherited! If you want to "
-"grant edit permissions for a sub-category for a specific role for example, "
-"set the upper level to \"reader\" and the desired sub-category to "
-"\"editor\". The other way round is not possible (permissions can only be "
-"widened, not restricted). If you can't select permissions in the table, this "
-"could be the reason."
-msgstr ""
-
-#: ../extras/knowledge-base.rst:159
+#: ../extras/knowledge-base.rst:148
 msgid ""
 "The roles require **knowledge base reader permission**. Your administrator "
 "has to provide the relevant groups with reader permissions for the knowledge "
@@ -5743,18 +5728,38 @@ msgid ""
 "accordingly."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:166
+#: ../extras/knowledge-base.rst:None
+msgid ""
+"Screencast showing the visibility option for categories for granular access "
+"permissions"
+msgstr ""
+
+#: ../extras/knowledge-base.rst:158
+msgid ""
+"In general, permissions of a parent category are inherited! If you want to "
+"grant edit permissions for a sub-category for a specific role for example, "
+"set the upper level to \"reader\" and the desired sub-category to "
+"\"editor\". The same workflow applies to granting \"none\" permissions, "
+"effectively hiding a given sub-category. The other way round is not "
+"possible. A role with \"editor\" permission has full access to it's sub-"
+"categories, so it's pointless to limit it's permissions. \"None\" "
+"permissions also cannot be changed down the tree since there would be no "
+"path to access permitted sub-categories. If you can't select permissions in "
+"the table, this could be the reason."
+msgstr ""
+
+#: ../extras/knowledge-base.rst:169
 msgid "Be aware that public answers are always available!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:168
+#: ../extras/knowledge-base.rst:171
 msgid ""
 "Knowledge base reader permission means that affected users can see "
 "**internal answers**. This is a potential issue if you're not dividing "
 "carefully!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:173
+#: ../extras/knowledge-base.rst:176
 msgid "Editing Answers"
 msgstr ""
 
@@ -5762,7 +5767,7 @@ msgstr ""
 msgid "Edit answer"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:179
+#: ../extras/knowledge-base.rst:182
 msgid ""
 "The knowledge base editor comes equipped with the same **rich text editing "
 "capabilities** available in the Zammad ticket composer. That means you can "
@@ -5771,19 +5776,19 @@ msgid ""
 "attachments and links!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:203
+#: ../extras/knowledge-base.rst:206
 msgid "Different link types"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:187
+#: ../extras/knowledge-base.rst:190
 msgid "🔗 **Weblink**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:187
+#: ../extras/knowledge-base.rst:190
 msgid "URLs pointing to other websites."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:191
+#: ../extras/knowledge-base.rst:194
 msgid "💡 **Link Answer**"
 msgstr ""
 
@@ -5795,7 +5800,7 @@ msgstr ""
 msgid "(Will not break if destination URL changes.)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:195
+#: ../extras/knowledge-base.rst:198
 msgid "📋 **Linked Tickets**"
 msgstr ""
 
@@ -5807,7 +5812,7 @@ msgstr ""
 msgid "(Visible only in Preview and Edit Modes.)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:203
+#: ../extras/knowledge-base.rst:206
 msgid "🏷️ **Tags**"
 msgstr ""
 
@@ -5825,42 +5830,42 @@ msgstr ""
 msgid "Screencast showing tags on answers"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:228
+#: ../extras/knowledge-base.rst:231
 msgid "Visibility"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:206
+#: ../extras/knowledge-base.rst:209
 msgid ""
 "Set the **visibility** of an answer to control who can see an article, or "
 "schedule it to be published at a later date. Articles are **color-coded** "
 "according to their visibility:"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:211
+#: ../extras/knowledge-base.rst:214
 msgid "**Public** (visible to everyone)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:213
+#: ../extras/knowledge-base.rst:216
 msgid "|blu|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:213
+#: ../extras/knowledge-base.rst:216
 msgid "**Internal** (visible to agents & editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:215
+#: ../extras/knowledge-base.rst:218
 msgid "|gry|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:215
+#: ../extras/knowledge-base.rst:218
 msgid "**Draft/Scheduled/Archived** (visible to editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:231
+#: ../extras/knowledge-base.rst:234
 msgid "Using answers in ticket articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:233
+#: ../extras/knowledge-base.rst:236
 msgid ""
 "As soon as the knowledge base contains one or more answers, you can use "
 "these just like text modules. Instead of ``::`` just use ``??`` to open the "
@@ -5868,22 +5873,22 @@ msgid ""
 "all languages available."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:238
+#: ../extras/knowledge-base.rst:241
 msgid ""
 "If you've found what you've been looking for, simply hit your ENTER-Key to "
 "load the answer into the ticket article. This way you don't have to throw "
 "URLs at your customer and provide the answer right away."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:242
+#: ../extras/knowledge-base.rst:245
 msgid "Loading answers into articles *does not* replace article content."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:248
+#: ../extras/knowledge-base.rst:251
 msgid "Screencast showing how to insert KB answers into articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:248
+#: ../extras/knowledge-base.rst:251
 msgid "Use ``??`` to find and load knowledge base answers into ticket articles"
 msgstr ""
 
@@ -7683,19 +7688,6 @@ msgid ""
 "You are currently reading the Zammad user documentation. There are also :"
 "docs:`system </index.html>` and :admin-docs:`administration manuals </index."
 "html>` available."
-msgstr ""
-
-#: ../basics/zammad-glossary.rst:618
-#, fuzzy
-msgid "Bottom section:"
-msgstr "Notificações"
-
-#: ../basics/zammad-glossary.rst:732
-msgid ""
-"The title of a ticket is different based on the channel it came in. You can "
-"find the title in the sidebar and in the top area in the ticket view. If the "
-"title is not very meaningful, you can change it by clicking on the title in "
-"a ticket view."
 msgstr ""
 
 #~ msgid "Status"

--- a/locale/ru/LC_MESSAGES/user-docs.po
+++ b/locale/ru/LC_MESSAGES/user-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-12 11:32+0200\n"
+"POT-Creation-Date: 2024-05-03 12:13+0200\n"
 "PO-Revision-Date: 2023-09-09 23:18+0000\n"
 "Last-Translator: ElectroKos <kosapashennyh@gmail.com>\n"
 "Language-Team: Russian <https://translations.zammad.org/projects/"
@@ -1310,7 +1310,7 @@ msgid ""
 msgstr ""
 
 #: ../snippets/ticket-state-type-circles.rst:4
-#: ../snippets/ticket-state-type-circles.rst:6 ../extras/knowledge-base.rst:211
+#: ../snippets/ticket-state-type-circles.rst:6 ../extras/knowledge-base.rst:214
 msgid "|grn|"
 msgstr "|grn|"
 
@@ -4060,7 +4060,7 @@ msgid "One or more open tickets"
 msgstr ""
 
 #: ../basics/zammad-glossary.rst:618
-msgid "Bootom section:"
+msgid "Bottom section:"
 msgstr ""
 
 #: ../basics/zammad-glossary.rst:622
@@ -4264,7 +4264,7 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:732
 msgid ""
-"The ticket of a ticket is different based on the channel it came in. You can "
+"The title of a ticket is different based on the channel it came in. You can "
 "find the title in the sidebar and in the top area in the ticket view. If the "
 "title is not very meaningful, you can change it by clicking on the title in "
 "a ticket view."
@@ -5269,23 +5269,7 @@ msgid ""
 "the information load for users that don't need the information."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:None
-msgid ""
-"Screencast showing the visibility option for categories for granular access "
-"permissions"
-msgstr ""
-
-#: ../extras/knowledge-base.rst:152
-msgid ""
-"In general, permissions of a parent category are inherited! If you want to "
-"grant edit permissions for a sub-category for a specific role for example, "
-"set the upper level to \"reader\" and the desired sub-category to "
-"\"editor\". The other way round is not possible (permissions can only be "
-"widened, not restricted). If you can't select permissions in the table, this "
-"could be the reason."
-msgstr ""
-
-#: ../extras/knowledge-base.rst:159
+#: ../extras/knowledge-base.rst:148
 msgid ""
 "The roles require **knowledge base reader permission**. Your administrator "
 "has to provide the relevant groups with reader permissions for the knowledge "
@@ -5294,18 +5278,38 @@ msgid ""
 "accordingly."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:166
+#: ../extras/knowledge-base.rst:None
+msgid ""
+"Screencast showing the visibility option for categories for granular access "
+"permissions"
+msgstr ""
+
+#: ../extras/knowledge-base.rst:158
+msgid ""
+"In general, permissions of a parent category are inherited! If you want to "
+"grant edit permissions for a sub-category for a specific role for example, "
+"set the upper level to \"reader\" and the desired sub-category to "
+"\"editor\". The same workflow applies to granting \"none\" permissions, "
+"effectively hiding a given sub-category. The other way round is not "
+"possible. A role with \"editor\" permission has full access to it's sub-"
+"categories, so it's pointless to limit it's permissions. \"None\" "
+"permissions also cannot be changed down the tree since there would be no "
+"path to access permitted sub-categories. If you can't select permissions in "
+"the table, this could be the reason."
+msgstr ""
+
+#: ../extras/knowledge-base.rst:169
 msgid "Be aware that public answers are always available!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:168
+#: ../extras/knowledge-base.rst:171
 msgid ""
 "Knowledge base reader permission means that affected users can see "
 "**internal answers**. This is a potential issue if you're not dividing "
 "carefully!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:173
+#: ../extras/knowledge-base.rst:176
 msgid "Editing Answers"
 msgstr ""
 
@@ -5313,7 +5317,7 @@ msgstr ""
 msgid "Edit answer"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:179
+#: ../extras/knowledge-base.rst:182
 msgid ""
 "The knowledge base editor comes equipped with the same **rich text editing "
 "capabilities** available in the Zammad ticket composer. That means you can "
@@ -5322,19 +5326,19 @@ msgid ""
 "attachments and links!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:203
+#: ../extras/knowledge-base.rst:206
 msgid "Different link types"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:187
+#: ../extras/knowledge-base.rst:190
 msgid "🔗 **Weblink**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:187
+#: ../extras/knowledge-base.rst:190
 msgid "URLs pointing to other websites."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:191
+#: ../extras/knowledge-base.rst:194
 msgid "💡 **Link Answer**"
 msgstr ""
 
@@ -5346,7 +5350,7 @@ msgstr ""
 msgid "(Will not break if destination URL changes.)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:195
+#: ../extras/knowledge-base.rst:198
 msgid "📋 **Linked Tickets**"
 msgstr ""
 
@@ -5358,7 +5362,7 @@ msgstr ""
 msgid "(Visible only in Preview and Edit Modes.)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:203
+#: ../extras/knowledge-base.rst:206
 msgid "🏷️ **Tags**"
 msgstr ""
 
@@ -5376,42 +5380,42 @@ msgstr ""
 msgid "Screencast showing tags on answers"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:228
+#: ../extras/knowledge-base.rst:231
 msgid "Visibility"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:206
+#: ../extras/knowledge-base.rst:209
 msgid ""
 "Set the **visibility** of an answer to control who can see an article, or "
 "schedule it to be published at a later date. Articles are **color-coded** "
 "according to their visibility:"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:211
+#: ../extras/knowledge-base.rst:214
 msgid "**Public** (visible to everyone)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:213
+#: ../extras/knowledge-base.rst:216
 msgid "|blu|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:213
+#: ../extras/knowledge-base.rst:216
 msgid "**Internal** (visible to agents & editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:215
+#: ../extras/knowledge-base.rst:218
 msgid "|gry|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:215
+#: ../extras/knowledge-base.rst:218
 msgid "**Draft/Scheduled/Archived** (visible to editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:231
+#: ../extras/knowledge-base.rst:234
 msgid "Using answers in ticket articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:233
+#: ../extras/knowledge-base.rst:236
 msgid ""
 "As soon as the knowledge base contains one or more answers, you can use "
 "these just like text modules. Instead of ``::`` just use ``??`` to open the "
@@ -5419,22 +5423,22 @@ msgid ""
 "all languages available."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:238
+#: ../extras/knowledge-base.rst:241
 msgid ""
 "If you've found what you've been looking for, simply hit your ENTER-Key to "
 "load the answer into the ticket article. This way you don't have to throw "
 "URLs at your customer and provide the answer right away."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:242
+#: ../extras/knowledge-base.rst:245
 msgid "Loading answers into articles *does not* replace article content."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:248
+#: ../extras/knowledge-base.rst:251
 msgid "Screencast showing how to insert KB answers into articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:248
+#: ../extras/knowledge-base.rst:251
 msgid "Use ``??`` to find and load knowledge base answers into ticket articles"
 msgstr ""
 
@@ -7147,18 +7151,6 @@ msgid ""
 "You are currently reading the Zammad user documentation. There are also :"
 "docs:`system </index.html>` and :admin-docs:`administration manuals </index."
 "html>` available."
-msgstr ""
-
-#: ../basics/zammad-glossary.rst:618
-msgid "Bottom section:"
-msgstr ""
-
-#: ../basics/zammad-glossary.rst:732
-msgid ""
-"The title of a ticket is different based on the channel it came in. You can "
-"find the title in the sidebar and in the top area in the ticket view. If the "
-"title is not very meaningful, you can change it by clicking on the title in "
-"a ticket view."
 msgstr ""
 
 #~ msgid "🤔 **How do I make macros?**"

--- a/locale/sr/LC_MESSAGES/user-docs.po
+++ b/locale/sr/LC_MESSAGES/user-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-12 11:32+0200\n"
+"POT-Creation-Date: 2024-05-03 12:13+0200\n"
 "PO-Revision-Date: 2024-04-18 09:00+0000\n"
 "Last-Translator: Dusan Vuckovic <dv@zammad.com>\n"
 "Language-Team: Serbian <https://translations.zammad.org/projects/"
@@ -1410,7 +1410,7 @@ msgstr ""
 "бојама:**"
 
 #: ../snippets/ticket-state-type-circles.rst:4
-#: ../snippets/ticket-state-type-circles.rst:6 ../extras/knowledge-base.rst:211
+#: ../snippets/ticket-state-type-circles.rst:6 ../extras/knowledge-base.rst:214
 msgid "|grn|"
 msgstr "|grn|"
 
@@ -4851,7 +4851,7 @@ msgid "One or more open tickets"
 msgstr "Један или више отворених тикета"
 
 #: ../basics/zammad-glossary.rst:618
-msgid "Bootom section:"
+msgid "Bottom section:"
 msgstr "Доњи одељак:"
 
 #: ../basics/zammad-glossary.rst:622
@@ -5121,14 +5121,14 @@ msgstr "Више можете сазнати у секцији :doc:`/advanced/t
 
 #: ../basics/zammad-glossary.rst:732
 msgid ""
-"The ticket of a ticket is different based on the channel it came in. You can "
+"The title of a ticket is different based on the channel it came in. You can "
 "find the title in the sidebar and in the top area in the ticket view. If the "
 "title is not very meaningful, you can change it by clicking on the title in "
 "a ticket view."
 msgstr ""
-"Наслов тикета зависи од канала на коме је примљен. Можете пронаћи наслов у "
-"бочној траци и заглављу прегледа тикета. Уколико наслов није смислен, можете "
-"га изменити кликом на исти у прегледу тикета."
+"Наслов тикета је другачији у зависности од канала на коме је примљен. Наслов "
+"можете пронаћи у траци са стране и при врху екрана у приказу тикета. Уколико "
+"вам наслов нема смисла, можете га изменити кликом на исти у приказу тикета."
 
 #: ../basics/zammad-glossary.rst:741
 msgid "Ticket hook"
@@ -6339,31 +6339,7 @@ msgstr ""
 "Ово вам омогућава да поделите групе корисника на нпр. ниво претплате како "
 "бисте смањили оптерећење информацијама за кориснике којима нису потребне."
 
-#: ../extras/knowledge-base.rst:None
-msgid ""
-"Screencast showing the visibility option for categories for granular access "
-"permissions"
-msgstr ""
-"Снимак екрана који приказује опцију видљивости за ограничене дозволе "
-"категорије"
-
-#: ../extras/knowledge-base.rst:152
-msgid ""
-"In general, permissions of a parent category are inherited! If you want to "
-"grant edit permissions for a sub-category for a specific role for example, "
-"set the upper level to \"reader\" and the desired sub-category to "
-"\"editor\". The other way round is not possible (permissions can only be "
-"widened, not restricted). If you can't select permissions in the table, this "
-"could be the reason."
-msgstr ""
-"Уопштено говорећи, дозволе надређене категорије се не наслеђују! Уколико, на "
-"пример, желите да одобрите дозволе уређивања за подкатегорија одговарајућој "
-"улози, подесите горњи ниво на „читаоца” и жељену подкатегорију на "
-"„уредника”. Обрнуто није могуће (дозволе је могуће само проширити, не и "
-"ограничити). Уколико не можете да одаберете дозволе у табели, ово може бити "
-"разлог."
-
-#: ../extras/knowledge-base.rst:159
+#: ../extras/knowledge-base.rst:148
 msgid ""
 "The roles require **knowledge base reader permission**. Your administrator "
 "has to provide the relevant groups with reader permissions for the knowledge "
@@ -6376,11 +6352,47 @@ msgstr ""
 "сигурни, замолите свог администратора да у складу са тим конфигурише :admin-"
 "docs:`дозволе улоге </manage/roles/agent-permissions.html>`."
 
-#: ../extras/knowledge-base.rst:166
+#: ../extras/knowledge-base.rst:None
+msgid ""
+"Screencast showing the visibility option for categories for granular access "
+"permissions"
+msgstr ""
+"Снимак екрана који приказује опцију видљивости за ограничене дозволе "
+"категорије"
+
+#: ../extras/knowledge-base.rst:158
+#, fuzzy
+#| msgid ""
+#| "In general, permissions of a parent category are inherited! If you want "
+#| "to grant edit permissions for a sub-category for a specific role for "
+#| "example, set the upper level to \"reader\" and the desired sub-category "
+#| "to \"editor\". The other way round is not possible (permissions can only "
+#| "be widened, not restricted). If you can't select permissions in the "
+#| "table, this could be the reason."
+msgid ""
+"In general, permissions of a parent category are inherited! If you want to "
+"grant edit permissions for a sub-category for a specific role for example, "
+"set the upper level to \"reader\" and the desired sub-category to "
+"\"editor\". The same workflow applies to granting \"none\" permissions, "
+"effectively hiding a given sub-category. The other way round is not "
+"possible. A role with \"editor\" permission has full access to it's sub-"
+"categories, so it's pointless to limit it's permissions. \"None\" "
+"permissions also cannot be changed down the tree since there would be no "
+"path to access permitted sub-categories. If you can't select permissions in "
+"the table, this could be the reason."
+msgstr ""
+"Уопштено говорећи, дозволе надређене категорије се не наслеђују! Уколико, на "
+"пример, желите да одобрите дозволе уређивања за подкатегорија одговарајућој "
+"улози, подесите горњи ниво на „читаоца” и жељену подкатегорију на "
+"„уредника”. Обрнуто није могуће (дозволе је могуће само проширити, не и "
+"ограничити). Уколико не можете да одаберете дозволе у табели, ово може бити "
+"разлог."
+
+#: ../extras/knowledge-base.rst:169
 msgid "Be aware that public answers are always available!"
 msgstr "Будите свесни да су јавни чланци су увек доступни!"
 
-#: ../extras/knowledge-base.rst:168
+#: ../extras/knowledge-base.rst:171
 msgid ""
 "Knowledge base reader permission means that affected users can see "
 "**internal answers**. This is a potential issue if you're not dividing "
@@ -6389,7 +6401,7 @@ msgstr ""
 "Дозвола за читање базе знања значи да корисници могу да виде **интерне "
 "чланке**. Ово је потенцијални проблем ако не делите пажљиво!"
 
-#: ../extras/knowledge-base.rst:173
+#: ../extras/knowledge-base.rst:176
 msgid "Editing Answers"
 msgstr "Уређивање чланака"
 
@@ -6397,7 +6409,7 @@ msgstr "Уређивање чланака"
 msgid "Edit answer"
 msgstr "Уредите чланак"
 
-#: ../extras/knowledge-base.rst:179
+#: ../extras/knowledge-base.rst:182
 msgid ""
 "The knowledge base editor comes equipped with the same **rich text editing "
 "capabilities** available in the Zammad ticket composer. That means you can "
@@ -6411,19 +6423,19 @@ msgstr ""
 "бисте уметнули форматирани текст, листе са ознакама и још много тога. Можете "
 "чак додати датотеке прилога и везе!"
 
-#: ../extras/knowledge-base.rst:203
+#: ../extras/knowledge-base.rst:206
 msgid "Different link types"
 msgstr "Различите врсте веза"
 
-#: ../extras/knowledge-base.rst:187
+#: ../extras/knowledge-base.rst:190
 msgid "🔗 **Weblink**"
 msgstr "🔗 **Интернет веза**"
 
-#: ../extras/knowledge-base.rst:187
+#: ../extras/knowledge-base.rst:190
 msgid "URLs pointing to other websites."
 msgstr "URL адресе које упућују на друге интернет локације."
 
-#: ../extras/knowledge-base.rst:191
+#: ../extras/knowledge-base.rst:194
 msgid "💡 **Link Answer**"
 msgstr "💡 **Веза ка чланку**"
 
@@ -6435,7 +6447,7 @@ msgstr "Интерне референце на друге чланке базе 
 msgid "(Will not break if destination URL changes.)"
 msgstr "(Неће се прекинути ако се одредишна URL адреса промени.)"
 
-#: ../extras/knowledge-base.rst:195
+#: ../extras/knowledge-base.rst:198
 msgid "📋 **Linked Tickets**"
 msgstr "📋 **Везе ка тикетима**"
 
@@ -6447,7 +6459,7 @@ msgstr "Интерне референце на Zammad тикете."
 msgid "(Visible only in Preview and Edit Modes.)"
 msgstr "(Видљиво само у режимима приказа и уређивања.)"
 
-#: ../extras/knowledge-base.rst:203
+#: ../extras/knowledge-base.rst:206
 msgid "🏷️ **Tags**"
 msgstr "🏷 **Ознаке**"
 
@@ -6469,11 +6481,11 @@ msgstr ""
 msgid "Screencast showing tags on answers"
 msgstr "Снимак екрана који приказује ознаке у чланкцима"
 
-#: ../extras/knowledge-base.rst:228
+#: ../extras/knowledge-base.rst:231
 msgid "Visibility"
 msgstr "Видљивост"
 
-#: ../extras/knowledge-base.rst:206
+#: ../extras/knowledge-base.rst:209
 msgid ""
 "Set the **visibility** of an answer to control who can see an article, or "
 "schedule it to be published at a later date. Articles are **color-coded** "
@@ -6483,31 +6495,31 @@ msgstr ""
 "или закажите његово објављивање за касније. Чланци су **означени бојама** "
 "према њиховој видљивости:"
 
-#: ../extras/knowledge-base.rst:211
+#: ../extras/knowledge-base.rst:214
 msgid "**Public** (visible to everyone)"
 msgstr "**Јавно** (видљиво свима)"
 
-#: ../extras/knowledge-base.rst:213
+#: ../extras/knowledge-base.rst:216
 msgid "|blu|"
 msgstr "|blu|"
 
-#: ../extras/knowledge-base.rst:213
+#: ../extras/knowledge-base.rst:216
 msgid "**Internal** (visible to agents & editors only)"
 msgstr "**Интерно** (видљиво само оператерима и уредницима)"
 
-#: ../extras/knowledge-base.rst:215
+#: ../extras/knowledge-base.rst:218
 msgid "|gry|"
 msgstr "|gry|"
 
-#: ../extras/knowledge-base.rst:215
+#: ../extras/knowledge-base.rst:218
 msgid "**Draft/Scheduled/Archived** (visible to editors only)"
 msgstr "**Нацрт/Заказано/Архивирано** (видљиво само уредницима)"
 
-#: ../extras/knowledge-base.rst:231
+#: ../extras/knowledge-base.rst:234
 msgid "Using answers in ticket articles"
 msgstr "Коришћење чланака у тикетима"
 
-#: ../extras/knowledge-base.rst:233
+#: ../extras/knowledge-base.rst:236
 msgid ""
 "As soon as the knowledge base contains one or more answers, you can use "
 "these just like text modules. Instead of ``::`` just use ``??`` to open the "
@@ -6519,7 +6531,7 @@ msgstr ""
 "претраге. Претрага се врши по целом тексту чланка и у наслову на свим "
 "доступним језицима."
 
-#: ../extras/knowledge-base.rst:238
+#: ../extras/knowledge-base.rst:241
 msgid ""
 "If you've found what you've been looking for, simply hit your ENTER-Key to "
 "load the answer into the ticket article. This way you don't have to throw "
@@ -6529,16 +6541,16 @@ msgstr ""
 "бисте учитали чланак у тикет. На овај начин не морате да шаљете URL адресе "
 "својим клијентима и можете одмах да им одговорите."
 
-#: ../extras/knowledge-base.rst:242
+#: ../extras/knowledge-base.rst:245
 msgid "Loading answers into articles *does not* replace article content."
 msgstr "Учитавање чланака *не* замењује садржај чланка тикета."
 
-#: ../extras/knowledge-base.rst:248
+#: ../extras/knowledge-base.rst:251
 msgid "Screencast showing how to insert KB answers into articles"
 msgstr ""
 "Снимак екрана који показује како да уметнете чланке базе знања у тикете"
 
-#: ../extras/knowledge-base.rst:248
+#: ../extras/knowledge-base.rst:251
 msgid "Use ``??`` to find and load knowledge base answers into ticket articles"
 msgstr "Користите ``??`` да пронађете и учитате чланке базе знања у тикете"
 
@@ -8628,20 +8640,18 @@ msgstr ""
 "`системски </index.html>` и :admin-docs:`администраторски </index.html>` "
 "приручници."
 
-#: ../basics/zammad-glossary.rst:618
-msgid "Bottom section:"
-msgstr "Доњи одељак:"
+#~ msgid "Bootom section:"
+#~ msgstr "Доњи одељак:"
 
-#: ../basics/zammad-glossary.rst:732
-msgid ""
-"The title of a ticket is different based on the channel it came in. You can "
-"find the title in the sidebar and in the top area in the ticket view. If the "
-"title is not very meaningful, you can change it by clicking on the title in "
-"a ticket view."
-msgstr ""
-"Наслов тикета је другачији у зависности од канала на коме је примљен. Наслов "
-"можете пронаћи у траци са стране и при врху екрана у приказу тикета. Уколико "
-"вам наслов нема смисла, можете га изменити кликом на исти у приказу тикета."
+#~ msgid ""
+#~ "The ticket of a ticket is different based on the channel it came in. You "
+#~ "can find the title in the sidebar and in the top area in the ticket view. "
+#~ "If the title is not very meaningful, you can change it by clicking on the "
+#~ "title in a ticket view."
+#~ msgstr ""
+#~ "Наслов тикета зависи од канала на коме је примљен. Можете пронаћи наслов "
+#~ "у бочној траци и заглављу прегледа тикета. Уколико наслов није смислен, "
+#~ "можете га изменити кликом на исти у прегледу тикета."
 
 #~ msgid "Status"
 #~ msgstr "Статус"

--- a/locale/sv/LC_MESSAGES/user-docs.po
+++ b/locale/sv/LC_MESSAGES/user-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-12 11:32+0200\n"
+"POT-Creation-Date: 2024-05-03 12:13+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -1262,7 +1262,7 @@ msgid ""
 msgstr ""
 
 #: ../snippets/ticket-state-type-circles.rst:4
-#: ../snippets/ticket-state-type-circles.rst:6 ../extras/knowledge-base.rst:211
+#: ../snippets/ticket-state-type-circles.rst:6 ../extras/knowledge-base.rst:214
 msgid "|grn|"
 msgstr ""
 
@@ -4008,7 +4008,7 @@ msgid "One or more open tickets"
 msgstr ""
 
 #: ../basics/zammad-glossary.rst:618
-msgid "Bootom section:"
+msgid "Bottom section:"
 msgstr ""
 
 #: ../basics/zammad-glossary.rst:622
@@ -4211,7 +4211,7 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:732
 msgid ""
-"The ticket of a ticket is different based on the channel it came in. You can "
+"The title of a ticket is different based on the channel it came in. You can "
 "find the title in the sidebar and in the top area in the ticket view. If the "
 "title is not very meaningful, you can change it by clicking on the title in "
 "a ticket view."
@@ -5214,23 +5214,7 @@ msgid ""
 "the information load for users that don't need the information."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:None
-msgid ""
-"Screencast showing the visibility option for categories for granular access "
-"permissions"
-msgstr ""
-
-#: ../extras/knowledge-base.rst:152
-msgid ""
-"In general, permissions of a parent category are inherited! If you want to "
-"grant edit permissions for a sub-category for a specific role for example, "
-"set the upper level to \"reader\" and the desired sub-category to "
-"\"editor\". The other way round is not possible (permissions can only be "
-"widened, not restricted). If you can't select permissions in the table, this "
-"could be the reason."
-msgstr ""
-
-#: ../extras/knowledge-base.rst:159
+#: ../extras/knowledge-base.rst:148
 msgid ""
 "The roles require **knowledge base reader permission**. Your administrator "
 "has to provide the relevant groups with reader permissions for the knowledge "
@@ -5239,18 +5223,38 @@ msgid ""
 "accordingly."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:166
+#: ../extras/knowledge-base.rst:None
+msgid ""
+"Screencast showing the visibility option for categories for granular access "
+"permissions"
+msgstr ""
+
+#: ../extras/knowledge-base.rst:158
+msgid ""
+"In general, permissions of a parent category are inherited! If you want to "
+"grant edit permissions for a sub-category for a specific role for example, "
+"set the upper level to \"reader\" and the desired sub-category to "
+"\"editor\". The same workflow applies to granting \"none\" permissions, "
+"effectively hiding a given sub-category. The other way round is not "
+"possible. A role with \"editor\" permission has full access to it's sub-"
+"categories, so it's pointless to limit it's permissions. \"None\" "
+"permissions also cannot be changed down the tree since there would be no "
+"path to access permitted sub-categories. If you can't select permissions in "
+"the table, this could be the reason."
+msgstr ""
+
+#: ../extras/knowledge-base.rst:169
 msgid "Be aware that public answers are always available!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:168
+#: ../extras/knowledge-base.rst:171
 msgid ""
 "Knowledge base reader permission means that affected users can see "
 "**internal answers**. This is a potential issue if you're not dividing "
 "carefully!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:173
+#: ../extras/knowledge-base.rst:176
 msgid "Editing Answers"
 msgstr ""
 
@@ -5258,7 +5262,7 @@ msgstr ""
 msgid "Edit answer"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:179
+#: ../extras/knowledge-base.rst:182
 msgid ""
 "The knowledge base editor comes equipped with the same **rich text editing "
 "capabilities** available in the Zammad ticket composer. That means you can "
@@ -5267,19 +5271,19 @@ msgid ""
 "attachments and links!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:203
+#: ../extras/knowledge-base.rst:206
 msgid "Different link types"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:187
+#: ../extras/knowledge-base.rst:190
 msgid "🔗 **Weblink**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:187
+#: ../extras/knowledge-base.rst:190
 msgid "URLs pointing to other websites."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:191
+#: ../extras/knowledge-base.rst:194
 msgid "💡 **Link Answer**"
 msgstr ""
 
@@ -5291,7 +5295,7 @@ msgstr ""
 msgid "(Will not break if destination URL changes.)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:195
+#: ../extras/knowledge-base.rst:198
 msgid "📋 **Linked Tickets**"
 msgstr ""
 
@@ -5303,7 +5307,7 @@ msgstr ""
 msgid "(Visible only in Preview and Edit Modes.)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:203
+#: ../extras/knowledge-base.rst:206
 msgid "🏷️ **Tags**"
 msgstr ""
 
@@ -5321,42 +5325,42 @@ msgstr ""
 msgid "Screencast showing tags on answers"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:228
+#: ../extras/knowledge-base.rst:231
 msgid "Visibility"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:206
+#: ../extras/knowledge-base.rst:209
 msgid ""
 "Set the **visibility** of an answer to control who can see an article, or "
 "schedule it to be published at a later date. Articles are **color-coded** "
 "according to their visibility:"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:211
+#: ../extras/knowledge-base.rst:214
 msgid "**Public** (visible to everyone)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:213
+#: ../extras/knowledge-base.rst:216
 msgid "|blu|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:213
+#: ../extras/knowledge-base.rst:216
 msgid "**Internal** (visible to agents & editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:215
+#: ../extras/knowledge-base.rst:218
 msgid "|gry|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:215
+#: ../extras/knowledge-base.rst:218
 msgid "**Draft/Scheduled/Archived** (visible to editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:231
+#: ../extras/knowledge-base.rst:234
 msgid "Using answers in ticket articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:233
+#: ../extras/knowledge-base.rst:236
 msgid ""
 "As soon as the knowledge base contains one or more answers, you can use "
 "these just like text modules. Instead of ``::`` just use ``??`` to open the "
@@ -5364,22 +5368,22 @@ msgid ""
 "all languages available."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:238
+#: ../extras/knowledge-base.rst:241
 msgid ""
 "If you've found what you've been looking for, simply hit your ENTER-Key to "
 "load the answer into the ticket article. This way you don't have to throw "
 "URLs at your customer and provide the answer right away."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:242
+#: ../extras/knowledge-base.rst:245
 msgid "Loading answers into articles *does not* replace article content."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:248
+#: ../extras/knowledge-base.rst:251
 msgid "Screencast showing how to insert KB answers into articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:248
+#: ../extras/knowledge-base.rst:251
 msgid "Use ``??`` to find and load knowledge base answers into ticket articles"
 msgstr ""
 
@@ -7084,16 +7088,4 @@ msgid ""
 "You are currently reading the Zammad user documentation. There are also :"
 "docs:`system </index.html>` and :admin-docs:`administration manuals </index."
 "html>` available."
-msgstr ""
-
-#: ../basics/zammad-glossary.rst:618
-msgid "Bottom section:"
-msgstr ""
-
-#: ../basics/zammad-glossary.rst:732
-msgid ""
-"The title of a ticket is different based on the channel it came in. You can "
-"find the title in the sidebar and in the top area in the ticket view. If the "
-"title is not very meaningful, you can change it by clicking on the title in "
-"a ticket view."
 msgstr ""

--- a/locale/th/LC_MESSAGES/user-docs.po
+++ b/locale/th/LC_MESSAGES/user-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-12 11:32+0200\n"
+"POT-Creation-Date: 2024-05-03 12:13+0200\n"
 "PO-Revision-Date: 2022-04-16 15:56+0000\n"
 "Last-Translator: LAO <sumonchai@gmail.com>\n"
 "Language-Team: Thai <https://translations.zammad.org/projects/documentations/"
@@ -1277,7 +1277,7 @@ msgid ""
 msgstr ""
 
 #: ../snippets/ticket-state-type-circles.rst:4
-#: ../snippets/ticket-state-type-circles.rst:6 ../extras/knowledge-base.rst:211
+#: ../snippets/ticket-state-type-circles.rst:6 ../extras/knowledge-base.rst:214
 msgid "|grn|"
 msgstr "|grn|"
 
@@ -4029,8 +4029,9 @@ msgid "One or more open tickets"
 msgstr ""
 
 #: ../basics/zammad-glossary.rst:618
-msgid "Bootom section:"
-msgstr ""
+#, fuzzy
+msgid "Bottom section:"
+msgstr "แจ้งเตือน"
 
 #: ../basics/zammad-glossary.rst:622
 #, fuzzy
@@ -4235,7 +4236,7 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:732
 msgid ""
-"The ticket of a ticket is different based on the channel it came in. You can "
+"The title of a ticket is different based on the channel it came in. You can "
 "find the title in the sidebar and in the top area in the ticket view. If the "
 "title is not very meaningful, you can change it by clicking on the title in "
 "a ticket view."
@@ -5241,23 +5242,7 @@ msgid ""
 "the information load for users that don't need the information."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:None
-msgid ""
-"Screencast showing the visibility option for categories for granular access "
-"permissions"
-msgstr ""
-
-#: ../extras/knowledge-base.rst:152
-msgid ""
-"In general, permissions of a parent category are inherited! If you want to "
-"grant edit permissions for a sub-category for a specific role for example, "
-"set the upper level to \"reader\" and the desired sub-category to "
-"\"editor\". The other way round is not possible (permissions can only be "
-"widened, not restricted). If you can't select permissions in the table, this "
-"could be the reason."
-msgstr ""
-
-#: ../extras/knowledge-base.rst:159
+#: ../extras/knowledge-base.rst:148
 msgid ""
 "The roles require **knowledge base reader permission**. Your administrator "
 "has to provide the relevant groups with reader permissions for the knowledge "
@@ -5266,18 +5251,38 @@ msgid ""
 "accordingly."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:166
+#: ../extras/knowledge-base.rst:None
+msgid ""
+"Screencast showing the visibility option for categories for granular access "
+"permissions"
+msgstr ""
+
+#: ../extras/knowledge-base.rst:158
+msgid ""
+"In general, permissions of a parent category are inherited! If you want to "
+"grant edit permissions for a sub-category for a specific role for example, "
+"set the upper level to \"reader\" and the desired sub-category to "
+"\"editor\". The same workflow applies to granting \"none\" permissions, "
+"effectively hiding a given sub-category. The other way round is not "
+"possible. A role with \"editor\" permission has full access to it's sub-"
+"categories, so it's pointless to limit it's permissions. \"None\" "
+"permissions also cannot be changed down the tree since there would be no "
+"path to access permitted sub-categories. If you can't select permissions in "
+"the table, this could be the reason."
+msgstr ""
+
+#: ../extras/knowledge-base.rst:169
 msgid "Be aware that public answers are always available!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:168
+#: ../extras/knowledge-base.rst:171
 msgid ""
 "Knowledge base reader permission means that affected users can see "
 "**internal answers**. This is a potential issue if you're not dividing "
 "carefully!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:173
+#: ../extras/knowledge-base.rst:176
 msgid "Editing Answers"
 msgstr "กำลังแก้ไขคำตอบ"
 
@@ -5285,7 +5290,7 @@ msgstr "กำลังแก้ไขคำตอบ"
 msgid "Edit answer"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:179
+#: ../extras/knowledge-base.rst:182
 msgid ""
 "The knowledge base editor comes equipped with the same **rich text editing "
 "capabilities** available in the Zammad ticket composer. That means you can "
@@ -5294,19 +5299,19 @@ msgid ""
 "attachments and links!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:203
+#: ../extras/knowledge-base.rst:206
 msgid "Different link types"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:187
+#: ../extras/knowledge-base.rst:190
 msgid "🔗 **Weblink**"
 msgstr "🔗 **ลิ้งเข้าถึง**"
 
-#: ../extras/knowledge-base.rst:187
+#: ../extras/knowledge-base.rst:190
 msgid "URLs pointing to other websites."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:191
+#: ../extras/knowledge-base.rst:194
 msgid "💡 **Link Answer**"
 msgstr "💡 **ไป ดูคำตอบ**"
 
@@ -5318,7 +5323,7 @@ msgstr ""
 msgid "(Will not break if destination URL changes.)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:195
+#: ../extras/knowledge-base.rst:198
 msgid "📋 **Linked Tickets**"
 msgstr "📋 **เชื่อม ใบแจ้งซ่อม**"
 
@@ -5330,7 +5335,7 @@ msgstr ""
 msgid "(Visible only in Preview and Edit Modes.)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:203
+#: ../extras/knowledge-base.rst:206
 msgid "🏷️ **Tags**"
 msgstr ""
 
@@ -5348,42 +5353,42 @@ msgstr ""
 msgid "Screencast showing tags on answers"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:228
+#: ../extras/knowledge-base.rst:231
 msgid "Visibility"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:206
+#: ../extras/knowledge-base.rst:209
 msgid ""
 "Set the **visibility** of an answer to control who can see an article, or "
 "schedule it to be published at a later date. Articles are **color-coded** "
 "according to their visibility:"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:211
+#: ../extras/knowledge-base.rst:214
 msgid "**Public** (visible to everyone)"
 msgstr "**เผยแพร่** (ทุกคนเข้าดูได้)"
 
-#: ../extras/knowledge-base.rst:213
+#: ../extras/knowledge-base.rst:216
 msgid "|blu|"
 msgstr "|blu|"
 
-#: ../extras/knowledge-base.rst:213
+#: ../extras/knowledge-base.rst:216
 msgid "**Internal** (visible to agents & editors only)"
 msgstr "**ภายใน** (เจ้าหน้าที่ และผู้แก้ไข)"
 
-#: ../extras/knowledge-base.rst:215
+#: ../extras/knowledge-base.rst:218
 msgid "|gry|"
 msgstr "|gry|"
 
-#: ../extras/knowledge-base.rst:215
+#: ../extras/knowledge-base.rst:218
 msgid "**Draft/Scheduled/Archived** (visible to editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:231
+#: ../extras/knowledge-base.rst:234
 msgid "Using answers in ticket articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:233
+#: ../extras/knowledge-base.rst:236
 msgid ""
 "As soon as the knowledge base contains one or more answers, you can use "
 "these just like text modules. Instead of ``::`` just use ``??`` to open the "
@@ -5391,22 +5396,22 @@ msgid ""
 "all languages available."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:238
+#: ../extras/knowledge-base.rst:241
 msgid ""
 "If you've found what you've been looking for, simply hit your ENTER-Key to "
 "load the answer into the ticket article. This way you don't have to throw "
 "URLs at your customer and provide the answer right away."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:242
+#: ../extras/knowledge-base.rst:245
 msgid "Loading answers into articles *does not* replace article content."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:248
+#: ../extras/knowledge-base.rst:251
 msgid "Screencast showing how to insert KB answers into articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:248
+#: ../extras/knowledge-base.rst:251
 msgid "Use ``??`` to find and load knowledge base answers into ticket articles"
 msgstr ""
 
@@ -7135,19 +7140,6 @@ msgid ""
 "You are currently reading the Zammad user documentation. There are also :"
 "docs:`system </index.html>` and :admin-docs:`administration manuals </index."
 "html>` available."
-msgstr ""
-
-#: ../basics/zammad-glossary.rst:618
-#, fuzzy
-msgid "Bottom section:"
-msgstr "แจ้งเตือน"
-
-#: ../basics/zammad-glossary.rst:732
-msgid ""
-"The title of a ticket is different based on the channel it came in. You can "
-"find the title in the sidebar and in the top area in the ticket view. If the "
-"title is not very meaningful, you can change it by clicking on the title in "
-"a ticket view."
 msgstr ""
 
 #, fuzzy

--- a/locale/tr/LC_MESSAGES/user-docs.po
+++ b/locale/tr/LC_MESSAGES/user-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-12 11:32+0200\n"
+"POT-Creation-Date: 2024-05-03 12:13+0200\n"
 "PO-Revision-Date: 2024-02-17 07:00+0000\n"
 "Last-Translator: Kadir Çakmak <kadir.cakmak@estetikdecor.com>\n"
 "Language-Team: Turkish <https://translations.zammad.org/projects/"
@@ -1446,7 +1446,7 @@ msgstr ""
 "kodları:**"
 
 #: ../snippets/ticket-state-type-circles.rst:4
-#: ../snippets/ticket-state-type-circles.rst:6 ../extras/knowledge-base.rst:211
+#: ../snippets/ticket-state-type-circles.rst:6 ../extras/knowledge-base.rst:214
 msgid "|grn|"
 msgstr "|grn|"
 
@@ -4514,8 +4514,9 @@ msgid "One or more open tickets"
 msgstr "Biletlere Göre Tarama"
 
 #: ../basics/zammad-glossary.rst:618
-msgid "Bootom section:"
-msgstr ""
+#, fuzzy
+msgid "Bottom section:"
+msgstr "Bildirimler"
 
 #: ../basics/zammad-glossary.rst:622
 #, fuzzy
@@ -4737,7 +4738,7 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:732
 msgid ""
-"The ticket of a ticket is different based on the channel it came in. You can "
+"The title of a ticket is different based on the channel it came in. You can "
 "find the title in the sidebar and in the top area in the ticket view. If the "
 "title is not very meaningful, you can change it by clicking on the title in "
 "a ticket view."
@@ -5905,23 +5906,7 @@ msgid ""
 "the information load for users that don't need the information."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:None
-msgid ""
-"Screencast showing the visibility option for categories for granular access "
-"permissions"
-msgstr ""
-
-#: ../extras/knowledge-base.rst:152
-msgid ""
-"In general, permissions of a parent category are inherited! If you want to "
-"grant edit permissions for a sub-category for a specific role for example, "
-"set the upper level to \"reader\" and the desired sub-category to "
-"\"editor\". The other way round is not possible (permissions can only be "
-"widened, not restricted). If you can't select permissions in the table, this "
-"could be the reason."
-msgstr ""
-
-#: ../extras/knowledge-base.rst:159
+#: ../extras/knowledge-base.rst:148
 msgid ""
 "The roles require **knowledge base reader permission**. Your administrator "
 "has to provide the relevant groups with reader permissions for the knowledge "
@@ -5930,18 +5915,38 @@ msgid ""
 "accordingly."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:166
+#: ../extras/knowledge-base.rst:None
+msgid ""
+"Screencast showing the visibility option for categories for granular access "
+"permissions"
+msgstr ""
+
+#: ../extras/knowledge-base.rst:158
+msgid ""
+"In general, permissions of a parent category are inherited! If you want to "
+"grant edit permissions for a sub-category for a specific role for example, "
+"set the upper level to \"reader\" and the desired sub-category to "
+"\"editor\". The same workflow applies to granting \"none\" permissions, "
+"effectively hiding a given sub-category. The other way round is not "
+"possible. A role with \"editor\" permission has full access to it's sub-"
+"categories, so it's pointless to limit it's permissions. \"None\" "
+"permissions also cannot be changed down the tree since there would be no "
+"path to access permitted sub-categories. If you can't select permissions in "
+"the table, this could be the reason."
+msgstr ""
+
+#: ../extras/knowledge-base.rst:169
 msgid "Be aware that public answers are always available!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:168
+#: ../extras/knowledge-base.rst:171
 msgid ""
 "Knowledge base reader permission means that affected users can see "
 "**internal answers**. This is a potential issue if you're not dividing "
 "carefully!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:173
+#: ../extras/knowledge-base.rst:176
 msgid "Editing Answers"
 msgstr "Cevapları Düzenlemek"
 
@@ -5949,7 +5954,7 @@ msgstr "Cevapları Düzenlemek"
 msgid "Edit answer"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:179
+#: ../extras/knowledge-base.rst:182
 msgid ""
 "The knowledge base editor comes equipped with the same **rich text editing "
 "capabilities** available in the Zammad ticket composer. That means you can "
@@ -5964,19 +5969,19 @@ msgstr ""
 "kullanabileceğiniz anlamına gelir. Hatta dosya ekleri ve bağlantılar "
 "ekleyebilirsiniz!"
 
-#: ../extras/knowledge-base.rst:203
+#: ../extras/knowledge-base.rst:206
 msgid "Different link types"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:187
+#: ../extras/knowledge-base.rst:190
 msgid "🔗 **Weblink**"
 msgstr "🔗 **Web bağlantısı**"
 
-#: ../extras/knowledge-base.rst:187
+#: ../extras/knowledge-base.rst:190
 msgid "URLs pointing to other websites."
 msgstr "URL'ler diğer web sitelerini gösteriyor."
 
-#: ../extras/knowledge-base.rst:191
+#: ../extras/knowledge-base.rst:194
 msgid "💡 **Link Answer**"
 msgstr "💡 **Bağlantılı Cevap**"
 
@@ -5988,7 +5993,7 @@ msgstr "Diğer bilgi tabanı cevaplarından iç referanslar."
 msgid "(Will not break if destination URL changes.)"
 msgstr "(Hedef URL değişirse bozulmaz.)"
 
-#: ../extras/knowledge-base.rst:195
+#: ../extras/knowledge-base.rst:198
 msgid "📋 **Linked Tickets**"
 msgstr "📋 **Bağlı Biletler**"
 
@@ -6000,7 +6005,7 @@ msgstr "Zammad biletlerinden iç referanslar."
 msgid "(Visible only in Preview and Edit Modes.)"
 msgstr "(Sadece Önizleme ve Düzenleme Modlarında görünür.)"
 
-#: ../extras/knowledge-base.rst:203
+#: ../extras/knowledge-base.rst:206
 msgid "🏷️ **Tags**"
 msgstr ""
 
@@ -6018,11 +6023,11 @@ msgstr ""
 msgid "Screencast showing tags on answers"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:228
+#: ../extras/knowledge-base.rst:231
 msgid "Visibility"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:206
+#: ../extras/knowledge-base.rst:209
 #, fuzzy
 msgid ""
 "Set the **visibility** of an answer to control who can see an article, or "
@@ -6033,31 +6038,31 @@ msgstr ""
 "tarihte yayınlanmasını planlamak için yanıtın **görünürlüğünü** ayarlayın. "
 "Makaleler, görünürlüklerine göre **renk kodu** alır:"
 
-#: ../extras/knowledge-base.rst:211
+#: ../extras/knowledge-base.rst:214
 msgid "**Public** (visible to everyone)"
 msgstr "**Herkese Açık** (herkes tarafından görülebilir)"
 
-#: ../extras/knowledge-base.rst:213
+#: ../extras/knowledge-base.rst:216
 msgid "|blu|"
 msgstr "|blu|"
 
-#: ../extras/knowledge-base.rst:213
+#: ../extras/knowledge-base.rst:216
 msgid "**Internal** (visible to agents & editors only)"
 msgstr "**Dahili** (sadece aracılar ve editörler görebilir)"
 
-#: ../extras/knowledge-base.rst:215
+#: ../extras/knowledge-base.rst:218
 msgid "|gry|"
 msgstr "|gry|"
 
-#: ../extras/knowledge-base.rst:215
+#: ../extras/knowledge-base.rst:218
 msgid "**Draft/Scheduled/Archived** (visible to editors only)"
 msgstr "**Taslak/Planlanmış/Arşiv** (sadece editörler görebilir)"
 
-#: ../extras/knowledge-base.rst:231
+#: ../extras/knowledge-base.rst:234
 msgid "Using answers in ticket articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:233
+#: ../extras/knowledge-base.rst:236
 msgid ""
 "As soon as the knowledge base contains one or more answers, you can use "
 "these just like text modules. Instead of ``::`` just use ``??`` to open the "
@@ -6065,22 +6070,22 @@ msgid ""
 "all languages available."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:238
+#: ../extras/knowledge-base.rst:241
 msgid ""
 "If you've found what you've been looking for, simply hit your ENTER-Key to "
 "load the answer into the ticket article. This way you don't have to throw "
 "URLs at your customer and provide the answer right away."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:242
+#: ../extras/knowledge-base.rst:245
 msgid "Loading answers into articles *does not* replace article content."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:248
+#: ../extras/knowledge-base.rst:251
 msgid "Screencast showing how to insert KB answers into articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:248
+#: ../extras/knowledge-base.rst:251
 msgid "Use ``??`` to find and load knowledge base answers into ticket articles"
 msgstr ""
 
@@ -7974,19 +7979,6 @@ msgstr ""
 "Şu anda Zammad kullanıcı belgelerini okumaktasınız. Ayrıca :docs:`system </"
 "index.html>` ve :admin-docs:`administration manuals </index.html>` da "
 "mevcuttur."
-
-#: ../basics/zammad-glossary.rst:618
-#, fuzzy
-msgid "Bottom section:"
-msgstr "Bildirimler"
-
-#: ../basics/zammad-glossary.rst:732
-msgid ""
-"The title of a ticket is different based on the channel it came in. You can "
-"find the title in the sidebar and in the top area in the ticket view. If the "
-"title is not very meaningful, you can change it by clicking on the title in "
-"a ticket view."
-msgstr ""
 
 #, fuzzy
 #~ msgid "Status"

--- a/locale/zh_Hans/LC_MESSAGES/user-docs.po
+++ b/locale/zh_Hans/LC_MESSAGES/user-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-12 11:32+0200\n"
+"POT-Creation-Date: 2024-05-03 12:13+0200\n"
 "PO-Revision-Date: 2022-11-04 15:14+0000\n"
 "Last-Translator: Never Min <59808@qq.com>\n"
 "Language-Team: Chinese (Simplified) <https://translations.zammad.org/"
@@ -1328,7 +1328,7 @@ msgid ""
 msgstr ""
 
 #: ../snippets/ticket-state-type-circles.rst:4
-#: ../snippets/ticket-state-type-circles.rst:6 ../extras/knowledge-base.rst:211
+#: ../snippets/ticket-state-type-circles.rst:6 ../extras/knowledge-base.rst:214
 msgid "|grn|"
 msgstr ""
 
@@ -4076,7 +4076,7 @@ msgid "One or more open tickets"
 msgstr ""
 
 #: ../basics/zammad-glossary.rst:618
-msgid "Bootom section:"
+msgid "Bottom section:"
 msgstr ""
 
 #: ../basics/zammad-glossary.rst:622
@@ -4279,7 +4279,7 @@ msgstr ""
 
 #: ../basics/zammad-glossary.rst:732
 msgid ""
-"The ticket of a ticket is different based on the channel it came in. You can "
+"The title of a ticket is different based on the channel it came in. You can "
 "find the title in the sidebar and in the top area in the ticket view. If the "
 "title is not very meaningful, you can change it by clicking on the title in "
 "a ticket view."
@@ -5284,23 +5284,7 @@ msgid ""
 "the information load for users that don't need the information."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:None
-msgid ""
-"Screencast showing the visibility option for categories for granular access "
-"permissions"
-msgstr ""
-
-#: ../extras/knowledge-base.rst:152
-msgid ""
-"In general, permissions of a parent category are inherited! If you want to "
-"grant edit permissions for a sub-category for a specific role for example, "
-"set the upper level to \"reader\" and the desired sub-category to "
-"\"editor\". The other way round is not possible (permissions can only be "
-"widened, not restricted). If you can't select permissions in the table, this "
-"could be the reason."
-msgstr ""
-
-#: ../extras/knowledge-base.rst:159
+#: ../extras/knowledge-base.rst:148
 msgid ""
 "The roles require **knowledge base reader permission**. Your administrator "
 "has to provide the relevant groups with reader permissions for the knowledge "
@@ -5309,18 +5293,38 @@ msgid ""
 "accordingly."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:166
+#: ../extras/knowledge-base.rst:None
+msgid ""
+"Screencast showing the visibility option for categories for granular access "
+"permissions"
+msgstr ""
+
+#: ../extras/knowledge-base.rst:158
+msgid ""
+"In general, permissions of a parent category are inherited! If you want to "
+"grant edit permissions for a sub-category for a specific role for example, "
+"set the upper level to \"reader\" and the desired sub-category to "
+"\"editor\". The same workflow applies to granting \"none\" permissions, "
+"effectively hiding a given sub-category. The other way round is not "
+"possible. A role with \"editor\" permission has full access to it's sub-"
+"categories, so it's pointless to limit it's permissions. \"None\" "
+"permissions also cannot be changed down the tree since there would be no "
+"path to access permitted sub-categories. If you can't select permissions in "
+"the table, this could be the reason."
+msgstr ""
+
+#: ../extras/knowledge-base.rst:169
 msgid "Be aware that public answers are always available!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:168
+#: ../extras/knowledge-base.rst:171
 msgid ""
 "Knowledge base reader permission means that affected users can see "
 "**internal answers**. This is a potential issue if you're not dividing "
 "carefully!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:173
+#: ../extras/knowledge-base.rst:176
 msgid "Editing Answers"
 msgstr ""
 
@@ -5328,7 +5332,7 @@ msgstr ""
 msgid "Edit answer"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:179
+#: ../extras/knowledge-base.rst:182
 msgid ""
 "The knowledge base editor comes equipped with the same **rich text editing "
 "capabilities** available in the Zammad ticket composer. That means you can "
@@ -5337,19 +5341,19 @@ msgid ""
 "attachments and links!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:203
+#: ../extras/knowledge-base.rst:206
 msgid "Different link types"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:187
+#: ../extras/knowledge-base.rst:190
 msgid "🔗 **Weblink**"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:187
+#: ../extras/knowledge-base.rst:190
 msgid "URLs pointing to other websites."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:191
+#: ../extras/knowledge-base.rst:194
 msgid "💡 **Link Answer**"
 msgstr ""
 
@@ -5361,7 +5365,7 @@ msgstr ""
 msgid "(Will not break if destination URL changes.)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:195
+#: ../extras/knowledge-base.rst:198
 msgid "📋 **Linked Tickets**"
 msgstr ""
 
@@ -5373,7 +5377,7 @@ msgstr ""
 msgid "(Visible only in Preview and Edit Modes.)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:203
+#: ../extras/knowledge-base.rst:206
 msgid "🏷️ **Tags**"
 msgstr ""
 
@@ -5391,42 +5395,42 @@ msgstr ""
 msgid "Screencast showing tags on answers"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:228
+#: ../extras/knowledge-base.rst:231
 msgid "Visibility"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:206
+#: ../extras/knowledge-base.rst:209
 msgid ""
 "Set the **visibility** of an answer to control who can see an article, or "
 "schedule it to be published at a later date. Articles are **color-coded** "
 "according to their visibility:"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:211
+#: ../extras/knowledge-base.rst:214
 msgid "**Public** (visible to everyone)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:213
+#: ../extras/knowledge-base.rst:216
 msgid "|blu|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:213
+#: ../extras/knowledge-base.rst:216
 msgid "**Internal** (visible to agents & editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:215
+#: ../extras/knowledge-base.rst:218
 msgid "|gry|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:215
+#: ../extras/knowledge-base.rst:218
 msgid "**Draft/Scheduled/Archived** (visible to editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:231
+#: ../extras/knowledge-base.rst:234
 msgid "Using answers in ticket articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:233
+#: ../extras/knowledge-base.rst:236
 msgid ""
 "As soon as the knowledge base contains one or more answers, you can use "
 "these just like text modules. Instead of ``::`` just use ``??`` to open the "
@@ -5434,22 +5438,22 @@ msgid ""
 "all languages available."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:238
+#: ../extras/knowledge-base.rst:241
 msgid ""
 "If you've found what you've been looking for, simply hit your ENTER-Key to "
 "load the answer into the ticket article. This way you don't have to throw "
 "URLs at your customer and provide the answer right away."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:242
+#: ../extras/knowledge-base.rst:245
 msgid "Loading answers into articles *does not* replace article content."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:248
+#: ../extras/knowledge-base.rst:251
 msgid "Screencast showing how to insert KB answers into articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:248
+#: ../extras/knowledge-base.rst:251
 msgid "Use ``??`` to find and load knowledge base answers into ticket articles"
 msgstr ""
 
@@ -7160,18 +7164,6 @@ msgid ""
 "You are currently reading the Zammad user documentation. There are also :"
 "docs:`system </index.html>` and :admin-docs:`administration manuals </index."
 "html>` available."
-msgstr ""
-
-#: ../basics/zammad-glossary.rst:618
-msgid "Bottom section:"
-msgstr ""
-
-#: ../basics/zammad-glossary.rst:732
-msgid ""
-"The title of a ticket is different based on the channel it came in. You can "
-"find the title in the sidebar and in the top area in the ticket view. If the "
-"title is not very meaningful, you can change it by clicking on the title in "
-"a ticket view."
 msgstr ""
 
 #~ msgid "🤔 **How do I make macros?**"


### PR DESCRIPTION
Translations update from [Zammad-Translations](https://translations.zammad.org) for [Documentation/User Documentation (pre-release)](https://translations.zammad.org/projects/documentations/user-documentation-pre-release/).



Current translation status:

![Weblate translation status](https://translations.zammad.org/widget/documentations/user-documentation-pre-release/horizontal-auto.svg)