### PR TITLE
Translations update from Zammad-Translations

### DIFF
--- a/locale/sr/LC_MESSAGES/user-docs.po
+++ b/locale/sr/LC_MESSAGES/user-docs.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-10-18 10:59+0200\n"
-"PO-Revision-Date: 2024-09-25 07:00+0000\n"
+"PO-Revision-Date: 2024-10-29 09:30+0000\n"
 "Last-Translator: Dusan Vuckovic <dv@zammad.com>\n"
 "Language-Team: Serbian <https://translations.zammad.org/projects/"
 "documentations/user-documentation-pre-release/sr/>\n"
@@ -18,7 +18,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
 "n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
-"X-Generator: Weblate 5.7\n"
+"X-Generator: Weblate 5.7.2\n"
 
 #: ../advanced/keyboard-shortcuts.rst:2
 msgid "Keyboard Shortcuts"
@@ -2456,16 +2456,19 @@ msgid ""
 "menu or create a new customer by clicking the \"➕ Create new Customer\" "
 "button. A ticket may only have **one** customer."
 msgstr ""
+"Унести име или имејл адресу клијента за претрагу. Можете чак претраживати по "
+"организацијама и њиховим члановима. Одаберите опцију из падајућег менија или "
+"додајте новог клијента кликом на дугме „➕ Додај новог клијента”. Тикет "
+"может имати само **једног** клијента."
 
 #: ../basics/service-ticket/create.rst:45
-#, fuzzy
-#| msgid "Screenshot showing accounted times in ticket pane"
 msgid "Screenshot showing customer search while creating a new ticket"
-msgstr "Снимак екрана који приказује обрачунато време у панелу тикета"
+msgstr ""
+"Снимак екрана који приказује претрагу клијента приликом отварању новог тикета"
 
 #: ../basics/service-ticket/create.rst:45
 msgid "Ticket creation with customer suggestion based on search."
-msgstr ""
+msgstr "Отварање тикета са предлогом клијента на основу претраге."
 
 #: ../basics/service-ticket/create.rst:49
 msgid ""
@@ -5620,7 +5623,7 @@ msgstr "Списак задатака"
 
 #: ../extras/checklist.rst:5
 msgid "General"
-msgstr "Основно"
+msgstr "Уопштено"
 
 #: ../extras/checklist.rst:7
 msgid ""

--- a/locale/sv/LC_MESSAGES/user-docs.po
+++ b/locale/sv/LC_MESSAGES/user-docs.po
@@ -8,17 +8,20 @@ msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-10-18 10:59+0200\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: Automatically generated\n"
-"Language-Team: none\n"
+"PO-Revision-Date: 2024-10-25 11:00+0000\n"
+"Last-Translator: chrand818 <can@telenabler.com>\n"
+"Language-Team: Swedish <https://translations.zammad.org/projects/"
+"documentations/user-documentation-pre-release/sv/>\n"
 "Language: sv\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Weblate 5.7.2\n"
 
 #: ../advanced/keyboard-shortcuts.rst:2
 msgid "Keyboard Shortcuts"
-msgstr ""
+msgstr "Tangentbordsgenvägar"
 
 #: ../advanced/keyboard-shortcuts.rst:4
 msgid ""
@@ -26,57 +29,68 @@ msgid ""
 "as an expert user. But don't be afraid, you don't have to remember all of "
 "them."
 msgstr ""
+"Zammad har ett brett utbud av kortkommandon för att underlätta arbetet. Men "
+"var inte rädd, du behöver inte komma ihåg alla."
 
 #: ../advanced/keyboard-shortcuts.rst:8 ../basics/zammad-glossary.rst:508
 #: ../extras/chat.rst:11 ../extras/customers.rst:7
 #: ../extras/secure-email.rst:32 ../extras/shared-drafts.rst:5
 msgid "Overview"
-msgstr ""
+msgstr "Översikt"
 
 #: ../advanced/keyboard-shortcuts.rst:10
 msgid ""
 "Click on your avatar at the bottom of the main menu and select \"Keyboard "
 "Shortcuts\" or just press :kbd:`?` to open the keyboard shortcut overview."
 msgstr ""
