### PR TITLE
Translations update from Zammad-Translations

### DIFF
--- a/locale/sr/LC_MESSAGES/user-docs.po
+++ b/locale/sr/LC_MESSAGES/user-docs.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-08-16 11:12+0200\n"
-"PO-Revision-Date: 2024-08-14 08:00+0000\n"
+"PO-Revision-Date: 2024-08-22 12:00+0000\n"
 "Last-Translator: Dusan Vuckovic <dv@zammad.com>\n"
 "Language-Team: Serbian <https://translations.zammad.org/projects/"
 "documentations/user-documentation-pre-release/sr/>\n"
@@ -34,8 +34,6 @@ msgstr ""
 "тока као стручног корисника. Али не брините, не морате да их памтите све."
 
 #: ../advanced/keyboard-shortcuts.rst:8
-#, fuzzy
-#| msgid "Where to find them?"
 msgid "Where to Find Them?"
 msgstr "Где их пронаћи?"
 
@@ -668,8 +666,6 @@ msgstr ""
 "опцијама ``()`` и ``AND``/``OR``::"
 
 #: ../advanced/search.rst:24
-#, fuzzy
-#| msgid "Available attributes"
 msgid "Available Attributes"
 msgstr "Доступни атрибути"
 
@@ -856,8 +852,6 @@ msgstr ""
 "атрибути дозвољавају."
 
 #: ../advanced/search.rst:48
-#, fuzzy
-#| msgid "Combining search phrases"
 msgid "Combining Search Phrases"
 msgstr "Комбиновање фраза за претрагу"
 
@@ -934,8 +928,6 @@ msgid "Show everything with any pending state and an article count of 1 to 5."
 msgstr "Прикажи све са било којим стањем на чекању и бројем чланака од 1 до 5."
 
 #: ../advanced/search.rst:67
-#, fuzzy
-#| msgid "Some Ticket attributes and their type"
 msgid "Some Ticket Attributes and Their Type"
 msgstr "Неки атрибути тикета и њихов тип"
 
@@ -946,8 +938,6 @@ msgid ""
 msgstr "Испод можете пронаћи најважније атрибуте груписане по тикету и чланку."
 
 #: ../advanced/search.rst:72
-#, fuzzy
-#| msgid "Ticket attributes"
 msgid "Ticket Attributes"
 msgstr "Атрибути тикета"
 
@@ -1040,8 +1030,6 @@ msgid "pending_time: timestamp"
 msgstr "pending_time: временска ознака"
 
 #: ../advanced/search.rst:97
-#, fuzzy
-#| msgid "Article attributes"
 msgid "Article Attributes"
 msgstr "Атрибути чланка"
 
@@ -1124,8 +1112,6 @@ msgstr ""
 "тикету, користите **дугме за претплату**.)"
 
 #: ../advanced/suggested-workflows.rst:24
-#, fuzzy
-#| msgid "Reassigning tickets"
 msgid "Reassigning Tickets"
 msgstr "Додела тикета"
 
@@ -1260,8 +1246,6 @@ msgstr ""
 "само за тикете којима већ имате приступ."
 
 #: ../advanced/suggested-workflows.rst:97
-#, fuzzy
-#| msgid "Quickly assign in ticket listings"
 msgid "Quickly Assign in Ticket Listings"
 msgstr "Брза додела у прегледима тикета"
 
@@ -1475,8 +1459,6 @@ msgid "Drag and drop tabs to rearrange them."
 msgstr "Превуците и пустите прозоре да бисте их преуредили."
 
 #: ../advanced/tabs.rst:36
-#, fuzzy
-#| msgid "Tab behavior in ticket zooms"
 msgid "Tab Behavior in Ticket Zooms"
 msgstr "Понашање прозора у прегледу тикета"
 
@@ -1605,8 +1587,6 @@ msgstr ""
 "подешене)."
 
 #: ../advanced/text-modules.rst:21
-#, fuzzy
-#| msgid "Text modules missing?"
 msgid "Text Modules Missing?"
 msgstr "Недостаје вам текстуални исечак?"
 
