### PR TITLE
Translations update from Zammad-Translations

### DIFF
--- a/locale/da/LC_MESSAGES/user-docs.po
+++ b/locale/da/LC_MESSAGES/user-docs.po
@@ -8,13 +8,16 @@ msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-02-12 14:38+0100\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: Automatically generated\n"
-"Language-Team: none\n"
+"PO-Revision-Date: 2025-05-29 09:01+0000\n"
+"Last-Translator: LomaxThomas <thomas.hartvig@lomax.dk>\n"
+"Language-Team: Danish <https://translations.zammad.org/projects/"
+"documentations/user-documentation-latest/da/>\n"
 "Language: da\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Weblate 5.11.4\n"
 
 #: ../advanced/keyboard-shortcuts.rst:2
 msgid "Keyboard Shortcuts"
@@ -4632,7 +4635,7 @@ msgstr ""
 
 #: ../extras/checklist.rst:5
 msgid "General"
-msgstr ""
+msgstr "Generelt"
 
 #: ../extras/checklist.rst:7
 msgid ""

--- a/locale/th/LC_MESSAGES/user-docs.po
+++ b/locale/th/LC_MESSAGES/user-docs.po
@@ -8,16 +8,16 @@ msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-02-12 14:38+0100\n"
-"PO-Revision-Date: 2022-04-16 15:56+0000\n"
-"Last-Translator: LAO <sumonchai@gmail.com>\n"
+"PO-Revision-Date: 2025-05-29 09:01+0000\n"
+"Last-Translator: Sumonchai Wongphithak <sumonchai@gmail.com>\n"
 "Language-Team: Thai <https://translations.zammad.org/projects/documentations/"
-"user-documentation/th/>\n"
+"user-documentation-latest/th/>\n"
 "Language: th\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: Weblate 4.11.2\n"
+"X-Generator: Weblate 5.11.4\n"
 
 #: ../advanced/keyboard-shortcuts.rst:2
 msgid "Keyboard Shortcuts"
@@ -62,10 +62,8 @@ msgid "The keyboard shortcut overview."
 msgstr ""
 
 #: ../advanced/keyboard-shortcuts.rst:29
-#, fuzzy
-#| msgid "Ticket Settings"
 msgid "Settings"
-msgstr "ตั้งค่า ใบแจ้งซ่อม"
+msgstr "ตั้งค่า"
 
 #: ../advanced/keyboard-shortcuts.rst:31
 msgid "At the top of the dialog, you can:"
@@ -917,10 +915,8 @@ msgid ""
 msgstr ""
 
 #: ../advanced/search.rst:72
-#, fuzzy
-#| msgid "Ticket Settings"
 msgid "Ticket Attributes"
-msgstr "ตั้งค่า ใบแจ้งซ่อม"
+msgstr "คุณลักษณะของตั๋ว"
 
 #: ../advanced/search.rst:74
 msgid "number: string"


### PR DESCRIPTION
Translations update from [Zammad-Translations](https://translations.zammad.org) for [Documentation/User Documentation (latest)](https://translations.zammad.org/projects/documentations/user-documentation-latest/).



Current translation status:

![Weblate translation status](https://translations.zammad.org/widget/documentations/user-documentation-latest/horizontal-auto.svg)