+"Klicka på din avatar längst ned i huvudmenyn och välj \"Tangentbordsgenvägar"
+"\" eller tryck bara på :kbd:`?` för att öppna översikten över "
+"tangentbordsgenvägar."
 
 #: ../advanced/keyboard-shortcuts.rst:None
 #: ../extras/profile-and-settings.rst:12
 msgid "User submenu"
-msgstr ""
+msgstr "Användarmeny"
 
 #: ../advanced/keyboard-shortcuts.rst:18
 msgid ""
 "This will open an overview of available keyboard-shortcuts as in the "
 "following screenshot:"
 msgstr ""
+"Detta öppnar en översikt över tillgängliga tangentbordsgenvägar som i "
+"följande skärmdump:"
 
 #: ../advanced/keyboard-shortcuts.rst:26
 msgid "Keyboard shortcut cheat sheet"
-msgstr ""
+msgstr "Tangentbordsgenvägar fuskblad"
 
 #: ../advanced/keyboard-shortcuts.rst:26
 msgid "The keyboard shortcut overview."
-msgstr ""
+msgstr "Översikt tangentbordsgenvägar."
 
 #: ../advanced/keyboard-shortcuts.rst:29
 msgid "Settings"
-msgstr ""
+msgstr "Inställningar"
 
 #: ../advanced/keyboard-shortcuts.rst:31
 msgid "At the top of the dialog, you can:"
-msgstr ""
+msgstr "Längst upp i dialogrutan kan du:"
 
 #: ../advanced/keyboard-shortcuts.rst:33
 msgid ""
 "Enable or disable the shortcuts in general by switching the toggle on the "
 "left side."
 msgstr ""
+"Aktivera eller inaktivera genvägarna i genom att växla reglaget på vänster "
+"sida."
 
 #: ../advanced/keyboard-shortcuts.rst:35
 msgid ""
 "Switch to the old shortcuts if you got used to them by clicking on \"Switch "
 "back to old layout\" on the right side."
 msgstr ""
+"Byt till de gamla genvägarna om du har vant dig vid dem genom att klicka på "
+"\"Byt tillbaka till gammal layout\" på höger sida."
 
 #: ../advanced/keyboard-shortcuts.rst:38
 msgid ""
@@ -84,6 +98,10 @@ msgid ""
 "because browsers and operating systems could jam the key press signal. And "
 "the shortcut for opening this overview differs as well."
 msgstr ""
+"Tänk på att de gamla genvägarna inte fungerar lika tillförlitligt som de nya "
+"eftersom webbläsare och operativsystem kan blockera "
+"tangenttryckningssignalen. Och genvägen för att öppna den här översikten "
+"skiljer sig också åt."
 
 #: ../advanced/keyboard-shortcuts.rst:43
 msgid ""
@@ -92,454 +110,466 @@ msgid ""
 "should make sure to not delete your browser cache / session cookies for your "
 "Zammad instance."
 msgstr ""
+"Dessa inställningar sparas för närvarande endast i webbläsaren och inte i "
+"din användarprofil. Om du behöver inaktivera de eller byta till den gamla "
+"layouten bör du se till att inte radera webbläsarens cache / sessionscookies "
+"för din Zammad-instans."
 
 #: ../advanced/keyboard-shortcuts.rst:53
 msgid "Keyboard shortcut settings"
-msgstr ""
+msgstr "Inställningar för tangentbordsgenvägar"
 
 #: ../advanced/keyboard-shortcuts.rst:53
 msgid "The keyboard shortcut settings."
-msgstr ""
+msgstr "Inställningar för tangentbordsgenvägar."
 
 #: ../advanced/keyboard-shortcuts.rst:56
 msgid "List of Available Keyboard Shortcuts"
-msgstr ""
+msgstr "Lista över tillgängliga tangentbordsgenvägar"
 
 #: ../advanced/keyboard-shortcuts.rst:59
 msgid "Navigation"
