### PR TITLE
Translations update from Zammad-Translations

### DIFF
--- a/locale/it/LC_MESSAGES/user-docs.po
+++ b/locale/it/LC_MESSAGES/user-docs.po
@@ -8,16 +8,16 @@ msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-11-06 08:08+0100\n"
-"PO-Revision-Date: 2023-07-28 09:18+0000\n"
-"Last-Translator: crnfpp <crnfpp@unife.it>\n"
+"PO-Revision-Date: 2024-11-13 12:00+0000\n"
+"Last-Translator: Cap6991 <an_96_drea@hotmail.it>\n"
 "Language-Team: Italian <https://translations.zammad.org/projects/"
-"documentations/user-documentation-latest/it/>\n"
+"documentations/user-documentation-pre-release/it/>\n"
 "Language: it\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.18.2\n"
+"X-Generator: Weblate 5.7.2\n"
 
 #: ../advanced/keyboard-shortcuts.rst:2
 msgid "Keyboard Shortcuts"
@@ -347,7 +347,7 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:113
 msgid "Switch the visibility of the article between internal and public"
-msgstr ""
+msgstr "Cambia la visibilità dell'articolo tra interna e pubblica"
 
 #: ../advanced/keyboard-shortcuts.rst:114
 msgid ":kbd:`shift` :kbd:`c`"
@@ -355,7 +355,7 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:114
 msgid "Set state of the ticket to \"closed\""
-msgstr ""
+msgstr "Imposta stato del ticket a \"chiuso\""
 
 #: ../advanced/keyboard-shortcuts.rst:115
 msgid "Navigate through article"
@@ -387,7 +387,7 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:122
 msgid "Text Editing"
-msgstr ""
+msgstr "Editor Testo"
 
 #: ../advanced/keyboard-shortcuts.rst:137
 msgid "How"
@@ -451,7 +451,7 @@ msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:144
 msgid "Format text in **bold**"
-msgstr ""
+msgstr "Formatta il testo in **grassetto**"
 
 #: ../advanced/keyboard-shortcuts.rst:145
 msgid ":kbd:`ctrl` :kbd:`i`"


### PR DESCRIPTION
Translations update from [Zammad-Translations](https://translations.zammad.org) for [Documentation/User Documentation (pre-release)](https://translations.zammad.org/projects/documentations/user-documentation-pre-release/).



Current translation status:

![Weblate translation status](https://translations.zammad.org/widget/documentations/user-documentation-pre-release/horizontal-auto.svg)