### PR TITLE
Translations update from Zammad-Translations

### DIFF
--- a/locale/de/LC_MESSAGES/user-docs.po
+++ b/locale/de/LC_MESSAGES/user-docs.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-02-12 14:38+0100\n"
-"PO-Revision-Date: 2025-02-06 14:00+0000\n"
+"PO-Revision-Date: 2025-02-14 15:00+0000\n"
 "Last-Translator: Ralf Schmid <rsc@zammad.com>\n"
 "Language-Team: German <https://translations.zammad.org/projects/"
 "documentations/user-documentation-pre-release/de/>\n"
@@ -1508,7 +1508,7 @@ msgstr "|ylw|"
 
 #: ../snippets/ticket-state-type-circles.rst:5
 msgid "**Action needed** (e.g. new, open, pending reached)"
-msgstr ""
+msgstr "**Maßnahme erforderlich** (z.B. neu, offen, warten erreicht)"
 
 #: ../snippets/ticket-state-type-circles.rst:6
 msgid "|blk|"
@@ -1516,7 +1516,7 @@ msgstr "|blk|"
 
 #: ../snippets/ticket-state-type-circles.rst:7
 msgid "**Paused, no action needed right now** (e.g. pending)"
-msgstr ""
+msgstr "**Pausiert, im Moment keine Aktion erforderlich** (z.B. warten auf)"
 
 #: ../snippets/ticket-state-type-circles.rst:8 ../extras/knowledge-base.rst:214
 msgid "|grn|"
@@ -1524,7 +1524,7 @@ msgstr "|grn|"
 
 #: ../snippets/ticket-state-type-circles.rst:9
 msgid "**No action needed any more** (e.g. closed, merged)"
-msgstr ""
+msgstr "**keine Aktion mehr erforderlich** (z.B. geschlossen, zusammengefasst)"
 
 #: ../snippets/ticket-state-type-circles.rst:10
 msgid "|red|"
@@ -1533,6 +1533,8 @@ msgstr "|red|"
 #: ../snippets/ticket-state-type-circles.rst:11
 msgid "**Immediate action needed** (ticket escalated due to an SLA violation)"
 msgstr ""
+"**Sofortige Maßnahme erforderlich** (Ticket wurde aufgrund einer SLA-"
+"Verletzung eskaliert)"
 
 #: ../advanced/tabs.rst:31
 msgid ""
@@ -2343,16 +2345,12 @@ msgstr ""
 "und passen Sie diese entsprechend an."
 
 #: ../basics/find-ticket/browse.rst:31
-#, fuzzy
-#| msgid ""
-#| "Learn more about states and their color coding on this page: :doc:`/"
-#| "basics/service-ticket/settings/state`"
 msgid ""
 "The need for action is color coded and reflects mainly the :doc:`ticket "
 "states </basics/service-ticket/settings/state>`:"
 msgstr ""
-"Zu Status und deren Farben erfahren Sie mehr auf dieser Seite: :doc:`/basics/"
-"service-ticket/settings/state`"
+"Der Handlungsbedarf ist farblich gekennzeichnet und spiegelt hauptsächlich "
+"den :doc:`Ticket Status </basics/service-ticket/settings/state>` wider:"
 
 #: ../basics/find-ticket/browse.rst:34
 msgid ""
@@ -3315,6 +3313,9 @@ msgid ""
 "Customers can't set a priority for their own tickets. For more context, have "
 "a look at the `Github-Issue <https://github.com/zammad/zammad/issues/814>`_."
 msgstr ""
+"Kunden können keine Priorität für ihre eigenen Tickets festlegen. Weitere "
+"Informationen dazu finden Sie im `Github-Issue <https://github.com/zammad/"
+"zammad/issues/814>`_."
 
 #: ../basics/service-ticket/settings/state.rst:2
 #: ../basics/what-is-a-ticket.rst:51 ../basics/zammad-glossary.rst:682

--- a/locale/sr/LC_MESSAGES/user-docs.po
+++ b/locale/sr/LC_MESSAGES/user-docs.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-02-12 14:38+0100\n"
-"PO-Revision-Date: 2025-02-13 09:01+0000\n"
+"PO-Revision-Date: 2025-02-14 15:00+0000\n"
 "Last-Translator: Dusan Vuckovic <dv@zammad.com>\n"
 "Language-Team: Serbian <https://translations.zammad.org/projects/"
 "documentations/user-documentation-pre-release/sr/>\n"
@@ -1472,7 +1472,7 @@ msgstr "|ylw|"
 
 #: ../snippets/ticket-state-type-circles.rst:5
 msgid "**Action needed** (e.g. new, open, pending reached)"
-msgstr ""
+msgstr "**Захтева обраду** (нпр. нови, отворени, достигнуто време чекања)"
 
 #: ../snippets/ticket-state-type-circles.rst:6
 msgid "|blk|"
@@ -1480,7 +1480,7 @@ msgstr "|blk|"
 
 #: ../snippets/ticket-state-type-circles.rst:7
 msgid "**Paused, no action needed right now** (e.g. pending)"
-msgstr ""
+msgstr "**На паузи, не захтева обраду** (нпр. на чекању)"
 
 #: ../snippets/ticket-state-type-circles.rst:8 ../extras/knowledge-base.rst:214
 msgid "|grn|"
@@ -1488,7 +1488,7 @@ msgstr "|grn|"
 
 #: ../snippets/ticket-state-type-circles.rst:9
 msgid "**No action needed any more** (e.g. closed, merged)"
-msgstr ""
+msgstr "**Више не захтева обраду** (нпр. затворено, спојено)"
 
 #: ../snippets/ticket-state-type-circles.rst:10
 msgid "|red|"
@@ -1496,7 +1496,7 @@ msgstr "|red|"
 
 #: ../snippets/ticket-state-type-circles.rst:11
 msgid "**Immediate action needed** (ticket escalated due to an SLA violation)"
-msgstr ""
+msgstr "**Захтева тренутну обраду** (тикет је ескалиран услед SLA прекршаја)"
 
 #: ../advanced/tabs.rst:31
 msgid ""
@@ -2268,16 +2268,12 @@ msgid "Click-and-drag column dividers to adjust their width."
 msgstr "Кликните и превуците ивице колона да бисте прилагодили њихову ширину."
 
 #: ../basics/find-ticket/browse.rst:31
-#, fuzzy
-#| msgid ""
-#| "Learn more about states and their color coding on this page: :doc:`/"
-#| "basics/service-ticket/settings/state`"
 msgid ""
 "The need for action is color coded and reflects mainly the :doc:`ticket "
 "states </basics/service-ticket/settings/state>`:"
 msgstr ""
-"Сазнајте више о стањима и њиховим бојама у секцији :doc:`/basics/service-"
-"ticket/settings/state`."
+"Потреба за обрадом је означена бојом и углавном одражава :doc:`стања тикета "
+"</basics/service-ticket/settings/state>`:"
 
 #: ../basics/find-ticket/browse.rst:34
 msgid ""


### PR DESCRIPTION
Translations update from [Zammad-Translations](https://translations.zammad.org) for [Documentation/User Documentation (pre-release)](https://translations.zammad.org/projects/documentations/user-documentation-pre-release/).



Current translation status:

![Weblate translation status](https://translations.zammad.org/widget/documentations/user-documentation-pre-release/horizontal-auto.svg)