### PR TITLE
Translations update from Zammad-Translations

### DIFF
--- a/locale/de/LC_MESSAGES/user-docs.po
+++ b/locale/de/LC_MESSAGES/user-docs.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-02-04 13:50+0100\n"
-"PO-Revision-Date: 2024-12-20 14:00+0000\n"
+"PO-Revision-Date: 2025-02-06 14:00+0000\n"
 "Last-Translator: Ralf Schmid <rsc@zammad.com>\n"
 "Language-Team: German <https://translations.zammad.org/projects/"
 "documentations/user-documentation-pre-release/de/>\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 5.7.2\n"
+"X-Generator: Weblate 5.9.2\n"
 
 #: ../advanced/keyboard-shortcuts.rst:2
 msgid "Keyboard Shortcuts"
@@ -1092,10 +1092,8 @@ msgid "last_contact_customer_at: timestamp (last contact by customer)"
 msgstr "last_contact_customer_at: Zeitstempel (Letzter Kontakt durch Kunden)"
 
 #: ../advanced/search.rst:90
-#, fuzzy
-#| msgid "create_article_type: string (email|phone|web|...)"
 msgid "create_article_type.name: string (email|phone|web|...)"
-msgstr "create_article_type: String (email|phone|web|...)"
+msgstr "create_article_type.name: string (email|phone|web|...)"
 
 #: ../advanced/search.rst:91
 msgid "create_article_sender: string (Customer|Agent|System)"

--- a/locale/sr/LC_MESSAGES/user-docs.po
+++ b/locale/sr/LC_MESSAGES/user-docs.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-02-04 13:50+0100\n"
-"PO-Revision-Date: 2025-01-16 10:00+0000\n"
+"PO-Revision-Date: 2025-02-06 14:00+0000\n"
 "Last-Translator: Dusan Vuckovic <dv@zammad.com>\n"
 "Language-Team: Serbian <https://translations.zammad.org/projects/"
 "documentations/user-documentation-pre-release/sr/>\n"
@@ -1067,10 +1067,8 @@ msgstr ""
 "клијента)"
 
 #: ../advanced/search.rst:90
-#, fuzzy
-#| msgid "create_article_type: string (email|phone|web|...)"
 msgid "create_article_type.name: string (email|phone|web|...)"
-msgstr "create_article_type: текст (email|phone|web|…)"
+msgstr "create_article_type.name: текст (email|phone|web|…)"
 
 #: ../advanced/search.rst:91
 msgid "create_article_sender: string (Customer|Agent|System)"

--- a/locale/tr/LC_MESSAGES/user-docs.po
+++ b/locale/tr/LC_MESSAGES/user-docs.po
@@ -8,8 +8,8 @@ msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-02-04 13:50+0100\n"
-"PO-Revision-Date: 2024-02-17 07:00+0000\n"
-"Last-Translator: Kadir Çakmak <kadir.cakmak@estetikdecor.com>\n"
+"PO-Revision-Date: 2025-02-11 08:00+0000\n"
+"Last-Translator: Türk Oyuncu <recentlly@hotmail.com>\n"
 "Language-Team: Turkish <https://translations.zammad.org/projects/"
 "documentations/user-documentation-pre-release/tr/>\n"
 "Language: tr\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 5.3.1\n"
+"X-Generator: Weblate 5.9.2\n"
 
 #: ../advanced/keyboard-shortcuts.rst:2
 msgid "Keyboard Shortcuts"
@@ -79,7 +79,7 @@ msgstr "Bilet Ayarları"
 
 #: ../advanced/keyboard-shortcuts.rst:31
 msgid "At the top of the dialog, you can:"
-msgstr ""
+msgstr "İletişim kutusunun üst bölümünde şunları yapabilirsiniz:"
 
 #: ../advanced/keyboard-shortcuts.rst:33
 msgid ""


### PR DESCRIPTION
Translations update from [Zammad-Translations](https://translations.zammad.org) for [Documentation/User Documentation (pre-release)](https://translations.zammad.org/projects/documentations/user-documentation-pre-release/).



Current translation status:

![Weblate translation status](https://translations.zammad.org/widget/documentations/user-documentation-pre-release/horizontal-auto.svg)