### PR TITLE
Translations update from Zammad-Translations

### DIFF
--- a/locale/de/LC_MESSAGES/user-docs.po
+++ b/locale/de/LC_MESSAGES/user-docs.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-08-22 11:13+0200\n"
-"PO-Revision-Date: 2025-08-13 06:00+0000\n"
+"PO-Revision-Date: 2025-08-26 06:00+0000\n"
 "Last-Translator: Ralf Schmid <rsc@zammad.com>\n"
 "Language-Team: German <https://translations.zammad.org/projects/"
 "documentations/user-documentation-pre-release/de/>\n"
@@ -394,13 +394,13 @@ msgid ""
 "The most important formatting options are also available in the bubble menu. "
 "It automatically appears when you select text in the editor."
 msgstr ""
+"Die wichtigsten Formatierungsoptionen sind auch im Kontextmenü verfügbar. Es "
+"erscheint automatisch, wenn Sie Text im Editor markieren."
 
 #: ../advanced/keyboard-shortcuts.rst:0
 #: ../snippets/ui-protip-message-editor-features.rst:0
-#, fuzzy
-#| msgid "Screenshot shows avatar of an AI agent"
 msgid "Screenshot shows editor bubble menu to format text."
-msgstr "Screenshot zeigt Avatar eines KI-Agenten"
+msgstr "Screenshot zeigt das Kontextmenü des Editors zum Formatieren von Text."
 
 #: ../advanced/keyboard-shortcuts.rst:143
 msgid "How"
@@ -2695,17 +2695,15 @@ msgstr ""
 "Drop) von **🔤 Richtext**, **🌄 Bildern** und **📎 Datei-Anhängen**."
 
 #: ../snippets/ui-protip-message-editor-features.rst:6
-#, fuzzy
-#| msgid ""
-#| "Use the built-in :doc:`keyboard shortcuts </advanced/keyboard-shortcuts>` "
-#| "to apply rich text formatting."
 msgid ""
 "Use the built-in :doc:`keyboard shortcuts </advanced/keyboard-shortcuts>` to "
 "apply rich text formatting or select text and use a formatting option from "
 "the bubble menu which shows up after selecting text."
 msgstr ""
-"Benutzen Sie die integrierten :doc:`Tastaturkürzel </advanced/keyboard-"
-"shortcuts>`, um Text-Formatierungen anwenden zu können."
+"Verwenden Sie die eingebauten :doc:`Tastaturkürzel </advanced/keyboard-"
+"shortcuts>`, um Rich-Text-Formatierungen anzuwenden, oder markieren Sie Text "
+"und verwenden Sie eine Formatierungsoption aus dem Kontextmenü, das nach der "
+"Markierung des Textes angezeigt wird."
 
 #: ../snippets/ui-protip-message-editor-features.rst:13
 msgid ""

--- a/locale/sr/LC_MESSAGES/user-docs.po
+++ b/locale/sr/LC_MESSAGES/user-docs.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-08-22 11:13+0200\n"
-"PO-Revision-Date: 2025-08-15 07:00+0000\n"
+"PO-Revision-Date: 2025-08-26 06:00+0000\n"
 "Last-Translator: Dusan Vuckovic <dv@zammad.com>\n"
 "Language-Team: Serbian <https://translations.zammad.org/projects/"
 "documentations/user-documentation-pre-release/sr/>\n"
@@ -388,13 +388,13 @@ msgid ""
 "The most important formatting options are also available in the bubble menu. "
 "It automatically appears when you select text in the editor."
 msgstr ""
+"Најважније опције форматирања текста су такође доступне преко менија у "
+"облачићу. Биће аутоматски приказан приликом селекције текста у уреднику."
 
 #: ../advanced/keyboard-shortcuts.rst:0
 #: ../snippets/ui-protip-message-editor-features.rst:0
-#, fuzzy
-#| msgid "Screenshot shows avatar of an AI agent"
 msgid "Screenshot shows editor bubble menu to format text."
-msgstr "Снимак екрана који приказује сличицу AI агента"
+msgstr "Снимак екрана који приказује мени у облачићу за форматирање текста."
 
 #: ../advanced/keyboard-shortcuts.rst:143
 msgid "How"
@@ -2608,17 +2608,15 @@ msgstr ""
 "**🔤 богатог текста**, **🌄 слика** и **📎 датотека прилога**."
 
 #: ../snippets/ui-protip-message-editor-features.rst:6
-#, fuzzy
-#| msgid ""
-#| "Use the built-in :doc:`keyboard shortcuts </advanced/keyboard-shortcuts>` "
-#| "to apply rich text formatting."
 msgid ""
 "Use the built-in :doc:`keyboard shortcuts </advanced/keyboard-shortcuts>` to "
 "apply rich text formatting or select text and use a formatting option from "
 "the bubble menu which shows up after selecting text."
 msgstr ""
-"Користите уграђене :doc:`пречице на тастатури </advanced/keyboard-"
-"shortcuts>` за форматирање богатог текста."
+"Користите уграђене :doc:`пречице на тастатури </advanced/keyboard-shortcuts>`"
+" за форматирање богатог текста или одаберите текст и користите опције "
+"форматирања из менија у облачићу који ће бити приказан након селекције "
+"текста."
 
 #: ../snippets/ui-protip-message-editor-features.rst:13
 msgid ""


### PR DESCRIPTION
Translations update from [Zammad-Translations](https://translations.zammad.org) for [Documentation/User Documentation (pre-release)](https://translations.zammad.org/projects/documentations/user-documentation-pre-release/).



Current translation status:

![Weblate translation status](https://translations.zammad.org/widget/documentations/user-documentation-pre-release/horizontal-auto.svg)