### PR TITLE
Translations update from Zammad-Translations

### DIFF
--- a/locale/pl/LC_MESSAGES/user-docs.po
+++ b/locale/pl/LC_MESSAGES/user-docs.po
@@ -8,17 +8,17 @@ msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-09-09 08:29+0200\n"
-"PO-Revision-Date: 2024-06-13 21:00+0000\n"
-"Last-Translator: SamolJacek <samol.jacek@gmail.com>\n"
+"PO-Revision-Date: 2025-10-28 07:00+0000\n"
+"Last-Translator: MBekspert <michal.bosak@ekspert.biz>\n"
 "Language-Team: Polish <https://translations.zammad.org/projects/"
-"documentations/user-documentation-latest/pl/>\n"
+"documentations/user-documentation-pre-release/pl/>\n"
 "Language: pl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
 "|| n%100>=20) ? 1 : 2;\n"
-"X-Generator: Weblate 5.5.5\n"
+"X-Generator: Weblate 5.11.4\n"
 
 #: ../advanced/keyboard-shortcuts.rst:2
 msgid "Keyboard Shortcuts"
@@ -1152,9 +1152,8 @@ msgid "pending_time: timestamp"
 msgstr ""
 
 #: ../advanced/search.rst:95
-#, fuzzy
 msgid "Article Attributes"
-msgstr "Dostępne atrybuty"
+msgstr "cechy wpisu"
 
 #: ../advanced/search.rst:97
 msgid "article.from: string"
@@ -6261,7 +6260,7 @@ msgstr ""
 
 #: ../extras/mobile-view.rst:141
 msgid "Ticket Macros"
-msgstr ""
+msgstr "Makra zgłoszeń"
 
 #: ../extras/mobile-view.rst:142
 msgid "Ticket History"
@@ -6755,10 +6754,8 @@ msgid "The reporting screen consists of various sections:"
 msgstr ""
 
 #: ../extras/reporting.rst:None
-#, fuzzy
-#| msgid "Screencast showing how to run a macro within a ticket view."
 msgid "Screenshot showing different sections in the reporting screen"
-msgstr "Screencast pokazujący, jak uruchomić makro w widoku zgłoszenia."
+msgstr "Zrzut ekranu pokazuje różne sekcje w oknie raportów"
 
 #: ../extras/reporting.rst:20
 msgid ""


### PR DESCRIPTION
Translations update from [Zammad-Translations](https://translations.zammad.org) for [Documentation/User Documentation (pre-release)](https://translations.zammad.org/projects/documentations/user-documentation-pre-release/).



Current translation status:

![Weblate translation status](https://translations.zammad.org/widget/documentations/user-documentation-pre-release/horizontal-auto.svg)