### PR TITLE
Translations update from Zammad-Translations

### DIFF
--- a/locale/sv/LC_MESSAGES/user-docs.po
+++ b/locale/sv/LC_MESSAGES/user-docs.po
@@ -43,9 +43,9 @@ msgid ""
 "Click on your avatar at the bottom of the main menu and select \"Keyboard "
 "Shortcuts\" or just press :kbd:`?` to open the keyboard shortcut overview."
 msgstr ""
-"Klicka på din avatar längst ned i huvudmenyn och välj \"Tangentbordsgenvägar"
-"\" eller tryck bara på :kbd:`?` för att öppna översikten över "
-"tangentbordsgenvägar."
+"Klicka på din avatar längst ned i huvudmenyn och välj "
+"\"Tangentbordsgenvägar\" eller tryck bara på :kbd:`?` för att öppna "
+"översikten över tangentbordsgenvägar."
 
 #: ../advanced/keyboard-shortcuts.rst:None
 #: ../extras/profile-and-settings.rst:12
@@ -559,8 +559,8 @@ msgid ""
 "If you are a Mac user, use :kbd:`cmd` instead of :kbd:`ctrl` and :kbd:"
 "`ctrl` :kbd:`option` instead of :kbd:`shift` :kbd:`ctrl`."
 msgstr ""
-"Om du är Mac-användare använder du :kbd:`cmd` i stället för :kbd:`ctrl` och "
-":kbd:`ctrl` :kbd:`option` i stället för :kbd:`shift` :kbd:`ctrl`."
+"Om du är Mac-användare använder du :kbd:`cmd` i stället för :kbd:`ctrl` och :"
+"kbd:`ctrl` :kbd:`option` i stället för :kbd:`shift` :kbd:`ctrl`."
 
 #: ../advanced/macros.rst:2
 msgid "Macros"
@@ -604,8 +604,8 @@ msgid ""
 "The simplest way to apply a macro is to select it from the **Update ^** "
 "submenu in the Ticket View:"
 msgstr ""
-"Det enklaste sättet att använda ett makro är att välja det från undermenyn **"
-"Uppdatera ^** i ärendet:"
+"Det enklaste sättet att använda ett makro är att välja det från undermenyn "
+"**Uppdatera ^** i ärendet:"
 
 #: ../advanced/macros.rst:None
 msgid "Screencast showing how to run a macro within a ticket view."
@@ -649,7 +649,7 @@ msgstr ""
 
 #: ../advanced/macros.rst:52
 msgid "open a ticket overview;"
-msgstr ""
+msgstr "öppna ticketöversikt;"
 
 #: ../advanced/macros.rst:53
 msgid "select your desired tickets;"
@@ -682,7 +682,7 @@ msgstr ""
 
 #: ../advanced/search.rst:2
 msgid "Advanced Search"
-msgstr ""
+msgstr "Avancerad Sök"
 
 #: ../advanced/search.rst:4
 msgid ""
@@ -699,7 +699,7 @@ msgstr ""
 
 #: ../advanced/search.rst:13
 msgid "or::"
-msgstr ""
+msgstr "eller::"
 
 #: ../advanced/search.rst:18
 msgid ""
@@ -709,7 +709,7 @@ msgstr ""
 
 #: ../advanced/search.rst:24
 msgid "Available Attributes"
-msgstr ""
+msgstr "Tillgängliga Attributer"
 
 #: ../advanced/search.rst:28
 msgid ""
@@ -720,51 +720,51 @@ msgstr ""
 
 #: ../advanced/search.rst:35
 msgid "Attributes and their usuage"
-msgstr ""
+msgstr "Attributer och användningsområde"
 
 #: ../advanced/search.rst:1
 msgid "Attribute"
-msgstr ""
+msgstr "Egenskap"
 
 #: ../advanced/search.rst:1
 msgid "possible Values"
-msgstr ""
+msgstr "Möjliga Värden"
 
 #: ../advanced/search.rst:1
 msgid "Example"
-msgstr ""
+msgstr "Exempel"
 
 #: ../advanced/search.rst:1
 msgid "Description"
-msgstr ""
+msgstr "Förklaring"
 
 #: ../advanced/search.rst:1
 msgid "number"
-msgstr ""
+msgstr "nummer"
 
 #: ../advanced/search.rst:1
 msgid "1118566"
-msgstr ""
+msgstr "1118566"
 
 #: ../advanced/search.rst:1
 msgid "number:1118566 |br|\\ number:11185*"
-msgstr ""
+msgstr "nummer:1118566 |br|\\ nummer:11185*"
 
 #: ../advanced/search.rst:1
 msgid "Search for a Ticketnumber"
-msgstr ""
+msgstr "Sök efter ett Ticketnummer"
 
 #: ../advanced/search.rst:1
 msgid "title"
-msgstr ""
+msgstr "ämne"
 
 #: ../advanced/search.rst:1
 msgid "some title"
-msgstr ""
+msgstr "någon titel"
 
 #: ../advanced/search.rst:1
 msgid "title:\"some title\" |br|\\ title:Printer |br|\\ title: \"some ti*\""
-msgstr ""
+msgstr "titel:\"någon titel\" |br|\\ titel:Skrivare |br|\\ titel;\"någon ti*\""
 
 #: ../advanced/search.rst:1
 msgid ""
@@ -775,11 +775,11 @@ msgstr ""
 
 #: ../advanced/search.rst:1
 msgid "created_at"
-msgstr ""
+msgstr "skapad_vid"
 
 #: ../advanced/search.rst:1
 msgid "2018-11-18"