-msgstr ""
+msgstr "Navigering"
 
 #: ../advanced/keyboard-shortcuts.rst:62 ../advanced/keyboard-shortcuts.rst:90
 #: ../advanced/keyboard-shortcuts.rst:100
 #: ../advanced/keyboard-shortcuts.rst:109
 #: ../advanced/keyboard-shortcuts.rst:141
 msgid "Key / key combination"
-msgstr ""
+msgstr "Tangent / tangentkombination"
 
 #: ../advanced/keyboard-shortcuts.rst:62 ../advanced/keyboard-shortcuts.rst:90
 #: ../advanced/keyboard-shortcuts.rst:100
 #: ../advanced/keyboard-shortcuts.rst:109
 #: ../advanced/keyboard-shortcuts.rst:141
 msgid "Function"
-msgstr ""
+msgstr "Funktion"
 
 #: ../advanced/keyboard-shortcuts.rst:64
 msgid ":kbd:`h`"
-msgstr ""
+msgstr ":kbd:`h`"
 
 #: ../advanced/keyboard-shortcuts.rst:64
 msgid "Show dashboard"
-msgstr ""
+msgstr "Visa dashboard"
 
 #: ../advanced/keyboard-shortcuts.rst:65
 msgid ":kbd:`o`"
-msgstr ""
+msgstr ":kbd:`o`"
 
 #: ../advanced/keyboard-shortcuts.rst:65
 msgid "Show overviews"
-msgstr ""
+msgstr "Visa översikter"
 
 #: ../advanced/keyboard-shortcuts.rst:66
 msgid ":kbd:`s`"
-msgstr ""
+msgstr ":kbd:`s`"
 
 #: ../advanced/keyboard-shortcuts.rst:66
 msgid "Open the search"
-msgstr ""
+msgstr "Öppna sökningen"
 
 #: ../advanced/keyboard-shortcuts.rst:67
 msgid ":kbd:`a`"
-msgstr ""
+msgstr ":kbd:`a`"
 
 #: ../advanced/keyboard-shortcuts.rst:67
 msgid "Open notifications"
-msgstr ""
+msgstr "Öppna notifieringar"
 
 #: ../advanced/keyboard-shortcuts.rst:68
 msgid ":kbd:`n`"
-msgstr ""
+msgstr ":kbd:`n`"
 
 #: ../advanced/keyboard-shortcuts.rst:68 ../extras/mobile-view.rst:119
 msgid "Create a new ticket"
-msgstr ""
+msgstr "Skapa ett nytt ärende"
 
 #: ../advanced/keyboard-shortcuts.rst:69
 msgid ":kbd:`u`"
-msgstr ""
+msgstr ":kbd:`u`"
 
 #: ../advanced/keyboard-shortcuts.rst:69
 msgid "Open user menu"
-msgstr ""
+msgstr "Öppna användarmenyn"
 
 #: ../advanced/keyboard-shortcuts.rst:70
 msgid ":kbd:`?`"
-msgstr ""
+msgstr ":kbd:`?`"
 
 #: ../advanced/keyboard-shortcuts.rst:70
 msgid "Open shortcuts overview"
-msgstr ""
+msgstr "Öppna översikten för genvägar"
 
 #: ../advanced/keyboard-shortcuts.rst:71
 msgid ":kbd:`shift` :kbd:`l`"
-msgstr ""
+msgstr ":kbd:`shift` :kbd:`l`"
 
 #: ../advanced/keyboard-shortcuts.rst:71
 msgid "Log out"
-msgstr ""
+msgstr "Logga ut"
 
 #: ../advanced/keyboard-shortcuts.rst:72
 msgid ":kbd:`shift` :kbd:`w`"
-msgstr ""
+msgstr ":kbd:`shift` :kbd:`w`"
 
 #: ../advanced/keyboard-shortcuts.rst:72
 msgid "Close current tab"
-msgstr ""
+msgstr "Stäng aktuell flik"
 
 #: ../advanced/keyboard-shortcuts.rst:73
 msgid ":kbd:`shift` :kbd:`▶`"