@@ -1643,8 +1623,6 @@ msgstr ""
 "свог администратора!"
 
 #: ../advanced/text-modules.rst:38
-#, fuzzy
-#| msgid "Text modules on ticket creation"
 msgid "Text Modules on Ticket Creation"
 msgstr "Текстуални исечци приликом отварања тикета"
 
@@ -1657,8 +1635,6 @@ msgstr ""
 "отварања тикета, наши :ref:`ticket_templates` такође могу бити од користи."
 
 #: ../advanced/text-modules.rst:44
-#, fuzzy
-#| msgid "Customizing text modules"
 msgid "Customizing Text Modules"
 msgstr "Прилагођавање текстуалних исечака"
 
@@ -2298,12 +2274,9 @@ msgid "📎 text in file attachments (really!)"
 msgstr "📎 текст у датотекама прилога (заиста!)"
 
 #: ../basics/find-ticket/search.rst:20
-#, fuzzy
-#| msgid ""
-#| "🏷️ user/organization metadata (*e.g.,* notes stored on customer profiles)"
 msgid "🏷️ user/organization metadata (e.g. notes stored on customer profiles)"
 msgstr ""
-"🏷 подаци корисника/организације (*нпр.* напомене сачуване у профилима "
+"🏷 подаци корисника/организације (нпр. напомене сачуване у профилима "
 "клијената)"
 
 #: ../basics/find-ticket/search.rst:22
@@ -2724,8 +2697,6 @@ msgstr ""
 "мора да буде само интерна."
 
 #: ../basics/service-ticket/follow-up.rst:101
-#, fuzzy
-#| msgid "Using quotation"
 msgid "Using Quotation"
 msgstr "Цитирање"
 
@@ -2781,8 +2752,6 @@ msgid "Mark, press reply and work with quoted text!"
 msgstr "Означи, притисни одговор и обради цитирани текст!"
 
 #: ../basics/service-ticket/follow-up.rst:129
-#, fuzzy
-#| msgid "🔥 Keeping an eye on escalations"
 msgid "🔥 Keeping an Eye on Escalations"
 msgstr "🔥 Пазите на ескалације"
 
@@ -2818,8 +2787,6 @@ msgstr ""
 "детаљнијих информација о ескалацији"
 
 #: ../basics/service-ticket/follow-up.rst:145
-#, fuzzy
-#| msgid "Simultaneous processing of a ticket"
 msgid "Simultaneous Processing of a Ticket"
 msgstr "Симултана обрада тикета"
 
@@ -2921,8 +2888,6 @@ msgstr ""
 "Кликните поново да поништите."
 
 #: ../basics/service-ticket/settings.rst:50
-#, fuzzy
-#| msgid "Further ticket actions"
 msgid "Further Ticket Actions"
 msgstr "Додатне радње тикета"
 
@@ -3343,10 +3308,6 @@ msgstr ""
 "Тикет је конверзација која се састоји од порука између клијента и оператера."
 
 #: ../basics/what-is-a-ticket.rst:22
-#, fuzzy
-#| msgid ""
-#| "You know you’re doing a great job when you 1) respond to tickets quickly "
-#| "and 2) get them closed in a timely manner."
 msgid ""
 "You know you're doing a great job when you 1) respond to tickets quickly and "
 "2) get them closed in a timely manner."
@@ -3355,10 +3316,6 @@ msgstr ""
 "затворите их на време."
 
 #: ../basics/what-is-a-ticket.rst:26
-#, fuzzy
-#| msgid ""
-#| "👀 :doc:`Keep an eye on your dashboard </extras/dashboard>` to see how "
-#| "well you’re keeping up."
 msgid ""
 "👀 :doc:`Keep an eye on your dashboard </extras/dashboard>` to see how well "
 "you're keeping up."
@@ -3379,13 +3336,6 @@ msgstr ""
 "се чак и означити високим или ниским приоритетом."
 
 #: ../basics/what-is-a-ticket.rst:40