-msgstr ""
+msgstr "2018-11-18"
 
 #: ../advanced/search.rst:1
 msgid ""
@@ -814,7 +814,7 @@ msgstr ""
 
 #: ../advanced/search.rst:1
 msgid "article_count"
-msgstr ""
+msgstr "artikel_räkna"
 
 #: ../advanced/search.rst:1
 msgid "5 |br|\\ [5 TO 10] |br|\\ [5 TO \\*] |br|\\ [\\* TO 5]"
@@ -835,7 +835,7 @@ msgstr ""
 
 #: ../advanced/search.rst:1
 msgid "article.from"
-msgstr ""
+msgstr "artikel.från"
 
 #: ../advanced/search.rst:1
 msgid "\\*bob\\*"
@@ -891,7 +891,7 @@ msgstr ""
 
 #: ../advanced/search.rst:1
 msgid "Search phrase"
-msgstr ""
+msgstr "Sökfras"
 
 #: ../advanced/search.rst:1
 msgid ""
@@ -922,7 +922,7 @@ msgstr ""
 
 #: ../advanced/search.rst:1
 msgid "Show Tickets from bob@example.net that are either open or new"
-msgstr ""
+msgstr "Visa tickets från bob@example.net som är öppna eller nya"
 
 #: ../advanced/search.rst:1
 msgid "state.name:pending* AND article_count:[1 TO 5]"
@@ -944,23 +944,23 @@ msgstr ""
 
 #: ../advanced/search.rst:72
 msgid "Ticket Attributes"
-msgstr ""
+msgstr "Ticket Attributet"
 
 #: ../advanced/search.rst:74
 msgid "number: string"
-msgstr ""
+msgstr "nummer: sträng"
 
 #: ../advanced/search.rst:75
 msgid "title: string"
-msgstr ""
+msgstr "Ämne: sträng"
 
 #: ../advanced/search.rst:76
 msgid "group: object (group.name, ...)"
-msgstr ""
+msgstr "grupp: objekt (grupp.namn, ...)"
 
 #: ../advanced/search.rst:77
 msgid "priority: object (priority.name, ...)"
-msgstr ""
+msgstr "prioritet: ämne (prioritet.namn, ...)"
 
 #: ../advanced/search.rst:78
 msgid "state: object (state.name, ...)"
@@ -989,7 +989,7 @@ msgstr ""
 
 #: ../advanced/search.rst:85
 msgid "close_at: timestamp"
-msgstr ""
+msgstr "stängt_vid: tidstämpel"
 
 #: ../advanced/search.rst:86
 msgid "close_in_min: integer (business min till close)"
@@ -1216,11 +1216,11 @@ msgstr ""
 
 #: ../advanced/suggested-workflows.rst:102
 msgid "group"
-msgstr ""
+msgstr "grupp"
 
 #: ../advanced/suggested-workflows.rst:103
 msgid "owner"
-msgstr ""
+msgstr "ägare"
 
 #: ../advanced/suggested-workflows.rst:104
 msgid "state (with pending time if applicable)"
@@ -1228,7 +1228,7 @@ msgstr ""
 
 #: ../advanced/suggested-workflows.rst:105
 msgid "priority"
-msgstr ""
+msgstr "prioritet"
 
 #: ../advanced/suggested-workflows.rst:107
 msgid ""
@@ -1259,17 +1259,19 @@ msgstr ""
 
 #: ../advanced/suggested-workflows.rst:134
 msgid "Bulk action via drag and drop:"
-msgstr ""
+msgstr "Massåtgärd genom drag och släpp:"
 
 #: ../advanced/suggested-workflows.rst:123
 msgid "**🤓 You can change owners and groups even faster 🚀**"
-msgstr ""
+msgstr "**🤓 Du kan nu ändra ägare och grupper ännu snabbare 🚀**"
 
 #: ../advanced/suggested-workflows.rst:0
 msgid ""
 "Drag selected tickets and drop then on a group or agent to change\n"
 "ticket group / owner"
 msgstr ""
+"Dra och släpp markerade tickets på en grupp eller en agent för att ändra\n"
+"ticket grupp / ägare"
 
 #: ../advanced/suggested-workflows.rst:130
 msgid ""
@@ -1281,11 +1283,11 @@ msgstr ""
 
 #: ../advanced/suggested-workflows.rst:135
 msgid "This functionality is only available in ticket overviews."
-msgstr ""
+msgstr "Denna funktion är enbart tillgänglig i översikt av tickets."
 
 #: ../advanced/tabs.rst:2
 msgid "Tabs"
-msgstr ""
+msgstr "Flikar"
 
 #: ../advanced/tabs.rst:4
 msgid ""
@@ -4663,7 +4665,7 @@ msgstr ""
 
 #: ../extras/checklist.rst:5
 msgid "General"
-msgstr ""
+msgstr "Allmänt"
 
 #: ../extras/checklist.rst:7
 msgid ""
@@ -4683,7 +4685,7 @@ msgstr ""
 
 #: ../extras/checklist.rst:18
 msgid "Usage"
-msgstr ""
+msgstr "Användning"
 
 #: ../extras/checklist.rst:21 ../index.rst:9
 msgid "Basics"


### PR DESCRIPTION
Translations update from [Zammad-Translations](https://translations.zammad.org) for [Documentation/User Documentation (pre-release)](https://translations.zammad.org/projects/documentations/user-documentation-pre-release/).



Current translation status:

![Weblate translation status](https://translations.zammad.org/widget/documentations/user-documentation-pre-release/horizontal-auto.svg)