-msgstr ""
+msgstr ":kbd:`shift` :kbd:`▶`"
 
 #: ../advanced/keyboard-shortcuts.rst:73
 msgid "Show next tab"
-msgstr ""
+msgstr "Visa nästa flik"
 
 #: ../advanced/keyboard-shortcuts.rst:74
 msgid ":kbd:`shift` :kbd:`◀`"
-msgstr ""
+msgstr ":kbd:`shift` :kbd:`◀`"
 
 #: ../advanced/keyboard-shortcuts.rst:74
 msgid "Show previous tab"
-msgstr ""
+msgstr "Visa föregående flik"
 
 #: ../advanced/keyboard-shortcuts.rst:75
 msgid ":kbd:`ctrl` :kbd:`enter`"
-msgstr ""
+msgstr ":kbd:`ctrl` :kbd:`enter`"
 
 #: ../advanced/keyboard-shortcuts.rst:75
 msgid "Confirm/submit in dialogs"
-msgstr ""
+msgstr "Bekräfta/sänd i dialogrutor"
 
 #: ../advanced/keyboard-shortcuts.rst:76
 msgid ":kbd:`▲` / :kbd:`▼`"
-msgstr ""
+msgstr ":kbd:`▲` / :kbd:`▼`"
 
 #: ../advanced/keyboard-shortcuts.rst:76
 msgid "Move selection/cursor up and down"
-msgstr ""
+msgstr "Flytta markeringen/pekaren upp och ner"
 
 #: ../advanced/keyboard-shortcuts.rst:77 ../advanced/keyboard-shortcuts.rst:115
 msgid ":kbd:`◀` / :kbd:`▶`"
-msgstr ""
+msgstr ":kbd:`◀` / :kbd:`▶`"
 
 #: ../advanced/keyboard-shortcuts.rst:77
 msgid "Move selection/cursor left and right"
-msgstr ""
+msgstr "Flytta markeringen/pekaren åt vänster och höger"
 
 #: ../advanced/keyboard-shortcuts.rst:78
 msgid ":kbd:`enter`"
-msgstr ""
+msgstr ":kbd:`enter`"
 
 #: ../advanced/keyboard-shortcuts.rst:78
 msgid "Select item / confirm"
-msgstr ""
+msgstr "Välj objekt / bekräfta"
 
 #: ../advanced/keyboard-shortcuts.rst:79
 msgid ":kbd:`.`"
-msgstr ""
+msgstr ":kbd:`.`"
 
 #: ../advanced/keyboard-shortcuts.rst:79
 msgid "Copy current object number (e.g. ticket number)"
-msgstr ""
+msgstr "Kopiera aktuellt objektnummer (t.ex. ärendenummer)"
 
 #: ../advanced/keyboard-shortcuts.rst:80
 msgid ":kbd:`..`"
-msgstr ""
+msgstr ":kbd:`..`"
 
 #: ../advanced/keyboard-shortcuts.rst:80
 msgid "Add the title of the object to the number"
-msgstr ""
+msgstr "Lägg till titeln på objektet till numret"
 
 #: ../advanced/keyboard-shortcuts.rst:81
 msgid ":kbd:`...`"
-msgstr ""
+msgstr ":kbd:`...`"
 
 #: ../advanced/keyboard-shortcuts.rst:81
 msgid "Add the object link URL to the number and title"
-msgstr ""
+msgstr "Lägg till objektlänkens URL i numret och titeln"
 
 #: ../advanced/keyboard-shortcuts.rst:86
 msgid "Translations"
-msgstr ""
+msgstr "Översättningar"
 
 #: ../advanced/keyboard-shortcuts.rst:87
 msgid "Note: you need to have admin permissions to use this."
-msgstr ""
+msgstr "Obs: du måste ha administratörsbehörighet för att kunna använda detta."
 
 #: ../advanced/keyboard-shortcuts.rst:92
 msgid ":kbd:`t`"
