### PR TITLE
Translations update from Zammad-Translations

### DIFF
--- a/locale/de/LC_MESSAGES/user-docs.po
+++ b/locale/de/LC_MESSAGES/user-docs.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-08-08 15:39+0200\n"
-"PO-Revision-Date: 2025-07-26 07:00+0000\n"
+"PO-Revision-Date: 2025-08-13 06:00+0000\n"
 "Last-Translator: Ralf Schmid <rsc@zammad.com>\n"
 "Language-Team: German <https://translations.zammad.org/projects/"
 "documentations/user-documentation-pre-release/de/>\n"
@@ -5633,16 +5633,12 @@ msgid "Open questions (optional)"
 msgstr "Offene Fragen (optional)"
 
 #: ../extras/ai-features.rst:39
-#, fuzzy
-#| msgid "Open questions (optional)"
 msgid "Upcoming events (optional)"
-msgstr "Offene Fragen (optional)"
+msgstr "Anstehende Ereignisse (optional)"
 
 #: ../extras/ai-features.rst:40
-#, fuzzy
-#| msgid "Customer edit dialog"
 msgid "Customer sentiment (optional)"
-msgstr "Kunde bearbeiten Dialog"
+msgstr "Stimmung des Kunden (optional)"
 
 #: ../extras/ai-features.rst:43
 msgid "Smart Editor"


### PR DESCRIPTION
Translations update from [Zammad-Translations](https://translations.zammad.org) for [Documentation/User Documentation (pre-release)](https://translations.zammad.org/projects/documentations/user-documentation-pre-release/).



Current translation status:

![Weblate translation status](https://translations.zammad.org/widget/documentations/user-documentation-pre-release/horizontal-auto.svg)