### PR TITLE
Translations update from Zammad-Translations

### DIFF
--- a/locale/sr/LC_MESSAGES/user-docs.po
+++ b/locale/sr/LC_MESSAGES/user-docs.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-08-08 15:39+0200\n"
-"PO-Revision-Date: 2025-08-02 16:00+0000\n"
+"PO-Revision-Date: 2025-08-15 07:00+0000\n"
 "Last-Translator: Dusan Vuckovic <dv@zammad.com>\n"
 "Language-Team: Serbian <https://translations.zammad.org/projects/"
 "documentations/user-documentation-pre-release/sr/>\n"
@@ -5468,16 +5468,12 @@ msgid "Open questions (optional)"
 msgstr "Отворена питања (опционо)"
 
 #: ../extras/ai-features.rst:39
-#, fuzzy
-#| msgid "Open questions (optional)"
 msgid "Upcoming events (optional)"
-msgstr "Отворена питања (опционо)"
+msgstr "Предстојећи догађаји (опционо)"
 
 #: ../extras/ai-features.rst:40
-#, fuzzy
-#| msgid "Customer edit dialog"
 msgid "Customer sentiment (optional)"
-msgstr "Дијалог измене клијента"
+msgstr "Расположење клијента (опционо)"
 
 #: ../extras/ai-features.rst:43
 msgid "Smart Editor"


### PR DESCRIPTION
Translations update from [Zammad-Translations](https://translations.zammad.org) for [Documentation/User Documentation (pre-release)](https://translations.zammad.org/projects/documentations/user-documentation-pre-release/).



Current translation status:

![Weblate translation status](https://translations.zammad.org/widget/documentations/user-documentation-pre-release/horizontal-auto.svg)