-msgstr ""
+msgstr ":kbd:`t`"
 
 #: ../advanced/keyboard-shortcuts.rst:92
 msgid "Enable or disable the inline translation"
-msgstr ""
+msgstr "Aktivera eller inaktivera inline-översättning"
 
 #: ../advanced/keyboard-shortcuts.rst:97 ../extras/profile-and-settings.rst:0
 msgid "Appearance"
-msgstr ""
+msgstr "Utseende"
 
 #: ../advanced/keyboard-shortcuts.rst:102
 msgid ":kbd:`d`"
-msgstr ""
+msgstr ":kbd:`d`"
 
 #: ../advanced/keyboard-shortcuts.rst:102
 msgid "Switch between dark and light mode"
-msgstr ""
+msgstr "Växla mellan mörkt och ljust läge"
 
 #: ../advanced/keyboard-shortcuts.rst:106
 msgid "Tickets"
-msgstr ""
+msgstr "Ärenden"
 
 #: ../advanced/keyboard-shortcuts.rst:111
 msgid ":kbd:`x`"
-msgstr ""
+msgstr ":kbd:`x`"
 
 #: ../advanced/keyboard-shortcuts.rst:111
 msgid "Create a new note article"
-msgstr ""
+msgstr "Skapa en ny artikel"
 
 #: ../advanced/keyboard-shortcuts.rst:112
 msgid ":kbd:`r`"
-msgstr ""
+msgstr ":kbd:`r`"
 
 #: ../advanced/keyboard-shortcuts.rst:112
 msgid "Reply to the last article"
-msgstr ""
+msgstr "Svara på den senaste artikeln"
 
 #: ../advanced/keyboard-shortcuts.rst:113
 msgid ":kbd:`i`"
-msgstr ""
+msgstr ":kbd:`i`"
 
 #: ../advanced/keyboard-shortcuts.rst:113
 msgid "Switch the visibility of the article between internal and public"
-msgstr ""
+msgstr "Växla synligheten för artikeln mellan intern och publik"
 
 #: ../advanced/keyboard-shortcuts.rst:114
 msgid ":kbd:`shift` :kbd:`c`"
-msgstr ""
+msgstr ":kbd:`shift` :kbd:`c`"
 
 #: ../advanced/keyboard-shortcuts.rst:114
 msgid "Set state of the ticket to \"closed\""
-msgstr ""
+msgstr "Sätt status på ärendet till \"stängt\""
 
 #: ../advanced/keyboard-shortcuts.rst:115
 msgid "Navigate through article"
-msgstr ""
+msgstr "Navigera genom artikeln"
 
 #: ../advanced/keyboard-shortcuts.rst:116
 msgid ":kbd:`::`"
-msgstr ""
+msgstr ":kbd:`::`"
 
 #: ../advanced/keyboard-shortcuts.rst:116
 msgid "Insert text module (while composing an article)"
-msgstr ""
+msgstr "Infoga textmodul (när du skriver en artikel)"
 
 #: ../advanced/keyboard-shortcuts.rst:117
 msgid ":kbd:`??`"
-msgstr ""
+msgstr ":kbd:`??`"
 
 #: ../advanced/keyboard-shortcuts.rst:117
 msgid "Insert knowledge base article (while composing an article)"
-msgstr ""
+msgstr "Infoga artikel från kunskapsbanken (när du skriver en artikel)"
 
 #: ../advanced/keyboard-shortcuts.rst:118
 msgid ":kbd:`@@`"
-msgstr ""
+msgstr ":kbd:`@@`"
 
 #: ../advanced/keyboard-shortcuts.rst:118
 msgid "Mention a user (while composing an article)"
-msgstr ""
+msgstr "Nämn en användare (när du skriver en artikel)"
 
 #: ../advanced/keyboard-shortcuts.rst:122
 msgid "Text Editing"
-msgstr ""
+msgstr "Textredigering"
 
 #: ../advanced/keyboard-shortcuts.rst:137
 msgid "How"