-#, fuzzy
-#| msgid ""
-#| "For the sake of simplicity, we’ll refer to this metadata as the "
-#| "**settings** of a ticket. All of these settings can be changed at any "
-#| "time. Each setting is explained in detail :doc:`here </basics/service-"
-#| "ticket/settings>`, but for the time being, let’s go over the two most "
-#| "important ones:"
 msgid ""
 "For the sake of simplicity, we'll refer to this metadata as the **settings** "
 "of a ticket. All of these settings can be changed at any time. Each setting "
@@ -5856,11 +5806,6 @@ msgid "Checking Your Stats"
 msgstr "Преглед ваших статистика"
 
 #: ../extras/dashboard.rst:4
-#, fuzzy
-#| msgid ""
-#| "The **dashboard** is the first thing you’ll see after logging in. Monitor "
-#| "your productivity at a glance, compare your stats to the company average "
-#| "(in gray below your own), and see what everyone else is up to."
 msgid ""
 "The **dashboard** is the first thing you'll see after logging in. Monitor "
 "your productivity at a glance, compare your stats to the company average (in "
@@ -5962,10 +5907,8 @@ msgid "**7. Activity Stream**"
 msgstr "**7. Ток активности**"
 
 #: ../extras/dashboard.rst:37
-#, fuzzy
-#| msgid "What’s everyone else on your team up to?"
 msgid "What's everyone else on your team up to?"
-msgstr "Шта сви остали у твом тиму раде?"
+msgstr "Шта раде остали у твом тиму?"
 
 #: ../extras/github-gitlab-integration.rst:2
 msgid "GitHub / GitLab Integration"
@@ -6013,8 +5956,6 @@ msgid "GitLub logo"
 msgstr "Gitlab лого"
 
 #: ../extras/github-gitlab-integration.rst:20
-#, fuzzy
-#| msgid "What can it do?"
 msgid "What Can It Do?"
 msgstr "Чему служи?"
 
@@ -6145,8 +6086,6 @@ msgid "So How Does It Work?"
 msgstr "Како то уствари функционише?"
 
 #: ../extras/i-doit-track-company-property.rst:41
-#, fuzzy
-#| msgid "In Zammad: Link i-doit assets to tickets"
 msgid "In Zammad: Link i-doit Assets To Tickets"
 msgstr "У Zammad-у: Повежите i-doit објекте са тикетима"
 
@@ -6185,8 +6124,6 @@ msgstr ""
 "Кликните на повезан објекат у панелу тикета да бисте га отворили у i-doit."
 
 #: ../extras/i-doit-track-company-property.rst:60
-#, fuzzy
-#| msgid "In i-doit: List & create tickets for a given asset"
 msgid "In i-doit: List & Create Tickets For a Given Asset"
 msgstr "У i-doit: Излистајте и отворите тикете за дат објекат"
 
@@ -6688,8 +6625,6 @@ msgid "**Draft/Scheduled/Archived** (visible to editors only)"
 msgstr "**Нацрт/Заказано/Архивирано** (видљиво само уредницима)"
 
 #: ../extras/knowledge-base.rst:234
-#, fuzzy
-#| msgid "Using answers in ticket articles"
 msgid "Using Answers In Ticket Articles"
 msgstr "Коришћење чланака у тикетима"
 
@@ -7968,8 +7903,6 @@ msgstr ""
 "Кориснички нацрти су *увек* доступни!"
 
 #: ../extras/shared-drafts.rst:36
-#, fuzzy
-#| msgid "Handling drafts"
 msgid "Handling Drafts"
 msgstr "Руковање нацртима"
 


### PR DESCRIPTION
Translations update from [Zammad-Translations](https://translations.zammad.org) for [Documentation/User Documentation (pre-release)](https://translations.zammad.org/projects/documentations/user-documentation-pre-release/).



Current translation status:

![Weblate translation status](https://translations.zammad.org/widget/documentations/user-documentation-pre-release/horizontal-auto.svg)