-msgstr ""
+msgstr "Hur"
 
 #: ../advanced/keyboard-shortcuts.rst:125
 msgid "You can apply a text format *before* typing or *after* typing. Example:"
 msgstr ""
+"Du kan formatera text *innan* du skriver eller *efter* du skriver. Exempel "
+"på detta:"
 
 #: ../advanced/keyboard-shortcuts.rst:127
 msgid "Before typing:"
-msgstr ""
+msgstr "Innan du skriver:"
 
 #: ../advanced/keyboard-shortcuts.rst:129
 msgid "Press :kbd:`ctrl` :kbd:`i` to enter *italics* mode,"
-msgstr ""
+msgstr "Tryck på :kbd:`ctrl` :kbd:`i` för att gå till *kursivt*-läge,"
 
 #: ../advanced/keyboard-shortcuts.rst:130
 msgid "enter your desired text, and"
-msgstr ""
+msgstr "ange önskad text och"
 
 #: ../advanced/keyboard-shortcuts.rst:131
 msgid "press :kbd:`ctrl` :kbd:`i` again to return to normal text mode."
 msgstr ""
+"tryck på :kbd:`ctrl` :kbd:`i` igen för att återgå till normalt textläge."
 
 #: ../advanced/keyboard-shortcuts.rst:133
 msgid "After typing:"
-msgstr ""
+msgstr "Efter att ha skrivit:"
 
 #: ../advanced/keyboard-shortcuts.rst:135
 msgid "Enter your desired text,"
-msgstr ""
+msgstr "Skriv in önskad text,"
 
 #: ../advanced/keyboard-shortcuts.rst:136
 msgid "click-and-drag with the mouse to select it, and"
-msgstr ""
+msgstr "klicka och dra med musen för att markera den, och"
 
 #: ../advanced/keyboard-shortcuts.rst:137
 msgid "press :kbd:`ctrl` :kbd:`i` to set the text in *italics*."
-msgstr ""
+msgstr "tryck :kbd:`ctrl` :kbd:`i` för att sätta texten i *kursivt*."
 
 #: ../advanced/keyboard-shortcuts.rst:158
 msgid "Key Combinations"
-msgstr ""
+msgstr "Tangentkombinationer"
 
 #: ../advanced/keyboard-shortcuts.rst:143
 msgid ":kbd:`ctrl` :kbd:`u`"
-msgstr ""
+msgstr ":kbd:`ctrl` :kbd:`u`"
 
 #: ../advanced/keyboard-shortcuts.rst:143
 msgid "Format text underlined"
-msgstr ""
+msgstr "Formatera text understruken"
 
 #: ../advanced/keyboard-shortcuts.rst:144
 msgid ":kbd:`ctrl` :kbd:`b`"
-msgstr ""
+msgstr ":kbd:`ctrl` :kbd:`b`"
 
 #: ../advanced/keyboard-shortcuts.rst:144
 msgid "Format text in **bold**"
-msgstr ""
+msgstr "Formatera text i **fetstil**"
 
 #: ../advanced/keyboard-shortcuts.rst:145
 msgid ":kbd:`ctrl` :kbd:`i`"
-msgstr ""
+msgstr ":kbd:`ctrl` :kbd:`i`"
 
 #: ../advanced/keyboard-shortcuts.rst:145
 msgid "Format text in *italics*"
-msgstr ""
+msgstr "Formatera text i *kursiv stil*"
 
 #: ../advanced/keyboard-shortcuts.rst:146
 msgid ":kbd:`ctrl` :kbd:`s`"
-msgstr ""
+msgstr ":kbd:`ctrl` :kbd:`s`"
 
 #: ../advanced/keyboard-shortcuts.rst:146
 msgid "Format text as  ̶s̶t̶r̶i̶k̶e̶t̶h̶r̶o̶u̶g̶h̶"
-msgstr ""
+msgstr "Formatera text som g̶e̶n̶o̶m̶s̶t̶r̶u̶k̶e̶n̶"
 
 #: ../advanced/keyboard-shortcuts.rst:147
 msgid ":kbd:`ctrl` :kbd:`v`"
-msgstr ""
+msgstr ":kbd:`ctrl` :kbd:`v`"
 
 #: ../advanced/keyboard-shortcuts.rst:147
 msgid "Paste text from clipboard"
-msgstr ""
+msgstr "Klistra in text från urklipp"
 
 #: ../advanced/keyboard-shortcuts.rst:148
 msgid ":kbd:`shift` :kbd:`ctrl` :kbd:`v`"
-msgstr ""
+msgstr ":kbd:`shift` :kbd:`ctrl` :kbd:`v`"
 
 #: ../advanced/keyboard-shortcuts.rst:148
 msgid "Paste text from clipboard (as plain text)"
-msgstr ""
+msgstr "Klistra in text från urklipp (som vanlig text)"
 
 #: ../advanced/keyboard-shortcuts.rst:149
 msgid ":kbd:`shift` :kbd:`ctrl` :kbd:`f`"
-msgstr ""
+msgstr ":kbd:`shift` :kbd:`ctrl` :kbd:`f`"
 
 #: ../advanced/keyboard-shortcuts.rst:149
 msgid "Remove formatting of text"
-msgstr ""
+msgstr "Ta bort formatering av text"
 
 #: ../advanced/keyboard-shortcuts.rst:150
 msgid ":kbd:`shift` :kbd:`ctrl` :kbd:`y`"
-msgstr ""
+msgstr ":kbd:`shift` :kbd:`ctrl` :kbd:`y`"
 
 #: ../advanced/keyboard-shortcuts.rst:150
 msgid "Remove formatting of the whole text"
-msgstr ""
+msgstr "Ta bort formateringen av hela texten"
 
 #: ../advanced/keyboard-shortcuts.rst:151
 msgid ":kbd:`shift` :kbd:`ctrl` :kbd:`z`"
-msgstr ""
+msgstr ":kbd:`shift` :kbd:`ctrl` :kbd:`z`"
 
 #: ../advanced/keyboard-shortcuts.rst:151
 msgid "Insert a horizontal line"
-msgstr ""
+msgstr "Infoga en horisontell linje"
 
 #: ../advanced/keyboard-shortcuts.rst:152
 msgid ":kbd:`shift` :kbd:`ctrl` :kbd:`l`"
-msgstr ""
+msgstr ":kbd:`shift` :kbd:`ctrl` :kbd:`l`"
 
 #: ../advanced/keyboard-shortcuts.rst:152
 msgid "Format as unordered list"
-msgstr ""
+msgstr "Formatera som oordnad lista"
 
 #: ../advanced/keyboard-shortcuts.rst:153
 msgid ":kbd:`shift` :kbd:`ctrl` :kbd:`k`"
-msgstr ""
+msgstr ":kbd:`shift` :kbd:`ctrl` :kbd:`k`"
 
 #: ../advanced/keyboard-shortcuts.rst:153
 msgid "Format as ordered list"
-msgstr ""
+msgstr "Formatera som ordnad lista"
 
 #: ../advanced/keyboard-shortcuts.rst:154
 msgid ":kbd:`shift` :kbd:`ctrl` :kbd:`1`"
-msgstr ""
+msgstr ":kbd:`shift` :kbd:`ctrl` :kbd:`1`"
 
 #: ../advanced/keyboard-shortcuts.rst:154
 msgid "Format as h1 heading"
-msgstr ""
+msgstr "Formatera som h1-rubrik"
 
 #: ../advanced/keyboard-shortcuts.rst:155
+#, fuzzy
 msgid ":kbd:`shift` :kbd:`ctrl` :kbd:`2`"
-msgstr ""
+msgstr ":kbd:`shift` :kbd:`ctrl` :kbd:`2`"
 
 #: ../advanced/keyboard-shortcuts.rst:155
 msgid "Format as h2 heading"
-msgstr ""
+msgstr "Formatera som h2-rubrik"
 
 #: ../advanced/keyboard-shortcuts.rst:156
 msgid ":kbd:`shift` :kbd:`ctrl` :kbd:`3`"
-msgstr ""
+msgstr ":kbd:`shift` :kbd:`ctrl` :kbd:`3`"
 
 #: ../advanced/keyboard-shortcuts.rst:156
 msgid "Format as h3 heading"
-msgstr ""
+msgstr "Formatera som h3-rubrik"
 
 #: ../advanced/keyboard-shortcuts.rst:157
 msgid ":kbd:`shift` :kbd:`ctrl` :kbd:`x`"
-msgstr ""
+msgstr ":kbd:`shift` :kbd:`ctrl` :kbd:`x`"
 
 #: ../advanced/keyboard-shortcuts.rst:157
 msgid "Remove any hyperlink"
-msgstr ""
+msgstr "Ta bort hyperlänk"
 
 #: ../advanced/keyboard-shortcuts.rst:160
+#, fuzzy
 msgid ""
 "If you are a Mac user, use :kbd:`cmd` instead of :kbd:`ctrl` and :kbd:"
 "`ctrl` :kbd:`option` instead of :kbd:`shift` :kbd:`ctrl`."
 msgstr ""
+"Om du är Mac-användare använder du :kbd:`cmd` i stället för :kbd:`ctrl` och "
+":kbd:`ctrl` :kbd:`option` i stället för :kbd:`shift` :kbd:`ctrl`."
 
 #: ../advanced/macros.rst:2
 msgid "Macros"
-msgstr ""
+msgstr "Macros"
 
 #: ../advanced/macros.rst:4
 msgid "Macros are **🖱️ one-click shortcuts** for applying changes to a ticket."
 msgstr ""
+"Makron är **🖱️ genvägar med ett klick** för att göra ändringar i ett ärende."
 
 #: ../advanced/macros.rst:6
 msgid ""
@@ -547,6 +577,9 @@ msgid ""
 "close-and-tag-as-spam or reassign-to-another-group), macros can make the job "
 "a whole lot easier."
 msgstr ""
+"Om du gör samma ändringar i många olika ärenden (*t.ex.* stäng-och-tagga-som-"
+"spam eller omfördela till en annan grupp) kan makron göra jobbet mycket "
+"enklare."
 
 #: ../advanced/macros.rst:10
 msgid ""
@@ -554,24 +587,29 @@ msgid ""
 "html>`. If you have an idea for a macro you'd like to use, your Zammad admin "
 "can probably make it happen."
 msgstr ""
+"Makron kan skapas av din :admin-docs:`administratör </manage/macros.html>`. "
+"Om du har en idé om ett makro som du skulle vilja använda, kan din "
+"administratör förmodligen få det att hända."
 
 #: ../advanced/macros.rst:14
 msgid "Macros can be applied in two ways: on a single ticket, or in bulk."
-msgstr ""
+msgstr "Makron kan användas på två sätt: på ett enskilt ärende eller i bulk."
 
 #: ../advanced/macros.rst:17
 msgid "On a Single Ticket"
-msgstr ""
+msgstr "På ett Ärende"
 
 #: ../advanced/macros.rst:19
 msgid ""
 "The simplest way to apply a macro is to select it from the **Update ^** "
 "submenu in the Ticket View:"
 msgstr ""
+"Det enklaste sättet att använda ett makro är att välja det från undermenyn **"
+"Uppdatera ^** i ärendet:"
 
 #: ../advanced/macros.rst:None
 msgid "Screencast showing how to run a macro within a ticket view."
-msgstr ""
+msgstr "Screencast som visar hur man kör ett makro i ett ärende."
 
 #: ../advanced/macros.rst:27
 msgid "💾 **Macro = Update**"


### PR DESCRIPTION
Translations update from [Zammad-Translations](https://translations.zammad.org) for [Documentation/User Documentation (pre-release)](https://translations.zammad.org/projects/documentations/user-documentation-pre-release/).



Current translation status:

![Weblate translation status](https://translations.zammad.org/widget/documentations/user-documentation-pre-release/horizontal-auto.svg)