### PR TITLE
Translations update from Zammad-Translations

### DIFF
--- a/locale/cs/LC_MESSAGES/user-docs.po
+++ b/locale/cs/LC_MESSAGES/user-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-09 08:29+0200\n"
+"POT-Creation-Date: 2025-11-04 07:08+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -1305,55 +1305,51 @@ msgstr ""
 #: ../advanced/tabs.rst:4
 msgid ""
 "As you click through Zammad, you will see a list of entries appear in the "
-"main menu area. These are your **open tabs.**"
+"main menu area. These are your **open tabs.** You can freely switch between "
+"open tabs without losing your work - all unsaved changes are automatically "
+"backed up to the server."
 msgstr ""
 
-#: ../advanced/tabs.rst:7
-msgid ""
-"You can freely switch between open tabs without losing your work - all "
-"unsaved changes are automatically backed up to the server."
-msgstr ""
-
-#: ../advanced/tabs.rst:13
+#: ../advanced/tabs.rst:12
 msgid "Sample view of Tabs"
 msgstr ""
 
-#: ../advanced/tabs.rst:13
+#: ../advanced/tabs.rst:12
 msgid ""
 "Tabs appear in the main menu as you visit different parts of the application."
 msgstr ""
 
-#: ../advanced/tabs.rst:16
+#: ../advanced/tabs.rst:15
 msgid "**What items open in a new “tab”?**"
 msgstr ""
 
-#: ../advanced/tabs.rst:18
+#: ../advanced/tabs.rst:17
 msgid "Existing tickets"
 msgstr ""
 
-#: ../advanced/tabs.rst:19
+#: ../advanced/tabs.rst:18
 msgid "New tickets"
 msgstr ""
 
-#: ../advanced/tabs.rst:20
+#: ../advanced/tabs.rst:19
 msgid "Users"
 msgstr ""
 
-#: ../advanced/tabs.rst:21 ../extras/organizations.rst:2
+#: ../advanced/tabs.rst:20 ../extras/organizations.rst:2
 msgid "Organizations"
 msgstr ""
 
-#: ../advanced/tabs.rst:22
+#: ../advanced/tabs.rst:21
 msgid "Omnisearch"
 msgstr ""
 
-#: ../advanced/tabs.rst:24 ../basics/find-ticket/browse.rst:27
+#: ../advanced/tabs.rst:23 ../basics/find-ticket/browse.rst:27
 #: ../basics/find-ticket/search.rst:33 ../basics/service-ticket/create.rst:47
 #: ../snippets/ui-protip-message-editor-features.rst:1
 msgid "**🖱️ UI Protip**"
 msgstr ""
 
-#: ../advanced/tabs.rst:26
+#: ../advanced/tabs.rst:25
 msgid ""
 ":doc:`Ticket states </basics/service-ticket/settings/state>` are **color-"
 "coded:**"
@@ -1391,21 +1387,21 @@ msgstr ""
 msgid "**Immediate action needed** (ticket escalated due to an SLA violation)"
 msgstr ""
 
-#: ../advanced/tabs.rst:31
+#: ../advanced/tabs.rst:30
 msgid ""
 "A **pulsing dot** means that a ticket has new activity since you last viewed "
 "it."
 msgstr ""
 
-#: ../advanced/tabs.rst:33
+#: ../advanced/tabs.rst:32
 msgid "Drag and drop tabs to rearrange them."
 msgstr ""
 
-#: ../advanced/tabs.rst:36
+#: ../advanced/tabs.rst:35
 msgid "Tab Behavior in Ticket Zooms"
 msgstr ""
 
-#: ../advanced/tabs.rst:38
+#: ../advanced/tabs.rst:37
 msgid ""
 "You may have noticed the \"Stay on tab\" button next to \"Update\" on the "
 "lower right already. This behavior of a tab can be configured by your "
@@ -1417,47 +1413,47 @@ msgstr ""
 msgid "Tab behavior can be adjusted in tickets manually"
 msgstr ""
 
-#: ../advanced/tabs.rst:47
+#: ../advanced/tabs.rst:46
 msgid ""
 "To overrule your administrator's settings, simply choose the action you "
 "prefer. Zammad will remember this preference until you change its setting."
 msgstr ""
 
-#: ../advanced/tabs.rst:52
+#: ../advanced/tabs.rst:51
 msgid "Close tab"
 msgstr ""
 
-#: ../advanced/tabs.rst:51
+#: ../advanced/tabs.rst:50
 msgid ""
 "Upon updating the ticket, Zammad will automatically close the tab. You'll be "
 "returned to the last view that was open."
 msgstr ""
 
-#: ../advanced/tabs.rst:58
+#: ../advanced/tabs.rst:57
 msgid "Close tab on ticket close"
 msgstr ""
 
-#: ../advanced/tabs.rst:55
+#: ../advanced/tabs.rst:54
 msgid ""
 "Ticket tabs will be closed only if you change the state to \"closed\" upon "
 "ticket update."
 msgstr ""
 
-#: ../advanced/tabs.rst:58
+#: ../advanced/tabs.rst:57
 msgid "This does not apply for pending states that end in closed states."
 msgstr ""
 
-#: ../advanced/tabs.rst:66
+#: ../advanced/tabs.rst:65
 msgid "Next in overview"
 msgstr ""
 
-#: ../advanced/tabs.rst:61
+#: ../advanced/tabs.rst:60
 msgid ""
 "If you opened a ticket from any overview, Zammad will jump to the next "
 "ticket in said overview. Zammad recycles the open tab."
 msgstr ""
 
-#: ../advanced/tabs.rst:64
+#: ../advanced/tabs.rst:63
 msgid ""
 "This option is only available if you open the ticket from an overview. "
 "Zammad will ignore the setting if you opened the ticket directly and fall "
@@ -1468,12 +1464,20 @@ msgstr ""
 msgid "Stay on tab"
 msgstr ""
 
-#: ../advanced/tabs.rst:69
+#: ../advanced/tabs.rst:68
 msgid "Updating the ticket doesn't have any effect on the tab."
 msgstr ""
 
-#: ../advanced/tabs.rst:71
+#: ../advanced/tabs.rst:70
 msgid "*This is the default setting in Zammad installations.*"
+msgstr ""
+
+#: ../advanced/tabs.rst:72
+msgid ""
+"Now that you are an expert in tab handling, one more thing might be "
+"interesting as well: the maximum number of tabs is 30 due to performance "
+"reasons. In case you reach the limit and open another tab, the first opened "
+"tab gets closed automatically."
 msgstr ""
 
 #: ../advanced/text-modules.rst:2

--- a/locale/da/LC_MESSAGES/user-docs.po
+++ b/locale/da/LC_MESSAGES/user-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-09 08:29+0200\n"
+"POT-Creation-Date: 2025-11-04 07:08+0000\n"
 "PO-Revision-Date: 2025-06-17 13:00+0000\n"
 "Last-Translator: LomaxThomas <thomas.hartvig@lomax.dk>\n"
 "Language-Team: Danish <https://translations.zammad.org/projects/"
@@ -1308,55 +1308,51 @@ msgstr ""
 #: ../advanced/tabs.rst:4
 msgid ""
 "As you click through Zammad, you will see a list of entries appear in the "
-"main menu area. These are your **open tabs.**"
+"main menu area. These are your **open tabs.** You can freely switch between "
+"open tabs without losing your work - all unsaved changes are automatically "
+"backed up to the server."
 msgstr ""
 
-#: ../advanced/tabs.rst:7
-msgid ""
-"You can freely switch between open tabs without losing your work - all "
-"unsaved changes are automatically backed up to the server."
-msgstr ""
-
-#: ../advanced/tabs.rst:13
+#: ../advanced/tabs.rst:12
 msgid "Sample view of Tabs"
 msgstr ""
 
-#: ../advanced/tabs.rst:13
+#: ../advanced/tabs.rst:12
 msgid ""
 "Tabs appear in the main menu as you visit different parts of the application."
 msgstr ""
 
-#: ../advanced/tabs.rst:16
+#: ../advanced/tabs.rst:15
 msgid "**What items open in a new “tab”?**"
 msgstr ""
 
-#: ../advanced/tabs.rst:18
+#: ../advanced/tabs.rst:17
 msgid "Existing tickets"
 msgstr ""
 
-#: ../advanced/tabs.rst:19
+#: ../advanced/tabs.rst:18
 msgid "New tickets"
 msgstr ""
 
-#: ../advanced/tabs.rst:20
+#: ../advanced/tabs.rst:19
 msgid "Users"
 msgstr ""
 
-#: ../advanced/tabs.rst:21 ../extras/organizations.rst:2
+#: ../advanced/tabs.rst:20 ../extras/organizations.rst:2
 msgid "Organizations"
 msgstr ""
 
-#: ../advanced/tabs.rst:22
+#: ../advanced/tabs.rst:21
 msgid "Omnisearch"
 msgstr ""
 
-#: ../advanced/tabs.rst:24 ../basics/find-ticket/browse.rst:27
+#: ../advanced/tabs.rst:23 ../basics/find-ticket/browse.rst:27
 #: ../basics/find-ticket/search.rst:33 ../basics/service-ticket/create.rst:47
 #: ../snippets/ui-protip-message-editor-features.rst:1
 msgid "**🖱️ UI Protip**"
 msgstr ""
 
-#: ../advanced/tabs.rst:26
+#: ../advanced/tabs.rst:25
 msgid ""
 ":doc:`Ticket states </basics/service-ticket/settings/state>` are **color-"
 "coded:**"
@@ -1394,21 +1390,21 @@ msgstr ""
 msgid "**Immediate action needed** (ticket escalated due to an SLA violation)"
 msgstr ""
 
-#: ../advanced/tabs.rst:31
+#: ../advanced/tabs.rst:30
 msgid ""
 "A **pulsing dot** means that a ticket has new activity since you last viewed "
 "it."
 msgstr ""
 
-#: ../advanced/tabs.rst:33
+#: ../advanced/tabs.rst:32
 msgid "Drag and drop tabs to rearrange them."
 msgstr ""
 
-#: ../advanced/tabs.rst:36
+#: ../advanced/tabs.rst:35
 msgid "Tab Behavior in Ticket Zooms"
 msgstr ""
 
-#: ../advanced/tabs.rst:38
+#: ../advanced/tabs.rst:37
 msgid ""
 "You may have noticed the \"Stay on tab\" button next to \"Update\" on the "
 "lower right already. This behavior of a tab can be configured by your "
@@ -1420,47 +1416,47 @@ msgstr ""
 msgid "Tab behavior can be adjusted in tickets manually"
 msgstr ""
 
-#: ../advanced/tabs.rst:47
+#: ../advanced/tabs.rst:46
 msgid ""
 "To overrule your administrator's settings, simply choose the action you "
 "prefer. Zammad will remember this preference until you change its setting."
 msgstr ""
 
-#: ../advanced/tabs.rst:52
+#: ../advanced/tabs.rst:51
 msgid "Close tab"
 msgstr ""
 
-#: ../advanced/tabs.rst:51
+#: ../advanced/tabs.rst:50
 msgid ""
 "Upon updating the ticket, Zammad will automatically close the tab. You'll be "
 "returned to the last view that was open."
 msgstr ""
 
-#: ../advanced/tabs.rst:58
+#: ../advanced/tabs.rst:57
 msgid "Close tab on ticket close"
 msgstr ""
 
-#: ../advanced/tabs.rst:55
+#: ../advanced/tabs.rst:54
 msgid ""
 "Ticket tabs will be closed only if you change the state to \"closed\" upon "
 "ticket update."
 msgstr ""
 
-#: ../advanced/tabs.rst:58
+#: ../advanced/tabs.rst:57
 msgid "This does not apply for pending states that end in closed states."
 msgstr ""
 
-#: ../advanced/tabs.rst:66
+#: ../advanced/tabs.rst:65
 msgid "Next in overview"
 msgstr ""
 
-#: ../advanced/tabs.rst:61
+#: ../advanced/tabs.rst:60
 msgid ""
 "If you opened a ticket from any overview, Zammad will jump to the next "
 "ticket in said overview. Zammad recycles the open tab."
 msgstr ""
 
-#: ../advanced/tabs.rst:64
+#: ../advanced/tabs.rst:63
 msgid ""
 "This option is only available if you open the ticket from an overview. "
 "Zammad will ignore the setting if you opened the ticket directly and fall "
@@ -1471,12 +1467,20 @@ msgstr ""
 msgid "Stay on tab"
 msgstr ""
 
-#: ../advanced/tabs.rst:69
+#: ../advanced/tabs.rst:68
 msgid "Updating the ticket doesn't have any effect on the tab."
 msgstr ""
 
-#: ../advanced/tabs.rst:71
+#: ../advanced/tabs.rst:70
 msgid "*This is the default setting in Zammad installations.*"
+msgstr ""
+
+#: ../advanced/tabs.rst:72
+msgid ""
+"Now that you are an expert in tab handling, one more thing might be "
+"interesting as well: the maximum number of tabs is 30 due to performance "
+"reasons. In case you reach the limit and open another tab, the first opened "
+"tab gets closed automatically."
 msgstr ""
 
 #: ../advanced/text-modules.rst:2

--- a/locale/de/LC_MESSAGES/user-docs.po
+++ b/locale/de/LC_MESSAGES/user-docs.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-09 08:29+0200\n"
-"PO-Revision-Date: 2025-09-11 07:00+0000\n"
+"POT-Creation-Date: 2025-11-04 07:08+0000\n"
+"PO-Revision-Date: 2025-11-06 16:00+0000\n"
 "Last-Translator: Ralf Schmid <rsc@zammad.com>\n"
 "Language-Team: German <https://translations.zammad.org/projects/"
 "documentations/user-documentation-pre-release/de/>\n"
@@ -1507,62 +1507,58 @@ msgstr "Tabs"
 #: ../advanced/tabs.rst:4
 msgid ""
 "As you click through Zammad, you will see a list of entries appear in the "
-"main menu area. These are your **open tabs.**"
+"main menu area. These are your **open tabs.** You can freely switch between "
+"open tabs without losing your work - all unsaved changes are automatically "
+"backed up to the server."
 msgstr ""
-"Wenn Sie sich durchs Zammad klicken, erscheint eine Liste der Einträge im "
-"Hauptmenü. Diese sind Ihre **offenen Tabs.**"
+"Wenn Sie sich durch Zammad klicken, sehen Sie im Hauptmenübereich eine Liste "
+"von Einträgen erscheinen. Dies sind Ihre **geöffneten Tabs.** Sie können "
+"frei zwischen geöffneten Tabs wechseln, ohne dass Ihre Änderungen verloren "
+"gehen – alle nicht gespeicherten Änderungen werden automatisch auf dem "
+"Server gesichert."
 
-#: ../advanced/tabs.rst:7
-msgid ""
-"You can freely switch between open tabs without losing your work - all "
-"unsaved changes are automatically backed up to the server."
-msgstr ""
-"Sie können frei zwischen offenen Tabs wechseln, ohne dass Ihre Änderungen "
-"verloren gehen – alle nicht gespeicherten Änderungen werden automatisch auf "
-"dem Server gesichert."
-
-#: ../advanced/tabs.rst:13
+#: ../advanced/tabs.rst:12
 msgid "Sample view of Tabs"
 msgstr "Beispielansicht von Tabs"
 
-#: ../advanced/tabs.rst:13
+#: ../advanced/tabs.rst:12
 msgid ""
 "Tabs appear in the main menu as you visit different parts of the application."
 msgstr ""
 "Die Tabs erscheinen im Hauptmenü, wenn Sie verschiedene Bereiche der "
 "Anwendung öffnen."
 
-#: ../advanced/tabs.rst:16
+#: ../advanced/tabs.rst:15
 msgid "**What items open in a new “tab”?**"
 msgstr "**Welche Elemente werden in einem neuen \"Tab\" geöffnet?**"
 
-#: ../advanced/tabs.rst:18
+#: ../advanced/tabs.rst:17
 msgid "Existing tickets"
 msgstr "Vorhandene Tickets"
 
-#: ../advanced/tabs.rst:19
+#: ../advanced/tabs.rst:18
 msgid "New tickets"
 msgstr "Neue Tickets"
 
-#: ../advanced/tabs.rst:20
+#: ../advanced/tabs.rst:19
 msgid "Users"
 msgstr "Benutzer"
 
-#: ../advanced/tabs.rst:21 ../extras/organizations.rst:2
+#: ../advanced/tabs.rst:20 ../extras/organizations.rst:2
 msgid "Organizations"
 msgstr "Organisationen"
 
-#: ../advanced/tabs.rst:22
+#: ../advanced/tabs.rst:21
 msgid "Omnisearch"
 msgstr "Suchanfragen"
 
-#: ../advanced/tabs.rst:24 ../basics/find-ticket/browse.rst:27
+#: ../advanced/tabs.rst:23 ../basics/find-ticket/browse.rst:27
 #: ../basics/find-ticket/search.rst:33 ../basics/service-ticket/create.rst:47
 #: ../snippets/ui-protip-message-editor-features.rst:1
 msgid "**🖱️ UI Protip**"
 msgstr "**🖱️Tipp für Profi-Benutzer**"
 
-#: ../advanced/tabs.rst:26
+#: ../advanced/tabs.rst:25
 msgid ""
 ":doc:`Ticket states </basics/service-ticket/settings/state>` are **color-"
 "coded:**"
@@ -1604,7 +1600,7 @@ msgstr ""
 "**Sofortige Maßnahme erforderlich** (Ticket wurde aufgrund einer SLA-"
 "Verletzung eskaliert)"
 
-#: ../advanced/tabs.rst:31
+#: ../advanced/tabs.rst:30
 msgid ""
 "A **pulsing dot** means that a ticket has new activity since you last viewed "
 "it."
@@ -1612,15 +1608,15 @@ msgstr ""
 "Ein **pulsierender Punkt** bedeutet, dass in einem Ticket neue Aktivitäten "
 "stattgefunden haben, seitdem Sie es zuletzt angesehen haben."
 
-#: ../advanced/tabs.rst:33
+#: ../advanced/tabs.rst:32
 msgid "Drag and drop tabs to rearrange them."
 msgstr "Mit Drag & Drop können Sie die Tabs neu anordnen."
 
-#: ../advanced/tabs.rst:36
+#: ../advanced/tabs.rst:35
 msgid "Tab Behavior in Ticket Zooms"
 msgstr "Tab-Verhalten in Ticket-Zooms"
 
-#: ../advanced/tabs.rst:38
+#: ../advanced/tabs.rst:37
 msgid ""
 "You may have noticed the \"Stay on tab\" button next to \"Update\" on the "
 "lower right already. This behavior of a tab can be configured by your "
@@ -1636,7 +1632,7 @@ msgstr ""
 msgid "Tab behavior can be adjusted in tickets manually"
 msgstr "Das Tab-Verhalten kann in Tickets manuell beeinflusst werden"
 
-#: ../advanced/tabs.rst:47
+#: ../advanced/tabs.rst:46
 msgid ""
 "To overrule your administrator's settings, simply choose the action you "
 "prefer. Zammad will remember this preference until you change its setting."
@@ -1645,11 +1641,11 @@ msgstr ""
 "Voreinstellung Ihres Administrators zu übergehen. Zammad erinnert sich an "
 "Ihre Auswahl bis Sie diese ändern."
 
-#: ../advanced/tabs.rst:52
+#: ../advanced/tabs.rst:51
 msgid "Close tab"
 msgstr "Tab schließen"
 
-#: ../advanced/tabs.rst:51
+#: ../advanced/tabs.rst:50
 msgid ""
 "Upon updating the ticket, Zammad will automatically close the tab. You'll be "
 "returned to the last view that was open."
@@ -1657,11 +1653,11 @@ msgstr ""
 "Beim Aktualisieren des Tickets wird Zammad das Tab automatisch schließen. "
 "Die zuvor geöffnete Ansicht wird Ihnen angezeigt."
 
-#: ../advanced/tabs.rst:58
+#: ../advanced/tabs.rst:57
 msgid "Close tab on ticket close"
 msgstr "Tab bei Ticketabschluss schließen"
 
-#: ../advanced/tabs.rst:55
+#: ../advanced/tabs.rst:54
 msgid ""
 "Ticket tabs will be closed only if you change the state to \"closed\" upon "
 "ticket update."
@@ -1669,17 +1665,17 @@ msgstr ""
 "Ticket tabs werden nur dann geschlossen, wenn Sie den Status zu "
 "\"geschlossen\" ändern und das Ticket aktualisieren."
 
-#: ../advanced/tabs.rst:58
+#: ../advanced/tabs.rst:57
 msgid "This does not apply for pending states that end in closed states."
 msgstr ""
 "Diese Einstellung hat keinen Einfluss auf warten Status die in geschlossenen "
 "Status enden."
 
-#: ../advanced/tabs.rst:66
+#: ../advanced/tabs.rst:65
 msgid "Next in overview"
 msgstr "Nächste in Übersicht"
 
-#: ../advanced/tabs.rst:61
+#: ../advanced/tabs.rst:60
 msgid ""
 "If you opened a ticket from any overview, Zammad will jump to the next "
 "ticket in said overview. Zammad recycles the open tab."
@@ -1688,7 +1684,7 @@ msgstr ""
 "nächsten Ticket der Übersicht springen. Das Tab wird von Zammad dabei wieder "
 "verwendet."
 
-#: ../advanced/tabs.rst:64
+#: ../advanced/tabs.rst:63
 msgid ""
 "This option is only available if you open the ticket from an overview. "
 "Zammad will ignore the setting if you opened the ticket directly and fall "
@@ -1702,13 +1698,25 @@ msgstr ""
 msgid "Stay on tab"
 msgstr "In Tab bleiben"
 
-#: ../advanced/tabs.rst:69
+#: ../advanced/tabs.rst:68
 msgid "Updating the ticket doesn't have any effect on the tab."
 msgstr "Das Aktualisieren des Tickets hat keinen Einfluss auf das Tab."
 
-#: ../advanced/tabs.rst:71
+#: ../advanced/tabs.rst:70
 msgid "*This is the default setting in Zammad installations.*"
 msgstr "*Das ist die Standardeinstellung in Zammad-Installationen.*"
+
+#: ../advanced/tabs.rst:72
+msgid ""
+"Now that you are an expert in tab handling, one more thing might be "
+"interesting as well: the maximum number of tabs is 30 due to performance "
+"reasons. In case you reach the limit and open another tab, the first opened "
+"tab gets closed automatically."
+msgstr ""
+"Da Sie nun ein Experte in der Handhabung von Tabs sind, noch eine "
+"Information: Die maximale Anzahl von Tabs ist aus Leistungsgründen auf 30 "
+"begrenzt. Wenn Sie diese Grenze erreichen und einen weiteren Tab öffnen, "
+"wird der zuerst geöffnete Tab automatisch geschlossen."
 
 #: ../advanced/text-modules.rst:2
 msgid "Working with Text Modules"
@@ -9625,6 +9633,13 @@ msgstr ""
 "Sie lesen gerade die Benutzerdokumentation von Zammad. Es sind "
 "außerdem :docs:`System- </index.html>` und :admin-docs:`Admin-"
 "Dokumentationen </index.html>` verfügbar."
+
+#~ msgid ""
+#~ "As you click through Zammad, you will see a list of entries appear in the "
+#~ "main menu area. These are your **open tabs.**"
+#~ msgstr ""
+#~ "Wenn Sie sich durchs Zammad klicken, erscheint eine Liste der Einträge im "
+#~ "Hauptmenü. Diese sind Ihre **offenen Tabs.**"
 
 #~ msgid "Smart Editor"
 #~ msgstr "Smart Editor"

--- a/locale/es/LC_MESSAGES/user-docs.po
+++ b/locale/es/LC_MESSAGES/user-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-09 08:29+0200\n"
+"POT-Creation-Date: 2025-11-04 07:08+0000\n"
 "PO-Revision-Date: 2025-10-11 17:00+0000\n"
 "Last-Translator: Eduardo Mosqueda <wayo.mosqueda@gmail.com>\n"
 "Language-Team: Spanish <https://translations.zammad.org/projects/"
@@ -1426,55 +1426,51 @@ msgstr ""
 #: ../advanced/tabs.rst:4
 msgid ""
 "As you click through Zammad, you will see a list of entries appear in the "
-"main menu area. These are your **open tabs.**"
+"main menu area. These are your **open tabs.** You can freely switch between "
+"open tabs without losing your work - all unsaved changes are automatically "
+"backed up to the server."
 msgstr ""
 
-#: ../advanced/tabs.rst:7
-msgid ""
-"You can freely switch between open tabs without losing your work - all "
-"unsaved changes are automatically backed up to the server."
-msgstr ""
-
-#: ../advanced/tabs.rst:13
+#: ../advanced/tabs.rst:12
 msgid "Sample view of Tabs"
 msgstr ""
 
-#: ../advanced/tabs.rst:13
+#: ../advanced/tabs.rst:12
 msgid ""
 "Tabs appear in the main menu as you visit different parts of the application."
 msgstr ""
 
-#: ../advanced/tabs.rst:16
+#: ../advanced/tabs.rst:15
 msgid "**What items open in a new “tab”?**"
 msgstr ""
 
-#: ../advanced/tabs.rst:18
+#: ../advanced/tabs.rst:17
 msgid "Existing tickets"
 msgstr ""
 
-#: ../advanced/tabs.rst:19
+#: ../advanced/tabs.rst:18
 msgid "New tickets"
 msgstr ""
 
-#: ../advanced/tabs.rst:20
+#: ../advanced/tabs.rst:19
 msgid "Users"
 msgstr ""
 
-#: ../advanced/tabs.rst:21 ../extras/organizations.rst:2
+#: ../advanced/tabs.rst:20 ../extras/organizations.rst:2
 msgid "Organizations"
 msgstr ""
 
-#: ../advanced/tabs.rst:22
+#: ../advanced/tabs.rst:21
 msgid "Omnisearch"
 msgstr ""
 
-#: ../advanced/tabs.rst:24 ../basics/find-ticket/browse.rst:27
+#: ../advanced/tabs.rst:23 ../basics/find-ticket/browse.rst:27
 #: ../basics/find-ticket/search.rst:33 ../basics/service-ticket/create.rst:47
 #: ../snippets/ui-protip-message-editor-features.rst:1
 msgid "**🖱️ UI Protip**"
 msgstr "**🖱️ Interfaz de usuario: Surgerencia pro**"
 
-#: ../advanced/tabs.rst:26
+#: ../advanced/tabs.rst:25
 msgid ""
 ":doc:`Ticket states </basics/service-ticket/settings/state>` are **color-"
 "coded:**"
@@ -1512,21 +1508,21 @@ msgstr ""
 msgid "**Immediate action needed** (ticket escalated due to an SLA violation)"
 msgstr ""
 
-#: ../advanced/tabs.rst:31
+#: ../advanced/tabs.rst:30
 msgid ""
 "A **pulsing dot** means that a ticket has new activity since you last viewed "
 "it."
 msgstr ""
 
-#: ../advanced/tabs.rst:33
+#: ../advanced/tabs.rst:32
 msgid "Drag and drop tabs to rearrange them."
 msgstr ""
 
-#: ../advanced/tabs.rst:36
+#: ../advanced/tabs.rst:35
 msgid "Tab Behavior in Ticket Zooms"
 msgstr ""
 
-#: ../advanced/tabs.rst:38
+#: ../advanced/tabs.rst:37
 msgid ""
 "You may have noticed the \"Stay on tab\" button next to \"Update\" on the "
 "lower right already. This behavior of a tab can be configured by your "
@@ -1538,47 +1534,47 @@ msgstr ""
 msgid "Tab behavior can be adjusted in tickets manually"
 msgstr ""
 
-#: ../advanced/tabs.rst:47
+#: ../advanced/tabs.rst:46
 msgid ""
 "To overrule your administrator's settings, simply choose the action you "
 "prefer. Zammad will remember this preference until you change its setting."
 msgstr ""
 
-#: ../advanced/tabs.rst:52
+#: ../advanced/tabs.rst:51
 msgid "Close tab"
 msgstr ""
 
-#: ../advanced/tabs.rst:51
+#: ../advanced/tabs.rst:50
 msgid ""
 "Upon updating the ticket, Zammad will automatically close the tab. You'll be "
 "returned to the last view that was open."
 msgstr ""
 
-#: ../advanced/tabs.rst:58
+#: ../advanced/tabs.rst:57
 msgid "Close tab on ticket close"
 msgstr ""
 
-#: ../advanced/tabs.rst:55
+#: ../advanced/tabs.rst:54
 msgid ""
 "Ticket tabs will be closed only if you change the state to \"closed\" upon "
 "ticket update."
 msgstr ""
 
-#: ../advanced/tabs.rst:58
+#: ../advanced/tabs.rst:57
 msgid "This does not apply for pending states that end in closed states."
 msgstr ""
 
-#: ../advanced/tabs.rst:66
+#: ../advanced/tabs.rst:65
 msgid "Next in overview"
 msgstr ""
 
-#: ../advanced/tabs.rst:61
+#: ../advanced/tabs.rst:60
 msgid ""
 "If you opened a ticket from any overview, Zammad will jump to the next "
 "ticket in said overview. Zammad recycles the open tab."
 msgstr ""
 
-#: ../advanced/tabs.rst:64
+#: ../advanced/tabs.rst:63
 msgid ""
 "This option is only available if you open the ticket from an overview. "
 "Zammad will ignore the setting if you opened the ticket directly and fall "
@@ -1589,12 +1585,20 @@ msgstr ""
 msgid "Stay on tab"
 msgstr ""
 
-#: ../advanced/tabs.rst:69
+#: ../advanced/tabs.rst:68
 msgid "Updating the ticket doesn't have any effect on the tab."
 msgstr ""
 
-#: ../advanced/tabs.rst:71
+#: ../advanced/tabs.rst:70
 msgid "*This is the default setting in Zammad installations.*"
+msgstr ""
+
+#: ../advanced/tabs.rst:72
+msgid ""
+"Now that you are an expert in tab handling, one more thing might be "
+"interesting as well: the maximum number of tabs is 30 due to performance "
+"reasons. In case you reach the limit and open another tab, the first opened "
+"tab gets closed automatically."
 msgstr ""
 
 #: ../advanced/text-modules.rst:2

--- a/locale/es_CO/LC_MESSAGES/user-docs.po
+++ b/locale/es_CO/LC_MESSAGES/user-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-09 08:29+0200\n"
+"POT-Creation-Date: 2025-11-04 07:08+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -1305,55 +1305,51 @@ msgstr ""
 #: ../advanced/tabs.rst:4
 msgid ""
 "As you click through Zammad, you will see a list of entries appear in the "
-"main menu area. These are your **open tabs.**"
+"main menu area. These are your **open tabs.** You can freely switch between "
+"open tabs without losing your work - all unsaved changes are automatically "
+"backed up to the server."
 msgstr ""
 
-#: ../advanced/tabs.rst:7
-msgid ""
-"You can freely switch between open tabs without losing your work - all "
-"unsaved changes are automatically backed up to the server."
-msgstr ""
-
-#: ../advanced/tabs.rst:13
+#: ../advanced/tabs.rst:12
 msgid "Sample view of Tabs"
 msgstr ""
 
-#: ../advanced/tabs.rst:13
+#: ../advanced/tabs.rst:12
 msgid ""
 "Tabs appear in the main menu as you visit different parts of the application."
 msgstr ""
 
-#: ../advanced/tabs.rst:16
+#: ../advanced/tabs.rst:15
 msgid "**What items open in a new “tab”?**"
 msgstr ""
 
-#: ../advanced/tabs.rst:18
+#: ../advanced/tabs.rst:17
 msgid "Existing tickets"
 msgstr ""
 
-#: ../advanced/tabs.rst:19
+#: ../advanced/tabs.rst:18
 msgid "New tickets"
 msgstr ""
 
-#: ../advanced/tabs.rst:20
+#: ../advanced/tabs.rst:19
 msgid "Users"
 msgstr ""
 
-#: ../advanced/tabs.rst:21 ../extras/organizations.rst:2
+#: ../advanced/tabs.rst:20 ../extras/organizations.rst:2
 msgid "Organizations"
 msgstr ""
 
-#: ../advanced/tabs.rst:22
+#: ../advanced/tabs.rst:21
 msgid "Omnisearch"
 msgstr ""
 
-#: ../advanced/tabs.rst:24 ../basics/find-ticket/browse.rst:27
+#: ../advanced/tabs.rst:23 ../basics/find-ticket/browse.rst:27
 #: ../basics/find-ticket/search.rst:33 ../basics/service-ticket/create.rst:47
 #: ../snippets/ui-protip-message-editor-features.rst:1
 msgid "**🖱️ UI Protip**"
 msgstr ""
 
-#: ../advanced/tabs.rst:26
+#: ../advanced/tabs.rst:25
 msgid ""
 ":doc:`Ticket states </basics/service-ticket/settings/state>` are **color-"
 "coded:**"
@@ -1391,21 +1387,21 @@ msgstr ""
 msgid "**Immediate action needed** (ticket escalated due to an SLA violation)"
 msgstr ""
 
-#: ../advanced/tabs.rst:31
+#: ../advanced/tabs.rst:30
 msgid ""
 "A **pulsing dot** means that a ticket has new activity since you last viewed "
 "it."
 msgstr ""
 
-#: ../advanced/tabs.rst:33
+#: ../advanced/tabs.rst:32
 msgid "Drag and drop tabs to rearrange them."
 msgstr ""
 
-#: ../advanced/tabs.rst:36
+#: ../advanced/tabs.rst:35
 msgid "Tab Behavior in Ticket Zooms"
 msgstr ""
 
-#: ../advanced/tabs.rst:38
+#: ../advanced/tabs.rst:37
 msgid ""
 "You may have noticed the \"Stay on tab\" button next to \"Update\" on the "
 "lower right already. This behavior of a tab can be configured by your "
@@ -1417,47 +1413,47 @@ msgstr ""
 msgid "Tab behavior can be adjusted in tickets manually"
 msgstr ""
 
-#: ../advanced/tabs.rst:47
+#: ../advanced/tabs.rst:46
 msgid ""
 "To overrule your administrator's settings, simply choose the action you "
 "prefer. Zammad will remember this preference until you change its setting."
 msgstr ""
 
-#: ../advanced/tabs.rst:52
+#: ../advanced/tabs.rst:51
 msgid "Close tab"
 msgstr ""
 
-#: ../advanced/tabs.rst:51
+#: ../advanced/tabs.rst:50
 msgid ""
 "Upon updating the ticket, Zammad will automatically close the tab. You'll be "
 "returned to the last view that was open."
 msgstr ""
 
-#: ../advanced/tabs.rst:58
+#: ../advanced/tabs.rst:57
 msgid "Close tab on ticket close"
 msgstr ""
 
-#: ../advanced/tabs.rst:55
+#: ../advanced/tabs.rst:54
 msgid ""
 "Ticket tabs will be closed only if you change the state to \"closed\" upon "
 "ticket update."
 msgstr ""
 
-#: ../advanced/tabs.rst:58
+#: ../advanced/tabs.rst:57
 msgid "This does not apply for pending states that end in closed states."
 msgstr ""
 
-#: ../advanced/tabs.rst:66
+#: ../advanced/tabs.rst:65
 msgid "Next in overview"
 msgstr ""
 
-#: ../advanced/tabs.rst:61
+#: ../advanced/tabs.rst:60
 msgid ""
 "If you opened a ticket from any overview, Zammad will jump to the next "
 "ticket in said overview. Zammad recycles the open tab."
 msgstr ""
 
-#: ../advanced/tabs.rst:64
+#: ../advanced/tabs.rst:63
 msgid ""
 "This option is only available if you open the ticket from an overview. "
 "Zammad will ignore the setting if you opened the ticket directly and fall "
@@ -1468,12 +1464,20 @@ msgstr ""
 msgid "Stay on tab"
 msgstr ""
 
-#: ../advanced/tabs.rst:69
+#: ../advanced/tabs.rst:68
 msgid "Updating the ticket doesn't have any effect on the tab."
 msgstr ""
 
-#: ../advanced/tabs.rst:71
+#: ../advanced/tabs.rst:70
 msgid "*This is the default setting in Zammad installations.*"
+msgstr ""
+
+#: ../advanced/tabs.rst:72
+msgid ""
+"Now that you are an expert in tab handling, one more thing might be "
+"interesting as well: the maximum number of tabs is 30 due to performance "
+"reasons. In case you reach the limit and open another tab, the first opened "
+"tab gets closed automatically."
 msgstr ""
 
 #: ../advanced/text-modules.rst:2

--- a/locale/es_MX/LC_MESSAGES/user-docs.po
+++ b/locale/es_MX/LC_MESSAGES/user-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-09 08:29+0200\n"
+"POT-Creation-Date: 2025-11-04 07:08+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -1305,55 +1305,51 @@ msgstr ""
 #: ../advanced/tabs.rst:4
 msgid ""
 "As you click through Zammad, you will see a list of entries appear in the "
-"main menu area. These are your **open tabs.**"
+"main menu area. These are your **open tabs.** You can freely switch between "
+"open tabs without losing your work - all unsaved changes are automatically "
+"backed up to the server."
 msgstr ""
 
-#: ../advanced/tabs.rst:7
-msgid ""
-"You can freely switch between open tabs without losing your work - all "
-"unsaved changes are automatically backed up to the server."
-msgstr ""
-
-#: ../advanced/tabs.rst:13
+#: ../advanced/tabs.rst:12
 msgid "Sample view of Tabs"
 msgstr ""
 
-#: ../advanced/tabs.rst:13
+#: ../advanced/tabs.rst:12
 msgid ""
 "Tabs appear in the main menu as you visit different parts of the application."
 msgstr ""
 
-#: ../advanced/tabs.rst:16
+#: ../advanced/tabs.rst:15
 msgid "**What items open in a new “tab”?**"
 msgstr ""
 
-#: ../advanced/tabs.rst:18
+#: ../advanced/tabs.rst:17
 msgid "Existing tickets"
 msgstr ""
 
-#: ../advanced/tabs.rst:19
+#: ../advanced/tabs.rst:18
 msgid "New tickets"
 msgstr ""
 
-#: ../advanced/tabs.rst:20
+#: ../advanced/tabs.rst:19
 msgid "Users"
 msgstr ""
 
-#: ../advanced/tabs.rst:21 ../extras/organizations.rst:2
+#: ../advanced/tabs.rst:20 ../extras/organizations.rst:2
 msgid "Organizations"
 msgstr ""
 
-#: ../advanced/tabs.rst:22
+#: ../advanced/tabs.rst:21
 msgid "Omnisearch"
 msgstr ""
 
-#: ../advanced/tabs.rst:24 ../basics/find-ticket/browse.rst:27
+#: ../advanced/tabs.rst:23 ../basics/find-ticket/browse.rst:27
 #: ../basics/find-ticket/search.rst:33 ../basics/service-ticket/create.rst:47
 #: ../snippets/ui-protip-message-editor-features.rst:1
 msgid "**🖱️ UI Protip**"
 msgstr ""
 
-#: ../advanced/tabs.rst:26
+#: ../advanced/tabs.rst:25
 msgid ""
 ":doc:`Ticket states </basics/service-ticket/settings/state>` are **color-"
 "coded:**"
@@ -1391,21 +1387,21 @@ msgstr ""
 msgid "**Immediate action needed** (ticket escalated due to an SLA violation)"
 msgstr ""
 
-#: ../advanced/tabs.rst:31
+#: ../advanced/tabs.rst:30
 msgid ""
 "A **pulsing dot** means that a ticket has new activity since you last viewed "
 "it."
 msgstr ""
 
-#: ../advanced/tabs.rst:33
+#: ../advanced/tabs.rst:32
 msgid "Drag and drop tabs to rearrange them."
 msgstr ""
 
-#: ../advanced/tabs.rst:36
+#: ../advanced/tabs.rst:35
 msgid "Tab Behavior in Ticket Zooms"
 msgstr ""
 
-#: ../advanced/tabs.rst:38
+#: ../advanced/tabs.rst:37
 msgid ""
 "You may have noticed the \"Stay on tab\" button next to \"Update\" on the "
 "lower right already. This behavior of a tab can be configured by your "
@@ -1417,47 +1413,47 @@ msgstr ""
 msgid "Tab behavior can be adjusted in tickets manually"
 msgstr ""
 
-#: ../advanced/tabs.rst:47
+#: ../advanced/tabs.rst:46
 msgid ""
 "To overrule your administrator's settings, simply choose the action you "
 "prefer. Zammad will remember this preference until you change its setting."
 msgstr ""
 
-#: ../advanced/tabs.rst:52
+#: ../advanced/tabs.rst:51
 msgid "Close tab"
 msgstr ""
 
-#: ../advanced/tabs.rst:51
+#: ../advanced/tabs.rst:50
 msgid ""
 "Upon updating the ticket, Zammad will automatically close the tab. You'll be "
 "returned to the last view that was open."
 msgstr ""
 
-#: ../advanced/tabs.rst:58
+#: ../advanced/tabs.rst:57
 msgid "Close tab on ticket close"
 msgstr ""
 
-#: ../advanced/tabs.rst:55
+#: ../advanced/tabs.rst:54
 msgid ""
 "Ticket tabs will be closed only if you change the state to \"closed\" upon "
 "ticket update."
 msgstr ""
 
-#: ../advanced/tabs.rst:58
+#: ../advanced/tabs.rst:57
 msgid "This does not apply for pending states that end in closed states."
 msgstr ""
 
-#: ../advanced/tabs.rst:66
+#: ../advanced/tabs.rst:65
 msgid "Next in overview"
 msgstr ""
 
-#: ../advanced/tabs.rst:61
+#: ../advanced/tabs.rst:60
 msgid ""
 "If you opened a ticket from any overview, Zammad will jump to the next "
 "ticket in said overview. Zammad recycles the open tab."
 msgstr ""
 
-#: ../advanced/tabs.rst:64
+#: ../advanced/tabs.rst:63
 msgid ""
 "This option is only available if you open the ticket from an overview. "
 "Zammad will ignore the setting if you opened the ticket directly and fall "
@@ -1468,12 +1464,20 @@ msgstr ""
 msgid "Stay on tab"
 msgstr ""
 
-#: ../advanced/tabs.rst:69
+#: ../advanced/tabs.rst:68
 msgid "Updating the ticket doesn't have any effect on the tab."
 msgstr ""
 
-#: ../advanced/tabs.rst:71
+#: ../advanced/tabs.rst:70
 msgid "*This is the default setting in Zammad installations.*"
+msgstr ""
+
+#: ../advanced/tabs.rst:72
+msgid ""
+"Now that you are an expert in tab handling, one more thing might be "
+"interesting as well: the maximum number of tabs is 30 due to performance "
+"reasons. In case you reach the limit and open another tab, the first opened "
+"tab gets closed automatically."
 msgstr ""
 
 #: ../advanced/text-modules.rst:2

--- a/locale/fa/LC_MESSAGES/user-docs.po
+++ b/locale/fa/LC_MESSAGES/user-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-09 08:29+0200\n"
+"POT-Creation-Date: 2025-11-04 07:08+0000\n"
 "PO-Revision-Date: 2024-11-19 05:00+0000\n"
 "Last-Translator: sesoltani <se.soltani@hotmail.com>\n"
 "Language-Team: Persian <https://translations.zammad.org/projects/"
@@ -1308,55 +1308,51 @@ msgstr ""
 #: ../advanced/tabs.rst:4
 msgid ""
 "As you click through Zammad, you will see a list of entries appear in the "
-"main menu area. These are your **open tabs.**"
+"main menu area. These are your **open tabs.** You can freely switch between "
+"open tabs without losing your work - all unsaved changes are automatically "
+"backed up to the server."
 msgstr ""
 
-#: ../advanced/tabs.rst:7
-msgid ""
-"You can freely switch between open tabs without losing your work - all "
-"unsaved changes are automatically backed up to the server."
-msgstr ""
-
-#: ../advanced/tabs.rst:13
+#: ../advanced/tabs.rst:12
 msgid "Sample view of Tabs"
 msgstr ""
 
-#: ../advanced/tabs.rst:13
+#: ../advanced/tabs.rst:12
 msgid ""
 "Tabs appear in the main menu as you visit different parts of the application."
 msgstr ""
 
-#: ../advanced/tabs.rst:16
+#: ../advanced/tabs.rst:15
 msgid "**What items open in a new “tab”?**"
 msgstr ""
 
-#: ../advanced/tabs.rst:18
+#: ../advanced/tabs.rst:17
 msgid "Existing tickets"
 msgstr ""
 
-#: ../advanced/tabs.rst:19
+#: ../advanced/tabs.rst:18
 msgid "New tickets"
 msgstr ""
 
-#: ../advanced/tabs.rst:20
+#: ../advanced/tabs.rst:19
 msgid "Users"
 msgstr ""
 
-#: ../advanced/tabs.rst:21 ../extras/organizations.rst:2
+#: ../advanced/tabs.rst:20 ../extras/organizations.rst:2
 msgid "Organizations"
 msgstr ""
 
-#: ../advanced/tabs.rst:22
+#: ../advanced/tabs.rst:21
 msgid "Omnisearch"
 msgstr ""
 
-#: ../advanced/tabs.rst:24 ../basics/find-ticket/browse.rst:27
+#: ../advanced/tabs.rst:23 ../basics/find-ticket/browse.rst:27
 #: ../basics/find-ticket/search.rst:33 ../basics/service-ticket/create.rst:47
 #: ../snippets/ui-protip-message-editor-features.rst:1
 msgid "**🖱️ UI Protip**"
 msgstr ""
 
-#: ../advanced/tabs.rst:26
+#: ../advanced/tabs.rst:25
 msgid ""
 ":doc:`Ticket states </basics/service-ticket/settings/state>` are **color-"
 "coded:**"
@@ -1394,21 +1390,21 @@ msgstr ""
 msgid "**Immediate action needed** (ticket escalated due to an SLA violation)"
 msgstr ""
 
-#: ../advanced/tabs.rst:31
+#: ../advanced/tabs.rst:30
 msgid ""
 "A **pulsing dot** means that a ticket has new activity since you last viewed "
 "it."
 msgstr ""
 
-#: ../advanced/tabs.rst:33
+#: ../advanced/tabs.rst:32
 msgid "Drag and drop tabs to rearrange them."
 msgstr ""
 
-#: ../advanced/tabs.rst:36
+#: ../advanced/tabs.rst:35
 msgid "Tab Behavior in Ticket Zooms"
 msgstr ""
 
-#: ../advanced/tabs.rst:38
+#: ../advanced/tabs.rst:37
 msgid ""
 "You may have noticed the \"Stay on tab\" button next to \"Update\" on the "
 "lower right already. This behavior of a tab can be configured by your "
@@ -1420,47 +1416,47 @@ msgstr ""
 msgid "Tab behavior can be adjusted in tickets manually"
 msgstr ""
 
-#: ../advanced/tabs.rst:47
+#: ../advanced/tabs.rst:46
 msgid ""
 "To overrule your administrator's settings, simply choose the action you "
 "prefer. Zammad will remember this preference until you change its setting."
 msgstr ""
 
-#: ../advanced/tabs.rst:52
+#: ../advanced/tabs.rst:51
 msgid "Close tab"
 msgstr ""
 
-#: ../advanced/tabs.rst:51
+#: ../advanced/tabs.rst:50
 msgid ""
 "Upon updating the ticket, Zammad will automatically close the tab. You'll be "
 "returned to the last view that was open."
 msgstr ""
 
-#: ../advanced/tabs.rst:58
+#: ../advanced/tabs.rst:57
 msgid "Close tab on ticket close"
 msgstr ""
 
-#: ../advanced/tabs.rst:55
+#: ../advanced/tabs.rst:54
 msgid ""
 "Ticket tabs will be closed only if you change the state to \"closed\" upon "
 "ticket update."
 msgstr ""
 
-#: ../advanced/tabs.rst:58
+#: ../advanced/tabs.rst:57
 msgid "This does not apply for pending states that end in closed states."
 msgstr ""
 
-#: ../advanced/tabs.rst:66
+#: ../advanced/tabs.rst:65
 msgid "Next in overview"
 msgstr ""
 
-#: ../advanced/tabs.rst:61
+#: ../advanced/tabs.rst:60
 msgid ""
 "If you opened a ticket from any overview, Zammad will jump to the next "
 "ticket in said overview. Zammad recycles the open tab."
 msgstr ""
 
-#: ../advanced/tabs.rst:64
+#: ../advanced/tabs.rst:63
 msgid ""
 "This option is only available if you open the ticket from an overview. "
 "Zammad will ignore the setting if you opened the ticket directly and fall "
@@ -1471,12 +1467,20 @@ msgstr ""
 msgid "Stay on tab"
 msgstr ""
 
-#: ../advanced/tabs.rst:69
+#: ../advanced/tabs.rst:68
 msgid "Updating the ticket doesn't have any effect on the tab."
 msgstr ""
 
-#: ../advanced/tabs.rst:71
+#: ../advanced/tabs.rst:70
 msgid "*This is the default setting in Zammad installations.*"
+msgstr ""
+
+#: ../advanced/tabs.rst:72
+msgid ""
+"Now that you are an expert in tab handling, one more thing might be "
+"interesting as well: the maximum number of tabs is 30 due to performance "
+"reasons. In case you reach the limit and open another tab, the first opened "
+"tab gets closed automatically."
 msgstr ""
 
 #: ../advanced/text-modules.rst:2

--- a/locale/fr/LC_MESSAGES/user-docs.po
+++ b/locale/fr/LC_MESSAGES/user-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-09 08:29+0200\n"
+"POT-Creation-Date: 2025-11-04 07:08+0000\n"
 "PO-Revision-Date: 2024-10-07 17:00+0000\n"
 "Last-Translator: Misha <misha@association-enoria.org>\n"
 "Language-Team: French <https://translations.zammad.org/projects/"
@@ -1505,64 +1505,62 @@ msgid "Tabs"
 msgstr "Onglets"
 
 #: ../advanced/tabs.rst:4
+#, fuzzy
+#| msgid ""
+#| "You can freely switch between open tabs without losing your work - all "
+#| "unsaved changes are automatically backed up to the server."
 msgid ""
 "As you click through Zammad, you will see a list of entries appear in the "
-"main menu area. These are your **open tabs.**"
-msgstr ""
-"En parcourant Zammad, vous remarquerez une liste d'entrées apparaitre dans "
-"la zone du menu principal. Ce sont vos **onglets ouverts.**"
-
-#: ../advanced/tabs.rst:7
-msgid ""
-"You can freely switch between open tabs without losing your work - all "
-"unsaved changes are automatically backed up to the server."
+"main menu area. These are your **open tabs.** You can freely switch between "
+"open tabs without losing your work - all unsaved changes are automatically "
+"backed up to the server."
 msgstr ""
 "Vous pouvez librement basculer entre les onglets ouverts sans perdre votre "
 "travail – Tous les changements non sauvegardés sont automatiquement "
 "enregistrés sur le serveur."
 
-#: ../advanced/tabs.rst:13
+#: ../advanced/tabs.rst:12
 msgid "Sample view of Tabs"
 msgstr "Vue d'exemple des onglets"
 
-#: ../advanced/tabs.rst:13
+#: ../advanced/tabs.rst:12
 msgid ""
 "Tabs appear in the main menu as you visit different parts of the application."
 msgstr ""
 "Des onglets apparaissent dans le menu principal quand vous visitez "
 "différentes parties de l'application."
 
-#: ../advanced/tabs.rst:16
+#: ../advanced/tabs.rst:15
 msgid "**What items open in a new “tab”?**"
 msgstr "**Quels éléments ouvrent un nouvel \"onglet\"?**"
 
-#: ../advanced/tabs.rst:18
+#: ../advanced/tabs.rst:17
 msgid "Existing tickets"
 msgstr "Tickets existants"
 
-#: ../advanced/tabs.rst:19
+#: ../advanced/tabs.rst:18
 msgid "New tickets"
 msgstr "Nouveaux tickets"
 
-#: ../advanced/tabs.rst:20
+#: ../advanced/tabs.rst:19
 msgid "Users"
 msgstr "Utilisateurs"
 
-#: ../advanced/tabs.rst:21 ../extras/organizations.rst:2
+#: ../advanced/tabs.rst:20 ../extras/organizations.rst:2
 msgid "Organizations"
 msgstr "Sociétés"
 
-#: ../advanced/tabs.rst:22
+#: ../advanced/tabs.rst:21
 msgid "Omnisearch"
 msgstr "Omnisearch"
 
-#: ../advanced/tabs.rst:24 ../basics/find-ticket/browse.rst:27
+#: ../advanced/tabs.rst:23 ../basics/find-ticket/browse.rst:27
 #: ../basics/find-ticket/search.rst:33 ../basics/service-ticket/create.rst:47
 #: ../snippets/ui-protip-message-editor-features.rst:1
 msgid "**🖱️ UI Protip**"
 msgstr "**🖱️ UI Protip**"
 
-#: ../advanced/tabs.rst:26
+#: ../advanced/tabs.rst:25
 msgid ""
 ":doc:`Ticket states </basics/service-ticket/settings/state>` are **color-"
 "coded:**"
@@ -1602,7 +1600,7 @@ msgstr "|red|"
 msgid "**Immediate action needed** (ticket escalated due to an SLA violation)"
 msgstr ""
 
-#: ../advanced/tabs.rst:31
+#: ../advanced/tabs.rst:30
 msgid ""
 "A **pulsing dot** means that a ticket has new activity since you last viewed "
 "it."
@@ -1610,15 +1608,15 @@ msgstr ""
 "Un **point clignotant** signifie un ticket avec une nouvelle activité depuis "
 "son dernier affichage."
 
-#: ../advanced/tabs.rst:33
+#: ../advanced/tabs.rst:32
 msgid "Drag and drop tabs to rearrange them."
 msgstr "Glisser et déposer des onglets pour les réorganiser."
 
-#: ../advanced/tabs.rst:36
+#: ../advanced/tabs.rst:35
 msgid "Tab Behavior in Ticket Zooms"
 msgstr "Comportement des onglets dans les détails d'un ticket"
 
-#: ../advanced/tabs.rst:38
+#: ../advanced/tabs.rst:37
 msgid ""
 "You may have noticed the \"Stay on tab\" button next to \"Update\" on the "
 "lower right already. This behavior of a tab can be configured by your "
@@ -1634,7 +1632,7 @@ msgid "Tab behavior can be adjusted in tickets manually"
 msgstr ""
 "Le comportement des onglets peut être ajuste depuis les tickets manuellement"
 
-#: ../advanced/tabs.rst:47
+#: ../advanced/tabs.rst:46
 msgid ""
 "To overrule your administrator's settings, simply choose the action you "
 "prefer. Zammad will remember this preference until you change its setting."
@@ -1643,11 +1641,11 @@ msgstr ""
 "ce que vous préférez. Zammad se souviendra de votre préférence jusqu'à ce "
 "que vous en changiez."
 
-#: ../advanced/tabs.rst:52
+#: ../advanced/tabs.rst:51
 msgid "Close tab"
 msgstr "Fermer l'onglet"
 
-#: ../advanced/tabs.rst:51
+#: ../advanced/tabs.rst:50
 msgid ""
 "Upon updating the ticket, Zammad will automatically close the tab. You'll be "
 "returned to the last view that was open."
@@ -1655,11 +1653,11 @@ msgstr ""
 "A la mise à jour du ticket, Zammad fermera automatiquement l'onglet. Vous "
 "serez renvoyé au dernier aperçu ouvert."
 
-#: ../advanced/tabs.rst:58
+#: ../advanced/tabs.rst:57
 msgid "Close tab on ticket close"
 msgstr "Fermer l'onglet à la fermeture du ticket"
 
-#: ../advanced/tabs.rst:55
+#: ../advanced/tabs.rst:54
 msgid ""
 "Ticket tabs will be closed only if you change the state to \"closed\" upon "
 "ticket update."
@@ -1667,15 +1665,15 @@ msgstr ""
 "L'onglet du ticket se fermera seulement si vous fermez le ticket lors de sa "
 "mise à jour."
 
-#: ../advanced/tabs.rst:58
+#: ../advanced/tabs.rst:57
 msgid "This does not apply for pending states that end in closed states."
 msgstr "Cela ne s'applique pas pour les états en attente de clôture."
 
-#: ../advanced/tabs.rst:66
+#: ../advanced/tabs.rst:65
 msgid "Next in overview"
 msgstr "Suivant dans la vue"
 
-#: ../advanced/tabs.rst:61
+#: ../advanced/tabs.rst:60
 msgid ""
 "If you opened a ticket from any overview, Zammad will jump to the next "
 "ticket in said overview. Zammad recycles the open tab."
@@ -1683,7 +1681,7 @@ msgstr ""
 "Si vous ouvrez un ticket depuis une vue, Zammad ira au prochain ticket dans "
 "la vue en question. Dans le même onglet."
 
-#: ../advanced/tabs.rst:64
+#: ../advanced/tabs.rst:63
 msgid ""
 "This option is only available if you open the ticket from an overview. "
 "Zammad will ignore the setting if you opened the ticket directly and fall "
@@ -1697,13 +1695,21 @@ msgstr ""
 msgid "Stay on tab"
 msgstr "Rester sur l'onglet"
 
-#: ../advanced/tabs.rst:69
+#: ../advanced/tabs.rst:68
 msgid "Updating the ticket doesn't have any effect on the tab."
 msgstr "Modifier un ticket n'a aucun effet sur l'onglet."
 
-#: ../advanced/tabs.rst:71
+#: ../advanced/tabs.rst:70
 msgid "*This is the default setting in Zammad installations.*"
 msgstr "*Ceci est le paramétrage par défaut des installations Zammad.*"
+
+#: ../advanced/tabs.rst:72
+msgid ""
+"Now that you are an expert in tab handling, one more thing might be "
+"interesting as well: the maximum number of tabs is 30 due to performance "
+"reasons. In case you reach the limit and open another tab, the first opened "
+"tab gets closed automatically."
+msgstr ""
 
 #: ../advanced/text-modules.rst:2
 msgid "Working with Text Modules"
@@ -8461,6 +8467,13 @@ msgid ""
 "also :docs:`system </index.html>` and :admin-docs:`administration manuals </"
 "index.html>` available."
 msgstr ""
+
+#~ msgid ""
+#~ "As you click through Zammad, you will see a list of entries appear in the "
+#~ "main menu area. These are your **open tabs.**"
+#~ msgstr ""
+#~ "En parcourant Zammad, vous remarquerez une liste d'entrées apparaitre "
+#~ "dans la zone du menu principal. Ce sont vos **onglets ouverts.**"
 
 #~ msgid "article.attachment.content_type: string (File type e.g. PDF)"
 #~ msgstr "article.attachment.content_type : chaîne (type du fichier e.g. PDF)"

--- a/locale/fr_CA/LC_MESSAGES/user-docs.po
+++ b/locale/fr_CA/LC_MESSAGES/user-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-09 08:29+0200\n"
+"POT-Creation-Date: 2025-11-04 07:08+0000\n"
 "PO-Revision-Date: 2022-04-16 15:56+0000\n"
 "Last-Translator: Marcel Herrguth <github@thehomeofanime.de>\n"
 "Language-Team: French (Canada) <https://translations.zammad.org/projects/"
@@ -1397,66 +1397,60 @@ msgid "Tabs"
 msgstr "Onglets"
 
 #: ../advanced/tabs.rst:4
-msgid ""
-"As you click through Zammad, you will see a list of entries appear in the "
-"main menu area. These are your **open tabs.**"
-msgstr ""
-"Lorsque vous cliquez sur Zammad, une liste d'entrées apparaît dans la zone "
-"du menu principal. Ce sont vos **onglets ouverts**."
-
-#: ../advanced/tabs.rst:7
 #, fuzzy
 msgid ""
-"You can freely switch between open tabs without losing your work - all "
-"unsaved changes are automatically backed up to the server."
+"As you click through Zammad, you will see a list of entries appear in the "
+"main menu area. These are your **open tabs.** You can freely switch between "
+"open tabs without losing your work - all unsaved changes are automatically "
+"backed up to the server."
 msgstr ""
 "Vous pouvez basculer librement entre les onglets ouverts sans perdre votre "
 "travail - toutes les modifications non enregistrées sont automatiquement "
 "sauvegardées sur le serveur."
 
-#: ../advanced/tabs.rst:13
+#: ../advanced/tabs.rst:12
 msgid "Sample view of Tabs"
 msgstr ""
 
-#: ../advanced/tabs.rst:13
+#: ../advanced/tabs.rst:12
 msgid ""
 "Tabs appear in the main menu as you visit different parts of the application."
 msgstr ""
 "Des onglets apparaissent dans le menu principal lorsque vous visitez "
 "différentes parties de l'application."
 
-#: ../advanced/tabs.rst:16
+#: ../advanced/tabs.rst:15
 #, fuzzy
 msgid "**What items open in a new “tab”?**"
 msgstr "Quels éléments s'ouvrent dans un nouvel \"onglet\" ?"
 
-#: ../advanced/tabs.rst:18
+#: ../advanced/tabs.rst:17
 msgid "Existing tickets"
 msgstr "Billets existants"
 
-#: ../advanced/tabs.rst:19
+#: ../advanced/tabs.rst:18
 msgid "New tickets"
 msgstr "Nouveaux billets"
 
-#: ../advanced/tabs.rst:20
+#: ../advanced/tabs.rst:19
 msgid "Users"
 msgstr "Utilisateurs"
 
-#: ../advanced/tabs.rst:21 ../extras/organizations.rst:2
+#: ../advanced/tabs.rst:20 ../extras/organizations.rst:2
 msgid "Organizations"
 msgstr "Organisations"
 
-#: ../advanced/tabs.rst:22
+#: ../advanced/tabs.rst:21
 msgid "Omnisearch"
 msgstr "Omnisearch"
 
-#: ../advanced/tabs.rst:24 ../basics/find-ticket/browse.rst:27
+#: ../advanced/tabs.rst:23 ../basics/find-ticket/browse.rst:27
 #: ../basics/find-ticket/search.rst:33 ../basics/service-ticket/create.rst:47
 #: ../snippets/ui-protip-message-editor-features.rst:1
 msgid "**🖱️ UI Protip**"
 msgstr "**🖱️ UI Protip**"
 
-#: ../advanced/tabs.rst:26
+#: ../advanced/tabs.rst:25
 msgid ""
 ":doc:`Ticket states </basics/service-ticket/settings/state>` are **color-"
 "coded:**"
@@ -1494,7 +1488,7 @@ msgstr "|red|"
 msgid "**Immediate action needed** (ticket escalated due to an SLA violation)"
 msgstr ""
 
-#: ../advanced/tabs.rst:31
+#: ../advanced/tabs.rst:30
 msgid ""
 "A **pulsing dot** means that a ticket has new activity since you last viewed "
 "it."
@@ -1502,15 +1496,15 @@ msgstr ""
 "Un **point clignottant** signifie qu'un billet a reçu une nouvelle activité "
 "depuis votre dernière consultation."
 
-#: ../advanced/tabs.rst:33
+#: ../advanced/tabs.rst:32
 msgid "Drag and drop tabs to rearrange them."
 msgstr "Glisser et déposer les onglets pour les réorganiser."
 
-#: ../advanced/tabs.rst:36
+#: ../advanced/tabs.rst:35
 msgid "Tab Behavior in Ticket Zooms"
 msgstr ""
 
-#: ../advanced/tabs.rst:38
+#: ../advanced/tabs.rst:37
 msgid ""
 "You may have noticed the \"Stay on tab\" button next to \"Update\" on the "
 "lower right already. This behavior of a tab can be configured by your "
@@ -1522,47 +1516,47 @@ msgstr ""
 msgid "Tab behavior can be adjusted in tickets manually"
 msgstr ""
 
-#: ../advanced/tabs.rst:47
+#: ../advanced/tabs.rst:46
 msgid ""
 "To overrule your administrator's settings, simply choose the action you "
 "prefer. Zammad will remember this preference until you change its setting."
 msgstr ""
 
-#: ../advanced/tabs.rst:52
+#: ../advanced/tabs.rst:51
 msgid "Close tab"
 msgstr ""
 
-#: ../advanced/tabs.rst:51
+#: ../advanced/tabs.rst:50
 msgid ""
 "Upon updating the ticket, Zammad will automatically close the tab. You'll be "
 "returned to the last view that was open."
 msgstr ""
 
-#: ../advanced/tabs.rst:58
+#: ../advanced/tabs.rst:57
 msgid "Close tab on ticket close"
 msgstr ""
 
-#: ../advanced/tabs.rst:55
+#: ../advanced/tabs.rst:54
 msgid ""
 "Ticket tabs will be closed only if you change the state to \"closed\" upon "
 "ticket update."
 msgstr ""
 
-#: ../advanced/tabs.rst:58
+#: ../advanced/tabs.rst:57
 msgid "This does not apply for pending states that end in closed states."
 msgstr ""
 
-#: ../advanced/tabs.rst:66
+#: ../advanced/tabs.rst:65
 msgid "Next in overview"
 msgstr ""
 
-#: ../advanced/tabs.rst:61
+#: ../advanced/tabs.rst:60
 msgid ""
 "If you opened a ticket from any overview, Zammad will jump to the next "
 "ticket in said overview. Zammad recycles the open tab."
 msgstr ""
 
-#: ../advanced/tabs.rst:64
+#: ../advanced/tabs.rst:63
 msgid ""
 "This option is only available if you open the ticket from an overview. "
 "Zammad will ignore the setting if you opened the ticket directly and fall "
@@ -1573,12 +1567,20 @@ msgstr ""
 msgid "Stay on tab"
 msgstr ""
 
-#: ../advanced/tabs.rst:69
+#: ../advanced/tabs.rst:68
 msgid "Updating the ticket doesn't have any effect on the tab."
 msgstr ""
 
-#: ../advanced/tabs.rst:71
+#: ../advanced/tabs.rst:70
 msgid "*This is the default setting in Zammad installations.*"
+msgstr ""
+
+#: ../advanced/tabs.rst:72
+msgid ""
+"Now that you are an expert in tab handling, one more thing might be "
+"interesting as well: the maximum number of tabs is 30 due to performance "
+"reasons. In case you reach the limit and open another tab, the first opened "
+"tab gets closed automatically."
 msgstr ""
 
 #: ../advanced/text-modules.rst:2
@@ -7876,6 +7878,13 @@ msgid ""
 "also :docs:`system </index.html>` and :admin-docs:`administration manuals </"
 "index.html>` available."
 msgstr ""
+
+#~ msgid ""
+#~ "As you click through Zammad, you will see a list of entries appear in the "
+#~ "main menu area. These are your **open tabs.**"
+#~ msgstr ""
+#~ "Lorsque vous cliquez sur Zammad, une liste d'entrées apparaît dans la "
+#~ "zone du menu principal. Ce sont vos **onglets ouverts**."
 
 #~ msgid "article.attachment.content_type: string (File type e.g. PDF)"
 #~ msgstr "article.attachment.content_type: string (File type e.g. PDF)"

--- a/locale/hr/LC_MESSAGES/user-docs.po
+++ b/locale/hr/LC_MESSAGES/user-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-09 08:29+0200\n"
+"POT-Creation-Date: 2025-11-04 07:08+0000\n"
 "PO-Revision-Date: 2022-06-15 14:40+0000\n"
 "Last-Translator: Ivan Perovic <ip@zammad.com>\n"
 "Language-Team: Croatian <https://translations.zammad.org/projects/"
@@ -1426,55 +1426,51 @@ msgstr ""
 #: ../advanced/tabs.rst:4
 msgid ""
 "As you click through Zammad, you will see a list of entries appear in the "
-"main menu area. These are your **open tabs.**"
+"main menu area. These are your **open tabs.** You can freely switch between "
+"open tabs without losing your work - all unsaved changes are automatically "
+"backed up to the server."
 msgstr ""
 
-#: ../advanced/tabs.rst:7
-msgid ""
-"You can freely switch between open tabs without losing your work - all "
-"unsaved changes are automatically backed up to the server."
-msgstr ""
-
-#: ../advanced/tabs.rst:13
+#: ../advanced/tabs.rst:12
 msgid "Sample view of Tabs"
 msgstr ""
 
-#: ../advanced/tabs.rst:13
+#: ../advanced/tabs.rst:12
 msgid ""
 "Tabs appear in the main menu as you visit different parts of the application."
 msgstr ""
 
-#: ../advanced/tabs.rst:16
+#: ../advanced/tabs.rst:15
 msgid "**What items open in a new “tab”?**"
 msgstr ""
 
-#: ../advanced/tabs.rst:18
+#: ../advanced/tabs.rst:17
 msgid "Existing tickets"
 msgstr ""
 
-#: ../advanced/tabs.rst:19
+#: ../advanced/tabs.rst:18
 msgid "New tickets"
 msgstr ""
 
-#: ../advanced/tabs.rst:20
+#: ../advanced/tabs.rst:19
 msgid "Users"
 msgstr ""
 
-#: ../advanced/tabs.rst:21 ../extras/organizations.rst:2
+#: ../advanced/tabs.rst:20 ../extras/organizations.rst:2
 msgid "Organizations"
 msgstr ""
 
-#: ../advanced/tabs.rst:22
+#: ../advanced/tabs.rst:21
 msgid "Omnisearch"
 msgstr ""
 
-#: ../advanced/tabs.rst:24 ../basics/find-ticket/browse.rst:27
+#: ../advanced/tabs.rst:23 ../basics/find-ticket/browse.rst:27
 #: ../basics/find-ticket/search.rst:33 ../basics/service-ticket/create.rst:47
 #: ../snippets/ui-protip-message-editor-features.rst:1
 msgid "**🖱️ UI Protip**"
 msgstr "**🖱️za napredne korisnike**"
 
-#: ../advanced/tabs.rst:26
+#: ../advanced/tabs.rst:25
 msgid ""
 ":doc:`Ticket states </basics/service-ticket/settings/state>` are **color-"
 "coded:**"
@@ -1512,21 +1508,21 @@ msgstr ""
 msgid "**Immediate action needed** (ticket escalated due to an SLA violation)"
 msgstr ""
 
-#: ../advanced/tabs.rst:31
+#: ../advanced/tabs.rst:30
 msgid ""
 "A **pulsing dot** means that a ticket has new activity since you last viewed "
 "it."
 msgstr ""
 
-#: ../advanced/tabs.rst:33
+#: ../advanced/tabs.rst:32
 msgid "Drag and drop tabs to rearrange them."
 msgstr ""
 
-#: ../advanced/tabs.rst:36
+#: ../advanced/tabs.rst:35
 msgid "Tab Behavior in Ticket Zooms"
 msgstr ""
 
-#: ../advanced/tabs.rst:38
+#: ../advanced/tabs.rst:37
 msgid ""
 "You may have noticed the \"Stay on tab\" button next to \"Update\" on the "
 "lower right already. This behavior of a tab can be configured by your "
@@ -1538,47 +1534,47 @@ msgstr ""
 msgid "Tab behavior can be adjusted in tickets manually"
 msgstr ""
 
-#: ../advanced/tabs.rst:47
+#: ../advanced/tabs.rst:46
 msgid ""
 "To overrule your administrator's settings, simply choose the action you "
 "prefer. Zammad will remember this preference until you change its setting."
 msgstr ""
 
-#: ../advanced/tabs.rst:52
+#: ../advanced/tabs.rst:51
 msgid "Close tab"
 msgstr ""
 
-#: ../advanced/tabs.rst:51
+#: ../advanced/tabs.rst:50
 msgid ""
 "Upon updating the ticket, Zammad will automatically close the tab. You'll be "
 "returned to the last view that was open."
 msgstr ""
 
-#: ../advanced/tabs.rst:58
+#: ../advanced/tabs.rst:57
 msgid "Close tab on ticket close"
 msgstr ""
 
-#: ../advanced/tabs.rst:55
+#: ../advanced/tabs.rst:54
 msgid ""
 "Ticket tabs will be closed only if you change the state to \"closed\" upon "
 "ticket update."
 msgstr ""
 
-#: ../advanced/tabs.rst:58
+#: ../advanced/tabs.rst:57
 msgid "This does not apply for pending states that end in closed states."
 msgstr ""
 
-#: ../advanced/tabs.rst:66
+#: ../advanced/tabs.rst:65
 msgid "Next in overview"
 msgstr ""
 
-#: ../advanced/tabs.rst:61
+#: ../advanced/tabs.rst:60
 msgid ""
 "If you opened a ticket from any overview, Zammad will jump to the next "
 "ticket in said overview. Zammad recycles the open tab."
 msgstr ""
 
-#: ../advanced/tabs.rst:64
+#: ../advanced/tabs.rst:63
 msgid ""
 "This option is only available if you open the ticket from an overview. "
 "Zammad will ignore the setting if you opened the ticket directly and fall "
@@ -1589,12 +1585,20 @@ msgstr ""
 msgid "Stay on tab"
 msgstr ""
 
-#: ../advanced/tabs.rst:69
+#: ../advanced/tabs.rst:68
 msgid "Updating the ticket doesn't have any effect on the tab."
 msgstr ""
 
-#: ../advanced/tabs.rst:71
+#: ../advanced/tabs.rst:70
 msgid "*This is the default setting in Zammad installations.*"
+msgstr ""
+
+#: ../advanced/tabs.rst:72
+msgid ""
+"Now that you are an expert in tab handling, one more thing might be "
+"interesting as well: the maximum number of tabs is 30 due to performance "
+"reasons. In case you reach the limit and open another tab, the first opened "
+"tab gets closed automatically."
 msgstr ""
 
 #: ../advanced/text-modules.rst:2

--- a/locale/hu/LC_MESSAGES/user-docs.po
+++ b/locale/hu/LC_MESSAGES/user-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-09 08:29+0200\n"
+"POT-Creation-Date: 2025-11-04 07:08+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -1305,55 +1305,51 @@ msgstr ""
 #: ../advanced/tabs.rst:4
 msgid ""
 "As you click through Zammad, you will see a list of entries appear in the "
-"main menu area. These are your **open tabs.**"
+"main menu area. These are your **open tabs.** You can freely switch between "
+"open tabs without losing your work - all unsaved changes are automatically "
+"backed up to the server."
 msgstr ""
 
-#: ../advanced/tabs.rst:7
-msgid ""
-"You can freely switch between open tabs without losing your work - all "
-"unsaved changes are automatically backed up to the server."
-msgstr ""
-
-#: ../advanced/tabs.rst:13
+#: ../advanced/tabs.rst:12
 msgid "Sample view of Tabs"
 msgstr ""
 
-#: ../advanced/tabs.rst:13
+#: ../advanced/tabs.rst:12
 msgid ""
 "Tabs appear in the main menu as you visit different parts of the application."
 msgstr ""
 
-#: ../advanced/tabs.rst:16
+#: ../advanced/tabs.rst:15
 msgid "**What items open in a new “tab”?**"
 msgstr ""
 
-#: ../advanced/tabs.rst:18
+#: ../advanced/tabs.rst:17
 msgid "Existing tickets"
 msgstr ""
 
-#: ../advanced/tabs.rst:19
+#: ../advanced/tabs.rst:18
 msgid "New tickets"
 msgstr ""
 
-#: ../advanced/tabs.rst:20
+#: ../advanced/tabs.rst:19
 msgid "Users"
 msgstr ""
 
-#: ../advanced/tabs.rst:21 ../extras/organizations.rst:2
+#: ../advanced/tabs.rst:20 ../extras/organizations.rst:2
 msgid "Organizations"
 msgstr ""
 
-#: ../advanced/tabs.rst:22
+#: ../advanced/tabs.rst:21
 msgid "Omnisearch"
 msgstr ""
 
-#: ../advanced/tabs.rst:24 ../basics/find-ticket/browse.rst:27
+#: ../advanced/tabs.rst:23 ../basics/find-ticket/browse.rst:27
 #: ../basics/find-ticket/search.rst:33 ../basics/service-ticket/create.rst:47
 #: ../snippets/ui-protip-message-editor-features.rst:1
 msgid "**🖱️ UI Protip**"
 msgstr ""
 
-#: ../advanced/tabs.rst:26
+#: ../advanced/tabs.rst:25
 msgid ""
 ":doc:`Ticket states </basics/service-ticket/settings/state>` are **color-"
 "coded:**"
@@ -1391,21 +1387,21 @@ msgstr ""
 msgid "**Immediate action needed** (ticket escalated due to an SLA violation)"
 msgstr ""
 
-#: ../advanced/tabs.rst:31
+#: ../advanced/tabs.rst:30
 msgid ""
 "A **pulsing dot** means that a ticket has new activity since you last viewed "
 "it."
 msgstr ""
 
-#: ../advanced/tabs.rst:33
+#: ../advanced/tabs.rst:32
 msgid "Drag and drop tabs to rearrange them."
 msgstr ""
 
-#: ../advanced/tabs.rst:36
+#: ../advanced/tabs.rst:35
 msgid "Tab Behavior in Ticket Zooms"
 msgstr ""
 
-#: ../advanced/tabs.rst:38
+#: ../advanced/tabs.rst:37
 msgid ""
 "You may have noticed the \"Stay on tab\" button next to \"Update\" on the "
 "lower right already. This behavior of a tab can be configured by your "
@@ -1417,47 +1413,47 @@ msgstr ""
 msgid "Tab behavior can be adjusted in tickets manually"
 msgstr ""
 
-#: ../advanced/tabs.rst:47
+#: ../advanced/tabs.rst:46
 msgid ""
 "To overrule your administrator's settings, simply choose the action you "
 "prefer. Zammad will remember this preference until you change its setting."
 msgstr ""
 
-#: ../advanced/tabs.rst:52
+#: ../advanced/tabs.rst:51
 msgid "Close tab"
 msgstr ""
 
-#: ../advanced/tabs.rst:51
+#: ../advanced/tabs.rst:50
 msgid ""
 "Upon updating the ticket, Zammad will automatically close the tab. You'll be "
 "returned to the last view that was open."
 msgstr ""
 
-#: ../advanced/tabs.rst:58
+#: ../advanced/tabs.rst:57
 msgid "Close tab on ticket close"
 msgstr ""
 
-#: ../advanced/tabs.rst:55
+#: ../advanced/tabs.rst:54
 msgid ""
 "Ticket tabs will be closed only if you change the state to \"closed\" upon "
 "ticket update."
 msgstr ""
 
-#: ../advanced/tabs.rst:58
+#: ../advanced/tabs.rst:57
 msgid "This does not apply for pending states that end in closed states."
 msgstr ""
 
-#: ../advanced/tabs.rst:66
+#: ../advanced/tabs.rst:65
 msgid "Next in overview"
 msgstr ""
 
-#: ../advanced/tabs.rst:61
+#: ../advanced/tabs.rst:60
 msgid ""
 "If you opened a ticket from any overview, Zammad will jump to the next "
 "ticket in said overview. Zammad recycles the open tab."
 msgstr ""
 
-#: ../advanced/tabs.rst:64
+#: ../advanced/tabs.rst:63
 msgid ""
 "This option is only available if you open the ticket from an overview. "
 "Zammad will ignore the setting if you opened the ticket directly and fall "
@@ -1468,12 +1464,20 @@ msgstr ""
 msgid "Stay on tab"
 msgstr ""
 
-#: ../advanced/tabs.rst:69
+#: ../advanced/tabs.rst:68
 msgid "Updating the ticket doesn't have any effect on the tab."
 msgstr ""
 
-#: ../advanced/tabs.rst:71
+#: ../advanced/tabs.rst:70
 msgid "*This is the default setting in Zammad installations.*"
+msgstr ""
+
+#: ../advanced/tabs.rst:72
+msgid ""
+"Now that you are an expert in tab handling, one more thing might be "
+"interesting as well: the maximum number of tabs is 30 due to performance "
+"reasons. In case you reach the limit and open another tab, the first opened "
+"tab gets closed automatically."
 msgstr ""
 
 #: ../advanced/text-modules.rst:2

--- a/locale/it/LC_MESSAGES/user-docs.po
+++ b/locale/it/LC_MESSAGES/user-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-09 08:29+0200\n"
+"POT-Creation-Date: 2025-11-04 07:08+0000\n"
 "PO-Revision-Date: 2025-09-06 07:00+0000\n"
 "Last-Translator: Rudolfet <hermy.t.m1997@gmail.com>\n"
 "Language-Team: Italian <https://translations.zammad.org/projects/"
@@ -1369,55 +1369,51 @@ msgstr ""
 #: ../advanced/tabs.rst:4
 msgid ""
 "As you click through Zammad, you will see a list of entries appear in the "
-"main menu area. These are your **open tabs.**"
+"main menu area. These are your **open tabs.** You can freely switch between "
+"open tabs without losing your work - all unsaved changes are automatically "
+"backed up to the server."
 msgstr ""
 
-#: ../advanced/tabs.rst:7
-msgid ""
-"You can freely switch between open tabs without losing your work - all "
-"unsaved changes are automatically backed up to the server."
-msgstr ""
-
-#: ../advanced/tabs.rst:13
+#: ../advanced/tabs.rst:12
 msgid "Sample view of Tabs"
 msgstr ""
 
-#: ../advanced/tabs.rst:13
+#: ../advanced/tabs.rst:12
 msgid ""
 "Tabs appear in the main menu as you visit different parts of the application."
 msgstr ""
 
-#: ../advanced/tabs.rst:16
+#: ../advanced/tabs.rst:15
 msgid "**What items open in a new “tab”?**"
 msgstr ""
 
-#: ../advanced/tabs.rst:18
+#: ../advanced/tabs.rst:17
 msgid "Existing tickets"
 msgstr ""
 
-#: ../advanced/tabs.rst:19
+#: ../advanced/tabs.rst:18
 msgid "New tickets"
 msgstr ""
 
-#: ../advanced/tabs.rst:20
+#: ../advanced/tabs.rst:19
 msgid "Users"
 msgstr ""
 
-#: ../advanced/tabs.rst:21 ../extras/organizations.rst:2
+#: ../advanced/tabs.rst:20 ../extras/organizations.rst:2
 msgid "Organizations"
 msgstr ""
 
-#: ../advanced/tabs.rst:22
+#: ../advanced/tabs.rst:21
 msgid "Omnisearch"
 msgstr ""
 
-#: ../advanced/tabs.rst:24 ../basics/find-ticket/browse.rst:27
+#: ../advanced/tabs.rst:23 ../basics/find-ticket/browse.rst:27
 #: ../basics/find-ticket/search.rst:33 ../basics/service-ticket/create.rst:47
 #: ../snippets/ui-protip-message-editor-features.rst:1
 msgid "**🖱️ UI Protip**"
 msgstr "**🖱️ Suggerimento sull'interfaccia utente**"
 
-#: ../advanced/tabs.rst:26
+#: ../advanced/tabs.rst:25
 msgid ""
 ":doc:`Ticket states </basics/service-ticket/settings/state>` are **color-"
 "coded:**"
@@ -1457,21 +1453,21 @@ msgstr "|red|"
 msgid "**Immediate action needed** (ticket escalated due to an SLA violation)"
 msgstr ""
 
-#: ../advanced/tabs.rst:31
+#: ../advanced/tabs.rst:30
 msgid ""
 "A **pulsing dot** means that a ticket has new activity since you last viewed "
 "it."
 msgstr ""
 
-#: ../advanced/tabs.rst:33
+#: ../advanced/tabs.rst:32
 msgid "Drag and drop tabs to rearrange them."
 msgstr ""
 
-#: ../advanced/tabs.rst:36
+#: ../advanced/tabs.rst:35
 msgid "Tab Behavior in Ticket Zooms"
 msgstr ""
 
-#: ../advanced/tabs.rst:38
+#: ../advanced/tabs.rst:37
 msgid ""
 "You may have noticed the \"Stay on tab\" button next to \"Update\" on the "
 "lower right already. This behavior of a tab can be configured by your "
@@ -1483,47 +1479,47 @@ msgstr ""
 msgid "Tab behavior can be adjusted in tickets manually"
 msgstr ""
 
-#: ../advanced/tabs.rst:47
+#: ../advanced/tabs.rst:46
 msgid ""
 "To overrule your administrator's settings, simply choose the action you "
 "prefer. Zammad will remember this preference until you change its setting."
 msgstr ""
 
-#: ../advanced/tabs.rst:52
+#: ../advanced/tabs.rst:51
 msgid "Close tab"
 msgstr ""
 
-#: ../advanced/tabs.rst:51
+#: ../advanced/tabs.rst:50
 msgid ""
 "Upon updating the ticket, Zammad will automatically close the tab. You'll be "
 "returned to the last view that was open."
 msgstr ""
 
-#: ../advanced/tabs.rst:58
+#: ../advanced/tabs.rst:57
 msgid "Close tab on ticket close"
 msgstr ""
 
-#: ../advanced/tabs.rst:55
+#: ../advanced/tabs.rst:54
 msgid ""
 "Ticket tabs will be closed only if you change the state to \"closed\" upon "
 "ticket update."
 msgstr ""
 
-#: ../advanced/tabs.rst:58
+#: ../advanced/tabs.rst:57
 msgid "This does not apply for pending states that end in closed states."
 msgstr ""
 
-#: ../advanced/tabs.rst:66
+#: ../advanced/tabs.rst:65
 msgid "Next in overview"
 msgstr ""
 
-#: ../advanced/tabs.rst:61
+#: ../advanced/tabs.rst:60
 msgid ""
 "If you opened a ticket from any overview, Zammad will jump to the next "
 "ticket in said overview. Zammad recycles the open tab."
 msgstr ""
 
-#: ../advanced/tabs.rst:64
+#: ../advanced/tabs.rst:63
 msgid ""
 "This option is only available if you open the ticket from an overview. "
 "Zammad will ignore the setting if you opened the ticket directly and fall "
@@ -1534,12 +1530,20 @@ msgstr ""
 msgid "Stay on tab"
 msgstr ""
 
-#: ../advanced/tabs.rst:69
+#: ../advanced/tabs.rst:68
 msgid "Updating the ticket doesn't have any effect on the tab."
 msgstr ""
 
-#: ../advanced/tabs.rst:71
+#: ../advanced/tabs.rst:70
 msgid "*This is the default setting in Zammad installations.*"
+msgstr ""
+
+#: ../advanced/tabs.rst:72
+msgid ""
+"Now that you are an expert in tab handling, one more thing might be "
+"interesting as well: the maximum number of tabs is 30 due to performance "
+"reasons. In case you reach the limit and open another tab, the first opened "
+"tab gets closed automatically."
 msgstr ""
 
 #: ../advanced/text-modules.rst:2

--- a/locale/nl/LC_MESSAGES/user-docs.po
+++ b/locale/nl/LC_MESSAGES/user-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-09 08:29+0200\n"
+"POT-Creation-Date: 2025-11-04 07:08+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -1305,55 +1305,51 @@ msgstr ""
 #: ../advanced/tabs.rst:4
 msgid ""
 "As you click through Zammad, you will see a list of entries appear in the "
-"main menu area. These are your **open tabs.**"
+"main menu area. These are your **open tabs.** You can freely switch between "
+"open tabs without losing your work - all unsaved changes are automatically "
+"backed up to the server."
 msgstr ""
 
-#: ../advanced/tabs.rst:7
-msgid ""
-"You can freely switch between open tabs without losing your work - all "
-"unsaved changes are automatically backed up to the server."
-msgstr ""
-
-#: ../advanced/tabs.rst:13
+#: ../advanced/tabs.rst:12
 msgid "Sample view of Tabs"
 msgstr ""
 
-#: ../advanced/tabs.rst:13
+#: ../advanced/tabs.rst:12
 msgid ""
 "Tabs appear in the main menu as you visit different parts of the application."
 msgstr ""
 
-#: ../advanced/tabs.rst:16
+#: ../advanced/tabs.rst:15
 msgid "**What items open in a new “tab”?**"
 msgstr ""
 
-#: ../advanced/tabs.rst:18
+#: ../advanced/tabs.rst:17
 msgid "Existing tickets"
 msgstr ""
 
-#: ../advanced/tabs.rst:19
+#: ../advanced/tabs.rst:18
 msgid "New tickets"
 msgstr ""
 
-#: ../advanced/tabs.rst:20
+#: ../advanced/tabs.rst:19
 msgid "Users"
 msgstr ""
 
-#: ../advanced/tabs.rst:21 ../extras/organizations.rst:2
+#: ../advanced/tabs.rst:20 ../extras/organizations.rst:2
 msgid "Organizations"
 msgstr ""
 
-#: ../advanced/tabs.rst:22
+#: ../advanced/tabs.rst:21
 msgid "Omnisearch"
 msgstr ""
 
-#: ../advanced/tabs.rst:24 ../basics/find-ticket/browse.rst:27
+#: ../advanced/tabs.rst:23 ../basics/find-ticket/browse.rst:27
 #: ../basics/find-ticket/search.rst:33 ../basics/service-ticket/create.rst:47
 #: ../snippets/ui-protip-message-editor-features.rst:1
 msgid "**🖱️ UI Protip**"
 msgstr ""
 
-#: ../advanced/tabs.rst:26
+#: ../advanced/tabs.rst:25
 msgid ""
 ":doc:`Ticket states </basics/service-ticket/settings/state>` are **color-"
 "coded:**"
@@ -1391,21 +1387,21 @@ msgstr ""
 msgid "**Immediate action needed** (ticket escalated due to an SLA violation)"
 msgstr ""
 
-#: ../advanced/tabs.rst:31
+#: ../advanced/tabs.rst:30
 msgid ""
 "A **pulsing dot** means that a ticket has new activity since you last viewed "
 "it."
 msgstr ""
 
-#: ../advanced/tabs.rst:33
+#: ../advanced/tabs.rst:32
 msgid "Drag and drop tabs to rearrange them."
 msgstr ""
 
-#: ../advanced/tabs.rst:36
+#: ../advanced/tabs.rst:35
 msgid "Tab Behavior in Ticket Zooms"
 msgstr ""
 
-#: ../advanced/tabs.rst:38
+#: ../advanced/tabs.rst:37
 msgid ""
 "You may have noticed the \"Stay on tab\" button next to \"Update\" on the "
 "lower right already. This behavior of a tab can be configured by your "
@@ -1417,47 +1413,47 @@ msgstr ""
 msgid "Tab behavior can be adjusted in tickets manually"
 msgstr ""
 
-#: ../advanced/tabs.rst:47
+#: ../advanced/tabs.rst:46
 msgid ""
 "To overrule your administrator's settings, simply choose the action you "
 "prefer. Zammad will remember this preference until you change its setting."
 msgstr ""
 
-#: ../advanced/tabs.rst:52
+#: ../advanced/tabs.rst:51
 msgid "Close tab"
 msgstr ""
 
-#: ../advanced/tabs.rst:51
+#: ../advanced/tabs.rst:50
 msgid ""
 "Upon updating the ticket, Zammad will automatically close the tab. You'll be "
 "returned to the last view that was open."
 msgstr ""
 
-#: ../advanced/tabs.rst:58
+#: ../advanced/tabs.rst:57
 msgid "Close tab on ticket close"
 msgstr ""
 
-#: ../advanced/tabs.rst:55
+#: ../advanced/tabs.rst:54
 msgid ""
 "Ticket tabs will be closed only if you change the state to \"closed\" upon "
 "ticket update."
 msgstr ""
 
-#: ../advanced/tabs.rst:58
+#: ../advanced/tabs.rst:57
 msgid "This does not apply for pending states that end in closed states."
 msgstr ""
 
-#: ../advanced/tabs.rst:66
+#: ../advanced/tabs.rst:65
 msgid "Next in overview"
 msgstr ""
 
-#: ../advanced/tabs.rst:61
+#: ../advanced/tabs.rst:60
 msgid ""
 "If you opened a ticket from any overview, Zammad will jump to the next "
 "ticket in said overview. Zammad recycles the open tab."
 msgstr ""
 
-#: ../advanced/tabs.rst:64
+#: ../advanced/tabs.rst:63
 msgid ""
 "This option is only available if you open the ticket from an overview. "
 "Zammad will ignore the setting if you opened the ticket directly and fall "
@@ -1468,12 +1464,20 @@ msgstr ""
 msgid "Stay on tab"
 msgstr ""
 
-#: ../advanced/tabs.rst:69
+#: ../advanced/tabs.rst:68
 msgid "Updating the ticket doesn't have any effect on the tab."
 msgstr ""
 
-#: ../advanced/tabs.rst:71
+#: ../advanced/tabs.rst:70
 msgid "*This is the default setting in Zammad installations.*"
+msgstr ""
+
+#: ../advanced/tabs.rst:72
+msgid ""
+"Now that you are an expert in tab handling, one more thing might be "
+"interesting as well: the maximum number of tabs is 30 due to performance "
+"reasons. In case you reach the limit and open another tab, the first opened "
+"tab gets closed automatically."
 msgstr ""
 
 #: ../advanced/text-modules.rst:2

--- a/locale/pl/LC_MESSAGES/user-docs.po
+++ b/locale/pl/LC_MESSAGES/user-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-09 08:29+0200\n"
+"POT-Creation-Date: 2025-11-04 07:08+0000\n"
 "PO-Revision-Date: 2025-10-28 07:00+0000\n"
 "Last-Translator: MBekspert <michal.bosak@ekspert.biz>\n"
 "Language-Team: Polish <https://translations.zammad.org/projects/"
@@ -1459,55 +1459,51 @@ msgstr ""
 #: ../advanced/tabs.rst:4
 msgid ""
 "As you click through Zammad, you will see a list of entries appear in the "
-"main menu area. These are your **open tabs.**"
+"main menu area. These are your **open tabs.** You can freely switch between "
+"open tabs without losing your work - all unsaved changes are automatically "
+"backed up to the server."
 msgstr ""
 
-#: ../advanced/tabs.rst:7
-msgid ""
-"You can freely switch between open tabs without losing your work - all "
-"unsaved changes are automatically backed up to the server."
-msgstr ""
-
-#: ../advanced/tabs.rst:13
+#: ../advanced/tabs.rst:12
 msgid "Sample view of Tabs"
 msgstr ""
 
-#: ../advanced/tabs.rst:13
+#: ../advanced/tabs.rst:12
 msgid ""
 "Tabs appear in the main menu as you visit different parts of the application."
 msgstr ""
 
-#: ../advanced/tabs.rst:16
+#: ../advanced/tabs.rst:15
 msgid "**What items open in a new “tab”?**"
 msgstr ""
 
-#: ../advanced/tabs.rst:18
+#: ../advanced/tabs.rst:17
 msgid "Existing tickets"
 msgstr ""
 
-#: ../advanced/tabs.rst:19
+#: ../advanced/tabs.rst:18
 msgid "New tickets"
 msgstr ""
 
-#: ../advanced/tabs.rst:20
+#: ../advanced/tabs.rst:19
 msgid "Users"
 msgstr ""
 
-#: ../advanced/tabs.rst:21 ../extras/organizations.rst:2
+#: ../advanced/tabs.rst:20 ../extras/organizations.rst:2
 msgid "Organizations"
 msgstr ""
 
-#: ../advanced/tabs.rst:22
+#: ../advanced/tabs.rst:21
 msgid "Omnisearch"
 msgstr ""
 
-#: ../advanced/tabs.rst:24 ../basics/find-ticket/browse.rst:27
+#: ../advanced/tabs.rst:23 ../basics/find-ticket/browse.rst:27
 #: ../basics/find-ticket/search.rst:33 ../basics/service-ticket/create.rst:47
 #: ../snippets/ui-protip-message-editor-features.rst:1
 msgid "**🖱️ UI Protip**"
 msgstr "**🖱️ Porada UI**"
 
-#: ../advanced/tabs.rst:26
+#: ../advanced/tabs.rst:25
 msgid ""
 ":doc:`Ticket states </basics/service-ticket/settings/state>` are **color-"
 "coded:**"
@@ -1545,21 +1541,21 @@ msgstr ""
 msgid "**Immediate action needed** (ticket escalated due to an SLA violation)"
 msgstr ""
 
-#: ../advanced/tabs.rst:31
+#: ../advanced/tabs.rst:30
 msgid ""
 "A **pulsing dot** means that a ticket has new activity since you last viewed "
 "it."
 msgstr ""
 
-#: ../advanced/tabs.rst:33
+#: ../advanced/tabs.rst:32
 msgid "Drag and drop tabs to rearrange them."
 msgstr ""
 
-#: ../advanced/tabs.rst:36
+#: ../advanced/tabs.rst:35
 msgid "Tab Behavior in Ticket Zooms"
 msgstr ""
 
-#: ../advanced/tabs.rst:38
+#: ../advanced/tabs.rst:37
 msgid ""
 "You may have noticed the \"Stay on tab\" button next to \"Update\" on the "
 "lower right already. This behavior of a tab can be configured by your "
@@ -1571,47 +1567,47 @@ msgstr ""
 msgid "Tab behavior can be adjusted in tickets manually"
 msgstr ""
 
-#: ../advanced/tabs.rst:47
+#: ../advanced/tabs.rst:46
 msgid ""
 "To overrule your administrator's settings, simply choose the action you "
 "prefer. Zammad will remember this preference until you change its setting."
 msgstr ""
 
-#: ../advanced/tabs.rst:52
+#: ../advanced/tabs.rst:51
 msgid "Close tab"
 msgstr ""
 
-#: ../advanced/tabs.rst:51
+#: ../advanced/tabs.rst:50
 msgid ""
 "Upon updating the ticket, Zammad will automatically close the tab. You'll be "
 "returned to the last view that was open."
 msgstr ""
 
-#: ../advanced/tabs.rst:58
+#: ../advanced/tabs.rst:57
 msgid "Close tab on ticket close"
 msgstr ""
 
-#: ../advanced/tabs.rst:55
+#: ../advanced/tabs.rst:54
 msgid ""
 "Ticket tabs will be closed only if you change the state to \"closed\" upon "
 "ticket update."
 msgstr ""
 
-#: ../advanced/tabs.rst:58
+#: ../advanced/tabs.rst:57
 msgid "This does not apply for pending states that end in closed states."
 msgstr ""
 
-#: ../advanced/tabs.rst:66
+#: ../advanced/tabs.rst:65
 msgid "Next in overview"
 msgstr ""
 
-#: ../advanced/tabs.rst:61
+#: ../advanced/tabs.rst:60
 msgid ""
 "If you opened a ticket from any overview, Zammad will jump to the next "
 "ticket in said overview. Zammad recycles the open tab."
 msgstr ""
 
-#: ../advanced/tabs.rst:64
+#: ../advanced/tabs.rst:63
 msgid ""
 "This option is only available if you open the ticket from an overview. "
 "Zammad will ignore the setting if you opened the ticket directly and fall "
@@ -1622,12 +1618,20 @@ msgstr ""
 msgid "Stay on tab"
 msgstr ""
 
-#: ../advanced/tabs.rst:69
+#: ../advanced/tabs.rst:68
 msgid "Updating the ticket doesn't have any effect on the tab."
 msgstr ""
 
-#: ../advanced/tabs.rst:71
+#: ../advanced/tabs.rst:70
 msgid "*This is the default setting in Zammad installations.*"
+msgstr ""
+
+#: ../advanced/tabs.rst:72
+msgid ""
+"Now that you are an expert in tab handling, one more thing might be "
+"interesting as well: the maximum number of tabs is 30 due to performance "
+"reasons. In case you reach the limit and open another tab, the first opened "
+"tab gets closed automatically."
 msgstr ""
 
 #: ../advanced/text-modules.rst:2

--- a/locale/pt_BR/LC_MESSAGES/user-docs.po
+++ b/locale/pt_BR/LC_MESSAGES/user-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-09 08:29+0200\n"
+"POT-Creation-Date: 2025-11-04 07:08+0000\n"
 "PO-Revision-Date: 2022-08-01 14:09+0000\n"
 "Last-Translator: Erico Cesar <ericocesar@webck.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://translations.zammad.org/projects/"
@@ -1412,65 +1412,59 @@ msgid "Tabs"
 msgstr "Abas"
 
 #: ../advanced/tabs.rst:4
-msgid ""
-"As you click through Zammad, you will see a list of entries appear in the "
-"main menu area. These are your **open tabs.**"
-msgstr ""
-"A media que você navega pelo Zammad, você verá uma lista aparecer na área do "
-"menu principal. Estas são as suas **abas abertas.**"
-
-#: ../advanced/tabs.rst:7
 #, fuzzy
 msgid ""
-"You can freely switch between open tabs without losing your work - all "
-"unsaved changes are automatically backed up to the server."
+"As you click through Zammad, you will see a list of entries appear in the "
+"main menu area. These are your **open tabs.** You can freely switch between "
+"open tabs without losing your work - all unsaved changes are automatically "
+"backed up to the server."
 msgstr ""
 "Você pode trocar entre abas livremente sem perder o seu trabalho - todas as "
 "alterações não salvas são automaticamente armazenadas no servidor."
 
-#: ../advanced/tabs.rst:13
+#: ../advanced/tabs.rst:12
 msgid "Sample view of Tabs"
 msgstr ""
 
-#: ../advanced/tabs.rst:13
+#: ../advanced/tabs.rst:12
 msgid ""
 "Tabs appear in the main menu as you visit different parts of the application."
 msgstr ""
 "Abas aparecem no menu principal a media que você visita partes diferentes da "
 "aplicação."
 
-#: ../advanced/tabs.rst:16
+#: ../advanced/tabs.rst:15
 #, fuzzy
 msgid "**What items open in a new “tab”?**"
 msgstr "Quais itens aparecem em uma nova \"aba\"?"
 
-#: ../advanced/tabs.rst:18
+#: ../advanced/tabs.rst:17
 msgid "Existing tickets"
 msgstr "Chamados atuais"
 
-#: ../advanced/tabs.rst:19
+#: ../advanced/tabs.rst:18
 msgid "New tickets"
 msgstr "Novos chamados"
 
-#: ../advanced/tabs.rst:20
+#: ../advanced/tabs.rst:19
 msgid "Users"
 msgstr "Usuários"
 
-#: ../advanced/tabs.rst:21 ../extras/organizations.rst:2
+#: ../advanced/tabs.rst:20 ../extras/organizations.rst:2
 msgid "Organizations"
 msgstr "Organizações"
 
-#: ../advanced/tabs.rst:22
+#: ../advanced/tabs.rst:21
 msgid "Omnisearch"
 msgstr "Resultados da busca"
 
-#: ../advanced/tabs.rst:24 ../basics/find-ticket/browse.rst:27
+#: ../advanced/tabs.rst:23 ../basics/find-ticket/browse.rst:27
 #: ../basics/find-ticket/search.rst:33 ../basics/service-ticket/create.rst:47
 #: ../snippets/ui-protip-message-editor-features.rst:1
 msgid "**🖱️ UI Protip**"
 msgstr "**🖱️ Dica profissional da interface de usuário**"
 
-#: ../advanced/tabs.rst:26
+#: ../advanced/tabs.rst:25
 msgid ""
 ":doc:`Ticket states </basics/service-ticket/settings/state>` are **color-"
 "coded:**"
@@ -1510,7 +1504,7 @@ msgstr "|red|"
 msgid "**Immediate action needed** (ticket escalated due to an SLA violation)"
 msgstr ""
 
-#: ../advanced/tabs.rst:31
+#: ../advanced/tabs.rst:30
 msgid ""
 "A **pulsing dot** means that a ticket has new activity since you last viewed "
 "it."
@@ -1518,15 +1512,15 @@ msgstr ""
 "Um **ponto pulsante** significa que o chamado tem nova atividade desde a "
 "última vez que foi visualizado."
 
-#: ../advanced/tabs.rst:33
+#: ../advanced/tabs.rst:32
 msgid "Drag and drop tabs to rearrange them."
 msgstr "Arraste as abas para rearranjar a ordem."
 
-#: ../advanced/tabs.rst:36
+#: ../advanced/tabs.rst:35
 msgid "Tab Behavior in Ticket Zooms"
 msgstr ""
 
-#: ../advanced/tabs.rst:38
+#: ../advanced/tabs.rst:37
 msgid ""
 "You may have noticed the \"Stay on tab\" button next to \"Update\" on the "
 "lower right already. This behavior of a tab can be configured by your "
@@ -1538,47 +1532,47 @@ msgstr ""
 msgid "Tab behavior can be adjusted in tickets manually"
 msgstr ""
 
-#: ../advanced/tabs.rst:47
+#: ../advanced/tabs.rst:46
 msgid ""
 "To overrule your administrator's settings, simply choose the action you "
 "prefer. Zammad will remember this preference until you change its setting."
 msgstr ""
 
-#: ../advanced/tabs.rst:52
+#: ../advanced/tabs.rst:51
 msgid "Close tab"
 msgstr ""
 
-#: ../advanced/tabs.rst:51
+#: ../advanced/tabs.rst:50
 msgid ""
 "Upon updating the ticket, Zammad will automatically close the tab. You'll be "
 "returned to the last view that was open."
 msgstr ""
 
-#: ../advanced/tabs.rst:58
+#: ../advanced/tabs.rst:57
 msgid "Close tab on ticket close"
 msgstr ""
 
-#: ../advanced/tabs.rst:55
+#: ../advanced/tabs.rst:54
 msgid ""
 "Ticket tabs will be closed only if you change the state to \"closed\" upon "
 "ticket update."
 msgstr ""
 
-#: ../advanced/tabs.rst:58
+#: ../advanced/tabs.rst:57
 msgid "This does not apply for pending states that end in closed states."
 msgstr ""
 
-#: ../advanced/tabs.rst:66
+#: ../advanced/tabs.rst:65
 msgid "Next in overview"
 msgstr ""
 
-#: ../advanced/tabs.rst:61
+#: ../advanced/tabs.rst:60
 msgid ""
 "If you opened a ticket from any overview, Zammad will jump to the next "
 "ticket in said overview. Zammad recycles the open tab."
 msgstr ""
 
-#: ../advanced/tabs.rst:64
+#: ../advanced/tabs.rst:63
 msgid ""
 "This option is only available if you open the ticket from an overview. "
 "Zammad will ignore the setting if you opened the ticket directly and fall "
@@ -1589,12 +1583,20 @@ msgstr ""
 msgid "Stay on tab"
 msgstr ""
 
-#: ../advanced/tabs.rst:69
+#: ../advanced/tabs.rst:68
 msgid "Updating the ticket doesn't have any effect on the tab."
 msgstr ""
 
-#: ../advanced/tabs.rst:71
+#: ../advanced/tabs.rst:70
 msgid "*This is the default setting in Zammad installations.*"
+msgstr ""
+
+#: ../advanced/tabs.rst:72
+msgid ""
+"Now that you are an expert in tab handling, one more thing might be "
+"interesting as well: the maximum number of tabs is 30 due to performance "
+"reasons. In case you reach the limit and open another tab, the first opened "
+"tab gets closed automatically."
 msgstr ""
 
 #: ../advanced/text-modules.rst:2
@@ -8318,6 +8320,13 @@ msgid ""
 "also :docs:`system </index.html>` and :admin-docs:`administration manuals </"
 "index.html>` available."
 msgstr ""
+
+#~ msgid ""
+#~ "As you click through Zammad, you will see a list of entries appear in the "
+#~ "main menu area. These are your **open tabs.**"
+#~ msgstr ""
+#~ "A media que você navega pelo Zammad, você verá uma lista aparecer na área "
+#~ "do menu principal. Estas são as suas **abas abertas.**"
 
 #~ msgid "**Closed**"
 #~ msgstr "**Fechado**"

--- a/locale/ru/LC_MESSAGES/user-docs.po
+++ b/locale/ru/LC_MESSAGES/user-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-09 08:29+0200\n"
+"POT-Creation-Date: 2025-11-04 07:08+0000\n"
 "PO-Revision-Date: 2025-05-08 10:00+0000\n"
 "Last-Translator: Nikita <nyakovlev@iko.tech>\n"
 "Language-Team: Russian <https://translations.zammad.org/projects/"
@@ -1486,63 +1486,61 @@ msgid "Tabs"
 msgstr "Вкладки"
 
 #: ../advanced/tabs.rst:4
+#, fuzzy
+#| msgid ""
+#| "You can freely switch between open tabs without losing your work - all "
+#| "unsaved changes are automatically backed up to the server."
 msgid ""
 "As you click through Zammad, you will see a list of entries appear in the "
-"main menu area. These are your **open tabs.**"
-msgstr ""
-"По мере того как вы будете переходить по Zammad, в области главного меню "
-"будет появляться список записей. Это ваши **открытые вкладки.**"
-
-#: ../advanced/tabs.rst:7
-msgid ""
-"You can freely switch between open tabs without losing your work - all "
-"unsaved changes are automatically backed up to the server."
+"main menu area. These are your **open tabs.** You can freely switch between "
+"open tabs without losing your work - all unsaved changes are automatically "
+"backed up to the server."
 msgstr ""
 "Вы можете свободно переключаться между открытыми вкладками, не теряя своей "
 "работы - все несохраненные изменения автоматически сохраняются на сервере."
 
-#: ../advanced/tabs.rst:13
+#: ../advanced/tabs.rst:12
 msgid "Sample view of Tabs"
 msgstr "Примерный вид вкладок"
 
-#: ../advanced/tabs.rst:13
+#: ../advanced/tabs.rst:12
 msgid ""
 "Tabs appear in the main menu as you visit different parts of the application."
 msgstr ""
 "Вкладки появляются в главном меню, когда Вы посещаете различные части "
 "приложения."
 
-#: ../advanced/tabs.rst:16
+#: ../advanced/tabs.rst:15
 msgid "**What items open in a new “tab”?**"
 msgstr "**Какие элементы открываются в новой “вкладке”?**"
 
-#: ../advanced/tabs.rst:18
+#: ../advanced/tabs.rst:17
 msgid "Existing tickets"
 msgstr "Существующие заявки"
 
-#: ../advanced/tabs.rst:19
+#: ../advanced/tabs.rst:18
 msgid "New tickets"
 msgstr "Новые заявки"
 
-#: ../advanced/tabs.rst:20
+#: ../advanced/tabs.rst:19
 msgid "Users"
 msgstr "Пользователи"
 
-#: ../advanced/tabs.rst:21 ../extras/organizations.rst:2
+#: ../advanced/tabs.rst:20 ../extras/organizations.rst:2
 msgid "Organizations"
 msgstr "Организации"
 
-#: ../advanced/tabs.rst:22
+#: ../advanced/tabs.rst:21
 msgid "Omnisearch"
 msgstr "Результаты поиска"
 
-#: ../advanced/tabs.rst:24 ../basics/find-ticket/browse.rst:27
+#: ../advanced/tabs.rst:23 ../basics/find-ticket/browse.rst:27
 #: ../basics/find-ticket/search.rst:33 ../basics/service-ticket/create.rst:47
 #: ../snippets/ui-protip-message-editor-features.rst:1
 msgid "**🖱️ UI Protip**"
 msgstr "**🖱️ UI Прототип**"
 
-#: ../advanced/tabs.rst:26
+#: ../advanced/tabs.rst:25
 msgid ""
 ":doc:`Ticket states </basics/service-ticket/settings/state>` are **color-"
 "coded:**"
@@ -1582,7 +1580,7 @@ msgstr "|red|"
 msgid "**Immediate action needed** (ticket escalated due to an SLA violation)"
 msgstr ""
 
-#: ../advanced/tabs.rst:31
+#: ../advanced/tabs.rst:30
 msgid ""
 "A **pulsing dot** means that a ticket has new activity since you last viewed "
 "it."
@@ -1590,15 +1588,15 @@ msgstr ""
 "**Пульсирующая точка** означает, что в заявке появилась новая активность с "
 "тех пор, как Вы просматривали ее в последний раз."
 
-#: ../advanced/tabs.rst:33
+#: ../advanced/tabs.rst:32
 msgid "Drag and drop tabs to rearrange them."
 msgstr "Перетаскивайте вкладки, чтобы изменить их расположение."
 
-#: ../advanced/tabs.rst:36
+#: ../advanced/tabs.rst:35
 msgid "Tab Behavior in Ticket Zooms"
 msgstr "Поведение вкладок при работе с заявкой"
 
-#: ../advanced/tabs.rst:38
+#: ../advanced/tabs.rst:37
 msgid ""
 "You may have noticed the \"Stay on tab\" button next to \"Update\" on the "
 "lower right already. This behavior of a tab can be configured by your "
@@ -1614,7 +1612,7 @@ msgstr ""
 msgid "Tab behavior can be adjusted in tickets manually"
 msgstr "Поведение вкладок можно настроить в заявках вручную"
 
-#: ../advanced/tabs.rst:47
+#: ../advanced/tabs.rst:46
 msgid ""
 "To overrule your administrator's settings, simply choose the action you "
 "prefer. Zammad will remember this preference until you change its setting."
@@ -1623,11 +1621,11 @@ msgstr ""
 "Вы предпочитаете. Zammad будет помнить об этом предпочтении, пока Вы не "
 "измените эту настройку."
 
-#: ../advanced/tabs.rst:52
+#: ../advanced/tabs.rst:51
 msgid "Close tab"
 msgstr "Закрыть вкладку"
 
-#: ../advanced/tabs.rst:51
+#: ../advanced/tabs.rst:50
 msgid ""
 "Upon updating the ticket, Zammad will automatically close the tab. You'll be "
 "returned to the last view that was open."
@@ -1635,11 +1633,11 @@ msgstr ""
 "После обновления заявки Zammad автоматически закроет вкладку. Вы вернетесь к "
 "последнему открытому виду."
 
-#: ../advanced/tabs.rst:58
+#: ../advanced/tabs.rst:57
 msgid "Close tab on ticket close"
 msgstr "Закрыть вкладку при закрытии заявки"
 
-#: ../advanced/tabs.rst:55
+#: ../advanced/tabs.rst:54
 msgid ""
 "Ticket tabs will be closed only if you change the state to \"closed\" upon "
 "ticket update."
@@ -1647,17 +1645,17 @@ msgstr ""
 "Вкладки заявок будут закрыты, только если Вы измените состояние заявки на "
 "\"закрыто\" при обновлении."
 
-#: ../advanced/tabs.rst:58
+#: ../advanced/tabs.rst:57
 msgid "This does not apply for pending states that end in closed states."
 msgstr ""
 "Это не относится к состояниям ожидания, которые заканчиваются закрытыми "
 "состояниями."
 
-#: ../advanced/tabs.rst:66
+#: ../advanced/tabs.rst:65
 msgid "Next in overview"
 msgstr "Далее в представлении"
 
-#: ../advanced/tabs.rst:61
+#: ../advanced/tabs.rst:60
 msgid ""
 "If you opened a ticket from any overview, Zammad will jump to the next "
 "ticket in said overview. Zammad recycles the open tab."
@@ -1665,7 +1663,7 @@ msgstr ""
 "Если Вы открыли заявку из любого представления, Zammad перейдет к следующей "
 "заявке в этом представлении. Zammad повторно использует открытую вкладку."
 
-#: ../advanced/tabs.rst:64
+#: ../advanced/tabs.rst:63
 msgid ""
 "This option is only available if you open the ticket from an overview. "
 "Zammad will ignore the setting if you opened the ticket directly and fall "
@@ -1679,13 +1677,21 @@ msgstr ""
 msgid "Stay on tab"
 msgstr "Остаться на вкладке"
 
-#: ../advanced/tabs.rst:69
+#: ../advanced/tabs.rst:68
 msgid "Updating the ticket doesn't have any effect on the tab."
 msgstr "Обновление заявки не оказывает никакого влияния на вкладку."
 
-#: ../advanced/tabs.rst:71
+#: ../advanced/tabs.rst:70
 msgid "*This is the default setting in Zammad installations.*"
 msgstr "*Это настройка по умолчанию при установке Zammad.*"
+
+#: ../advanced/tabs.rst:72
+msgid ""
+"Now that you are an expert in tab handling, one more thing might be "
+"interesting as well: the maximum number of tabs is 30 due to performance "
+"reasons. In case you reach the limit and open another tab, the first opened "
+"tab gets closed automatically."
+msgstr ""
 
 #: ../advanced/text-modules.rst:2
 msgid "Working with Text Modules"
@@ -8237,6 +8243,13 @@ msgid ""
 "also :docs:`system </index.html>` and :admin-docs:`administration manuals </"
 "index.html>` available."
 msgstr ""
+
+#~ msgid ""
+#~ "As you click through Zammad, you will see a list of entries appear in the "
+#~ "main menu area. These are your **open tabs.**"
+#~ msgstr ""
+#~ "По мере того как вы будете переходить по Zammad, в области главного меню "
+#~ "будет появляться список записей. Это ваши **открытые вкладки.**"
 
 #~ msgid "article.attachment.content_type: string (File type e.g. PDF)"
 #~ msgstr "article.attachment.content_type: string (тип файла, например, PDF)"

--- a/locale/sr/LC_MESSAGES/user-docs.po
+++ b/locale/sr/LC_MESSAGES/user-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-09 08:29+0200\n"
+"POT-Creation-Date: 2025-11-04 07:08+0000\n"
 "PO-Revision-Date: 2025-09-20 11:00+0000\n"
 "Last-Translator: Dusan Vuckovic <dv@zammad.com>\n"
 "Language-Team: Serbian <https://translations.zammad.org/projects/"
@@ -1466,63 +1466,61 @@ msgid "Tabs"
 msgstr "Језичци"
 
 #: ../advanced/tabs.rst:4
+#, fuzzy
+#| msgid ""
+#| "You can freely switch between open tabs without losing your work - all "
+#| "unsaved changes are automatically backed up to the server."
 msgid ""
 "As you click through Zammad, you will see a list of entries appear in the "
-"main menu area. These are your **open tabs.**"
-msgstr ""
-"Док кликћете по Zammad-у, приметићете листу ставки које се појављују у "
-"области главног менија. Ово су ваши **отворени прозори.**"
-
-#: ../advanced/tabs.rst:7
-msgid ""
-"You can freely switch between open tabs without losing your work - all "
-"unsaved changes are automatically backed up to the server."
+"main menu area. These are your **open tabs.** You can freely switch between "
+"open tabs without losing your work - all unsaved changes are automatically "
+"backed up to the server."
 msgstr ""
 "Можете слободно да прелазите између отворених прозора без губитка посла – "
 "све несачуване измене се аутоматски снимају на серверу."
 
-#: ../advanced/tabs.rst:13
+#: ../advanced/tabs.rst:12
 msgid "Sample view of Tabs"
 msgstr "Пример прозора"
 
-#: ../advanced/tabs.rst:13
+#: ../advanced/tabs.rst:12
 msgid ""
 "Tabs appear in the main menu as you visit different parts of the application."
 msgstr ""
 "Прозори се појављују у главном менију док посећујете различите делове "
 "апликације."
 
-#: ../advanced/tabs.rst:16
+#: ../advanced/tabs.rst:15
 msgid "**What items open in a new “tab”?**"
 msgstr "**Које ставке се отварају у новом „прозору“?**"
 
-#: ../advanced/tabs.rst:18
+#: ../advanced/tabs.rst:17
 msgid "Existing tickets"
 msgstr "Постојећи тикети"
 
-#: ../advanced/tabs.rst:19
+#: ../advanced/tabs.rst:18
 msgid "New tickets"
 msgstr "Новим тикетима"
 
-#: ../advanced/tabs.rst:20
+#: ../advanced/tabs.rst:19
 msgid "Users"
 msgstr "Корисници"
 
-#: ../advanced/tabs.rst:21 ../extras/organizations.rst:2
+#: ../advanced/tabs.rst:20 ../extras/organizations.rst:2
 msgid "Organizations"
 msgstr "Организације"
 
-#: ../advanced/tabs.rst:22
+#: ../advanced/tabs.rst:21
 msgid "Omnisearch"
 msgstr "Свеобухватна претрага"
 
-#: ../advanced/tabs.rst:24 ../basics/find-ticket/browse.rst:27
+#: ../advanced/tabs.rst:23 ../basics/find-ticket/browse.rst:27
 #: ../basics/find-ticket/search.rst:33 ../basics/service-ticket/create.rst:47
 #: ../snippets/ui-protip-message-editor-features.rst:1
 msgid "**🖱️ UI Protip**"
 msgstr "**🖱️ Мали савет**"
 
-#: ../advanced/tabs.rst:26
+#: ../advanced/tabs.rst:25
 msgid ""
 ":doc:`Ticket states </basics/service-ticket/settings/state>` are **color-"
 "coded:**"
@@ -1562,7 +1560,7 @@ msgstr "|red|"
 msgid "**Immediate action needed** (ticket escalated due to an SLA violation)"
 msgstr "**Захтева тренутну обраду** (тикет је ескалиран услед SLA прекршаја)"
 
-#: ../advanced/tabs.rst:31
+#: ../advanced/tabs.rst:30
 msgid ""
 "A **pulsing dot** means that a ticket has new activity since you last viewed "
 "it."
@@ -1570,15 +1568,15 @@ msgstr ""
 "**Пулсирајућа тачка** значи да тикет има нове активности од када сте га "
 "последњи пут погледали."
 
-#: ../advanced/tabs.rst:33
+#: ../advanced/tabs.rst:32
 msgid "Drag and drop tabs to rearrange them."
 msgstr "Превуците и пустите прозоре да бисте их преуредили."
 
-#: ../advanced/tabs.rst:36
+#: ../advanced/tabs.rst:35
 msgid "Tab Behavior in Ticket Zooms"
 msgstr "Понашање прозора у прегледу тикета"
 
-#: ../advanced/tabs.rst:38
+#: ../advanced/tabs.rst:37
 msgid ""
 "You may have noticed the \"Stay on tab\" button next to \"Update\" on the "
 "lower right already. This behavior of a tab can be configured by your "
@@ -1594,7 +1592,7 @@ msgstr ""
 msgid "Tab behavior can be adjusted in tickets manually"
 msgstr "Понашање прозора се може ручно подесити у тикетима"
 
-#: ../advanced/tabs.rst:47
+#: ../advanced/tabs.rst:46
 msgid ""
 "To overrule your administrator's settings, simply choose the action you "
 "prefer. Zammad will remember this preference until you change its setting."
@@ -1603,11 +1601,11 @@ msgstr ""
 "опцију коју желите. Zammad ће запамтити ово подешавање док не промените "
 "његову вредност."
 
-#: ../advanced/tabs.rst:52
+#: ../advanced/tabs.rst:51
 msgid "Close tab"
 msgstr "Затвори тренутни прозор"
 
-#: ../advanced/tabs.rst:51
+#: ../advanced/tabs.rst:50
 msgid ""
 "Upon updating the ticket, Zammad will automatically close the tab. You'll be "
 "returned to the last view that was open."
@@ -1615,11 +1613,11 @@ msgstr ""
 "Након освежавања тикета, Zammad ће аутоматски затворити прозор. Бићете "
 "враћени на последњи приказ који је био отворен."
 
-#: ../advanced/tabs.rst:58
+#: ../advanced/tabs.rst:57
 msgid "Close tab on ticket close"
 msgstr "Затвори прозор по затварању тикета"
 
-#: ../advanced/tabs.rst:55
+#: ../advanced/tabs.rst:54
 msgid ""
 "Ticket tabs will be closed only if you change the state to \"closed\" upon "
 "ticket update."
@@ -1627,16 +1625,16 @@ msgstr ""
 "Прозори тикета биће затворени само ако промените стање у \"затворено\" након "
 "освежавања тикета."
 
-#: ../advanced/tabs.rst:58
+#: ../advanced/tabs.rst:57
 msgid "This does not apply for pending states that end in closed states."
 msgstr ""
 "Ово се не односи на стања на чекању која ће завршити у затвореним стањима."
 
-#: ../advanced/tabs.rst:66
+#: ../advanced/tabs.rst:65
 msgid "Next in overview"
 msgstr "Иди на следећи из прегледа"
 
-#: ../advanced/tabs.rst:61
+#: ../advanced/tabs.rst:60
 msgid ""
 "If you opened a ticket from any overview, Zammad will jump to the next "
 "ticket in said overview. Zammad recycles the open tab."
@@ -1644,7 +1642,7 @@ msgstr ""
 "Ако сте отворили тикет из било ког прегледа, Zammad ће скочити на следећи "
 "тикет у наведеном прегледу. Zammad ће искористити већ отворени прозор."
 
-#: ../advanced/tabs.rst:64
+#: ../advanced/tabs.rst:63
 msgid ""
 "This option is only available if you open the ticket from an overview. "
 "Zammad will ignore the setting if you opened the ticket directly and fall "
@@ -1658,13 +1656,21 @@ msgstr ""
 msgid "Stay on tab"
 msgstr "Остани у прозору"
 
-#: ../advanced/tabs.rst:69
+#: ../advanced/tabs.rst:68
 msgid "Updating the ticket doesn't have any effect on the tab."
 msgstr "Освежавање тикета нема никаквог утицаја на прозор."
 
-#: ../advanced/tabs.rst:71
+#: ../advanced/tabs.rst:70
 msgid "*This is the default setting in Zammad installations.*"
 msgstr "*Ово је подразумевано подешавање у Zammad инсталацијама.*"
+
+#: ../advanced/tabs.rst:72
+msgid ""
+"Now that you are an expert in tab handling, one more thing might be "
+"interesting as well: the maximum number of tabs is 30 due to performance "
+"reasons. In case you reach the limit and open another tab, the first opened "
+"tab gets closed automatically."
+msgstr ""
 
 #: ../advanced/text-modules.rst:2
 msgid "Working with Text Modules"
@@ -5535,8 +5541,8 @@ msgstr ""
 "**Препиши сложени одељак и учини га лаким за разумевање**: Користи ваш нацрт "
 "као основу и покушава да га прошири у исполиран текст. Покушава да одреди "
 "структуру и побољша јасноћу и прецизност као и да уклони грешке у правопису "
-"и граматици. Могуће је искористити је прилагањем само основних информација ("
-"нпр. путем листе са тачкама) и пуштањем вештачке интелигенције да употпуни "
+"и граматици. Могуће је искористити је прилагањем само основних информација "
+"(нпр. путем листе са тачкама) и пуштањем вештачке интелигенције да употпуни "
 "одговор."
 
 #: ../extras/ai-features.rst:64
@@ -9334,6 +9340,13 @@ msgstr ""
 "Тренутно читате Zammad корисничку документацију. Такође су "
 "доступни :docs:`системски </index.html>` и :admin-docs:`администраторски </"
 "index.html>` приручници."
+
+#~ msgid ""
+#~ "As you click through Zammad, you will see a list of entries appear in the "
+#~ "main menu area. These are your **open tabs.**"
+#~ msgstr ""
+#~ "Док кликћете по Zammad-у, приметићете листу ставки које се појављују у "
+#~ "области главног менија. Ово су ваши **отворени прозори.**"
 
 #~ msgid "Smart Editor"
 #~ msgstr "Smart Editor"

--- a/locale/sv/LC_MESSAGES/user-docs.po
+++ b/locale/sv/LC_MESSAGES/user-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-09 08:29+0200\n"
+"POT-Creation-Date: 2025-11-04 07:08+0000\n"
 "PO-Revision-Date: 2024-10-25 11:00+0000\n"
 "Last-Translator: chrand818 <can@telenabler.com>\n"
 "Language-Team: Swedish <https://translations.zammad.org/projects/"
@@ -1357,55 +1357,51 @@ msgstr "Flikar"
 #: ../advanced/tabs.rst:4
 msgid ""
 "As you click through Zammad, you will see a list of entries appear in the "
-"main menu area. These are your **open tabs.**"
+"main menu area. These are your **open tabs.** You can freely switch between "
+"open tabs without losing your work - all unsaved changes are automatically "
+"backed up to the server."
 msgstr ""
 
-#: ../advanced/tabs.rst:7
-msgid ""
-"You can freely switch between open tabs without losing your work - all "
-"unsaved changes are automatically backed up to the server."
-msgstr ""
-
-#: ../advanced/tabs.rst:13
+#: ../advanced/tabs.rst:12
 msgid "Sample view of Tabs"
 msgstr ""
 
-#: ../advanced/tabs.rst:13
+#: ../advanced/tabs.rst:12
 msgid ""
 "Tabs appear in the main menu as you visit different parts of the application."
 msgstr ""
 
-#: ../advanced/tabs.rst:16
+#: ../advanced/tabs.rst:15
 msgid "**What items open in a new “tab”?**"
 msgstr ""
 
-#: ../advanced/tabs.rst:18
+#: ../advanced/tabs.rst:17
 msgid "Existing tickets"
 msgstr ""
 
-#: ../advanced/tabs.rst:19
+#: ../advanced/tabs.rst:18
 msgid "New tickets"
 msgstr ""
 
-#: ../advanced/tabs.rst:20
+#: ../advanced/tabs.rst:19
 msgid "Users"
 msgstr ""
 
-#: ../advanced/tabs.rst:21 ../extras/organizations.rst:2
+#: ../advanced/tabs.rst:20 ../extras/organizations.rst:2
 msgid "Organizations"
 msgstr ""
 
-#: ../advanced/tabs.rst:22
+#: ../advanced/tabs.rst:21
 msgid "Omnisearch"
 msgstr ""
 
-#: ../advanced/tabs.rst:24 ../basics/find-ticket/browse.rst:27
+#: ../advanced/tabs.rst:23 ../basics/find-ticket/browse.rst:27
 #: ../basics/find-ticket/search.rst:33 ../basics/service-ticket/create.rst:47
 #: ../snippets/ui-protip-message-editor-features.rst:1
 msgid "**🖱️ UI Protip**"
 msgstr ""
 
-#: ../advanced/tabs.rst:26
+#: ../advanced/tabs.rst:25
 msgid ""
 ":doc:`Ticket states </basics/service-ticket/settings/state>` are **color-"
 "coded:**"
@@ -1443,21 +1439,21 @@ msgstr ""
 msgid "**Immediate action needed** (ticket escalated due to an SLA violation)"
 msgstr ""
 
-#: ../advanced/tabs.rst:31
+#: ../advanced/tabs.rst:30
 msgid ""
 "A **pulsing dot** means that a ticket has new activity since you last viewed "
 "it."
 msgstr ""
 
-#: ../advanced/tabs.rst:33
+#: ../advanced/tabs.rst:32
 msgid "Drag and drop tabs to rearrange them."
 msgstr ""
 
-#: ../advanced/tabs.rst:36
+#: ../advanced/tabs.rst:35
 msgid "Tab Behavior in Ticket Zooms"
 msgstr ""
 
-#: ../advanced/tabs.rst:38
+#: ../advanced/tabs.rst:37
 msgid ""
 "You may have noticed the \"Stay on tab\" button next to \"Update\" on the "
 "lower right already. This behavior of a tab can be configured by your "
@@ -1469,47 +1465,47 @@ msgstr ""
 msgid "Tab behavior can be adjusted in tickets manually"
 msgstr ""
 
-#: ../advanced/tabs.rst:47
+#: ../advanced/tabs.rst:46
 msgid ""
 "To overrule your administrator's settings, simply choose the action you "
 "prefer. Zammad will remember this preference until you change its setting."
 msgstr ""
 
-#: ../advanced/tabs.rst:52
+#: ../advanced/tabs.rst:51
 msgid "Close tab"
 msgstr ""
 
-#: ../advanced/tabs.rst:51
+#: ../advanced/tabs.rst:50
 msgid ""
 "Upon updating the ticket, Zammad will automatically close the tab. You'll be "
 "returned to the last view that was open."
 msgstr ""
 
-#: ../advanced/tabs.rst:58
+#: ../advanced/tabs.rst:57
 msgid "Close tab on ticket close"
 msgstr ""
 
-#: ../advanced/tabs.rst:55
+#: ../advanced/tabs.rst:54
 msgid ""
 "Ticket tabs will be closed only if you change the state to \"closed\" upon "
 "ticket update."
 msgstr ""
 
-#: ../advanced/tabs.rst:58
+#: ../advanced/tabs.rst:57
 msgid "This does not apply for pending states that end in closed states."
 msgstr ""
 
-#: ../advanced/tabs.rst:66
+#: ../advanced/tabs.rst:65
 msgid "Next in overview"
 msgstr ""
 
-#: ../advanced/tabs.rst:61
+#: ../advanced/tabs.rst:60
 msgid ""
 "If you opened a ticket from any overview, Zammad will jump to the next "
 "ticket in said overview. Zammad recycles the open tab."
 msgstr ""
 
-#: ../advanced/tabs.rst:64
+#: ../advanced/tabs.rst:63
 msgid ""
 "This option is only available if you open the ticket from an overview. "
 "Zammad will ignore the setting if you opened the ticket directly and fall "
@@ -1520,12 +1516,20 @@ msgstr ""
 msgid "Stay on tab"
 msgstr ""
 
-#: ../advanced/tabs.rst:69
+#: ../advanced/tabs.rst:68
 msgid "Updating the ticket doesn't have any effect on the tab."
 msgstr ""
 
-#: ../advanced/tabs.rst:71
+#: ../advanced/tabs.rst:70
 msgid "*This is the default setting in Zammad installations.*"
+msgstr ""
+
+#: ../advanced/tabs.rst:72
+msgid ""
+"Now that you are an expert in tab handling, one more thing might be "
+"interesting as well: the maximum number of tabs is 30 due to performance "
+"reasons. In case you reach the limit and open another tab, the first opened "
+"tab gets closed automatically."
 msgstr ""
 
 #: ../advanced/text-modules.rst:2

--- a/locale/th/LC_MESSAGES/user-docs.po
+++ b/locale/th/LC_MESSAGES/user-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-09 08:29+0200\n"
+"POT-Creation-Date: 2025-11-04 07:08+0000\n"
 "PO-Revision-Date: 2025-05-29 09:01+0000\n"
 "Last-Translator: Sumonchai Wongphithak <sumonchai@gmail.com>\n"
 "Language-Team: Thai <https://translations.zammad.org/projects/documentations/"
@@ -1319,55 +1319,51 @@ msgstr ""
 #: ../advanced/tabs.rst:4
 msgid ""
 "As you click through Zammad, you will see a list of entries appear in the "
-"main menu area. These are your **open tabs.**"
+"main menu area. These are your **open tabs.** You can freely switch between "
+"open tabs without losing your work - all unsaved changes are automatically "
+"backed up to the server."
 msgstr ""
 
-#: ../advanced/tabs.rst:7
-msgid ""
-"You can freely switch between open tabs without losing your work - all "
-"unsaved changes are automatically backed up to the server."
-msgstr ""
-
-#: ../advanced/tabs.rst:13
+#: ../advanced/tabs.rst:12
 msgid "Sample view of Tabs"
 msgstr ""
 
-#: ../advanced/tabs.rst:13
+#: ../advanced/tabs.rst:12
 msgid ""
 "Tabs appear in the main menu as you visit different parts of the application."
 msgstr ""
 
-#: ../advanced/tabs.rst:16
+#: ../advanced/tabs.rst:15
 msgid "**What items open in a new “tab”?**"
 msgstr ""
 
-#: ../advanced/tabs.rst:18
+#: ../advanced/tabs.rst:17
 msgid "Existing tickets"
 msgstr ""
 
-#: ../advanced/tabs.rst:19
+#: ../advanced/tabs.rst:18
 msgid "New tickets"
 msgstr "สร้างใบแจ้งซ่อม"
 
-#: ../advanced/tabs.rst:20
+#: ../advanced/tabs.rst:19
 msgid "Users"
 msgstr ""
 
-#: ../advanced/tabs.rst:21 ../extras/organizations.rst:2
+#: ../advanced/tabs.rst:20 ../extras/organizations.rst:2
 msgid "Organizations"
 msgstr "องค์กร"
 
-#: ../advanced/tabs.rst:22
+#: ../advanced/tabs.rst:21
 msgid "Omnisearch"
 msgstr ""
 
-#: ../advanced/tabs.rst:24 ../basics/find-ticket/browse.rst:27
+#: ../advanced/tabs.rst:23 ../basics/find-ticket/browse.rst:27
 #: ../basics/find-ticket/search.rst:33 ../basics/service-ticket/create.rst:47
 #: ../snippets/ui-protip-message-editor-features.rst:1
 msgid "**🖱️ UI Protip**"
 msgstr "**🖱️ UI Protip**"
 
-#: ../advanced/tabs.rst:26
+#: ../advanced/tabs.rst:25
 msgid ""
 ":doc:`Ticket states </basics/service-ticket/settings/state>` are **color-"
 "coded:**"
@@ -1405,21 +1401,21 @@ msgstr "|red|"
 msgid "**Immediate action needed** (ticket escalated due to an SLA violation)"
 msgstr ""
 
-#: ../advanced/tabs.rst:31
+#: ../advanced/tabs.rst:30
 msgid ""
 "A **pulsing dot** means that a ticket has new activity since you last viewed "
 "it."
 msgstr ""
 
-#: ../advanced/tabs.rst:33
+#: ../advanced/tabs.rst:32
 msgid "Drag and drop tabs to rearrange them."
 msgstr ""
 
-#: ../advanced/tabs.rst:36
+#: ../advanced/tabs.rst:35
 msgid "Tab Behavior in Ticket Zooms"
 msgstr ""
 
-#: ../advanced/tabs.rst:38
+#: ../advanced/tabs.rst:37
 msgid ""
 "You may have noticed the \"Stay on tab\" button next to \"Update\" on the "
 "lower right already. This behavior of a tab can be configured by your "
@@ -1431,47 +1427,47 @@ msgstr ""
 msgid "Tab behavior can be adjusted in tickets manually"
 msgstr ""
 
-#: ../advanced/tabs.rst:47
+#: ../advanced/tabs.rst:46
 msgid ""
 "To overrule your administrator's settings, simply choose the action you "
 "prefer. Zammad will remember this preference until you change its setting."
 msgstr ""
 
-#: ../advanced/tabs.rst:52
+#: ../advanced/tabs.rst:51
 msgid "Close tab"
 msgstr ""
 
-#: ../advanced/tabs.rst:51
+#: ../advanced/tabs.rst:50
 msgid ""
 "Upon updating the ticket, Zammad will automatically close the tab. You'll be "
 "returned to the last view that was open."
 msgstr ""
 
-#: ../advanced/tabs.rst:58
+#: ../advanced/tabs.rst:57
 msgid "Close tab on ticket close"
 msgstr ""
 
-#: ../advanced/tabs.rst:55
+#: ../advanced/tabs.rst:54
 msgid ""
 "Ticket tabs will be closed only if you change the state to \"closed\" upon "
 "ticket update."
 msgstr ""
 
-#: ../advanced/tabs.rst:58
+#: ../advanced/tabs.rst:57
 msgid "This does not apply for pending states that end in closed states."
 msgstr ""
 
-#: ../advanced/tabs.rst:66
+#: ../advanced/tabs.rst:65
 msgid "Next in overview"
 msgstr ""
 
-#: ../advanced/tabs.rst:61
+#: ../advanced/tabs.rst:60
 msgid ""
 "If you opened a ticket from any overview, Zammad will jump to the next "
 "ticket in said overview. Zammad recycles the open tab."
 msgstr ""
 
-#: ../advanced/tabs.rst:64
+#: ../advanced/tabs.rst:63
 msgid ""
 "This option is only available if you open the ticket from an overview. "
 "Zammad will ignore the setting if you opened the ticket directly and fall "
@@ -1482,12 +1478,20 @@ msgstr ""
 msgid "Stay on tab"
 msgstr ""
 
-#: ../advanced/tabs.rst:69
+#: ../advanced/tabs.rst:68
 msgid "Updating the ticket doesn't have any effect on the tab."
 msgstr ""
 
-#: ../advanced/tabs.rst:71
+#: ../advanced/tabs.rst:70
 msgid "*This is the default setting in Zammad installations.*"
+msgstr ""
+
+#: ../advanced/tabs.rst:72
+msgid ""
+"Now that you are an expert in tab handling, one more thing might be "
+"interesting as well: the maximum number of tabs is 30 due to performance "
+"reasons. In case you reach the limit and open another tab, the first opened "
+"tab gets closed automatically."
 msgstr ""
 
 #: ../advanced/text-modules.rst:2

--- a/locale/tr/LC_MESSAGES/user-docs.po
+++ b/locale/tr/LC_MESSAGES/user-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-09 08:29+0200\n"
+"POT-Creation-Date: 2025-11-04 07:08+0000\n"
 "PO-Revision-Date: 2025-02-11 08:00+0000\n"
 "Last-Translator: Türk Oyuncu <recentlly@hotmail.com>\n"
 "Language-Team: Turkish <https://translations.zammad.org/projects/"
@@ -1502,66 +1502,60 @@ msgid "Tabs"
 msgstr "Sekmeler"
 
 #: ../advanced/tabs.rst:4
-msgid ""
-"As you click through Zammad, you will see a list of entries appear in the "
-"main menu area. These are your **open tabs.**"
-msgstr ""
-"Zammad'a tıkladığınızda, ana menü alanında girişlerin bir listesinin "
-"göründüğünü göreceksiniz. Bunlar **açık sekmelerinizdir.**"
-
-#: ../advanced/tabs.rst:7
 #, fuzzy
 msgid ""
-"You can freely switch between open tabs without losing your work - all "
-"unsaved changes are automatically backed up to the server."
+"As you click through Zammad, you will see a list of entries appear in the "
+"main menu area. These are your **open tabs.** You can freely switch between "
+"open tabs without losing your work - all unsaved changes are automatically "
+"backed up to the server."
 msgstr ""
 "Çalışmanızı kaybetmeden açık sekmeler arasında serbestçe geçiş "
 "yapabilirsiniz - kaydedilmemiş tüm değişiklikler otomatik olarak sunucuya "
 "yedeklenir."
 
-#: ../advanced/tabs.rst:13
+#: ../advanced/tabs.rst:12
 msgid "Sample view of Tabs"
 msgstr ""
 
-#: ../advanced/tabs.rst:13
+#: ../advanced/tabs.rst:12
 msgid ""
 "Tabs appear in the main menu as you visit different parts of the application."
 msgstr ""
 "Uygulamanın farklı bölümlerini ziyaret ettiğinizde ana menüde sekmeler "
 "görünür."
 
-#: ../advanced/tabs.rst:16
+#: ../advanced/tabs.rst:15
 #, fuzzy
 msgid "**What items open in a new “tab”?**"
 msgstr "Yeni bir \"sekmede\" hangi ögeler açılır?"
 
-#: ../advanced/tabs.rst:18
+#: ../advanced/tabs.rst:17
 msgid "Existing tickets"
 msgstr "Mevcut biletler"
 
-#: ../advanced/tabs.rst:19
+#: ../advanced/tabs.rst:18
 msgid "New tickets"
 msgstr "Yeni biletler"
 
-#: ../advanced/tabs.rst:20
+#: ../advanced/tabs.rst:19
 msgid "Users"
 msgstr "Kullanıcılar"
 
-#: ../advanced/tabs.rst:21 ../extras/organizations.rst:2
+#: ../advanced/tabs.rst:20 ../extras/organizations.rst:2
 msgid "Organizations"
 msgstr "Organizasyonlar"
 
-#: ../advanced/tabs.rst:22
+#: ../advanced/tabs.rst:21
 msgid "Omnisearch"
 msgstr "Omnisearch"
 
-#: ../advanced/tabs.rst:24 ../basics/find-ticket/browse.rst:27
+#: ../advanced/tabs.rst:23 ../basics/find-ticket/browse.rst:27
 #: ../basics/find-ticket/search.rst:33 ../basics/service-ticket/create.rst:47
 #: ../snippets/ui-protip-message-editor-features.rst:1
 msgid "**🖱️ UI Protip**"
 msgstr "**🖱️ UI Protipi**"
 
-#: ../advanced/tabs.rst:26
+#: ../advanced/tabs.rst:25
 msgid ""
 ":doc:`Ticket states </basics/service-ticket/settings/state>` are **color-"
 "coded:**"
@@ -1601,7 +1595,7 @@ msgstr "|red|"
 msgid "**Immediate action needed** (ticket escalated due to an SLA violation)"
 msgstr ""
 
-#: ../advanced/tabs.rst:31
+#: ../advanced/tabs.rst:30
 msgid ""
 "A **pulsing dot** means that a ticket has new activity since you last viewed "
 "it."
@@ -1609,15 +1603,15 @@ msgstr ""
 "**Titreşen nokta**, bir biletin son görüntülemenizden bu yana yeni "
 "etkinliklere sahip olduğu anlamına gelir."
 
-#: ../advanced/tabs.rst:33
+#: ../advanced/tabs.rst:32
 msgid "Drag and drop tabs to rearrange them."
 msgstr "Yeniden düzenlemek için sekmeleri sürükleyip bırakın."
 
-#: ../advanced/tabs.rst:36
+#: ../advanced/tabs.rst:35
 msgid "Tab Behavior in Ticket Zooms"
 msgstr ""
 
-#: ../advanced/tabs.rst:38
+#: ../advanced/tabs.rst:37
 msgid ""
 "You may have noticed the \"Stay on tab\" button next to \"Update\" on the "
 "lower right already. This behavior of a tab can be configured by your "
@@ -1629,47 +1623,47 @@ msgstr ""
 msgid "Tab behavior can be adjusted in tickets manually"
 msgstr ""
 
-#: ../advanced/tabs.rst:47
+#: ../advanced/tabs.rst:46
 msgid ""
 "To overrule your administrator's settings, simply choose the action you "
 "prefer. Zammad will remember this preference until you change its setting."
 msgstr ""
 
-#: ../advanced/tabs.rst:52
+#: ../advanced/tabs.rst:51
 msgid "Close tab"
 msgstr ""
 
-#: ../advanced/tabs.rst:51
+#: ../advanced/tabs.rst:50
 msgid ""
 "Upon updating the ticket, Zammad will automatically close the tab. You'll be "
 "returned to the last view that was open."
 msgstr ""
 
-#: ../advanced/tabs.rst:58
+#: ../advanced/tabs.rst:57
 msgid "Close tab on ticket close"
 msgstr ""
 
-#: ../advanced/tabs.rst:55
+#: ../advanced/tabs.rst:54
 msgid ""
 "Ticket tabs will be closed only if you change the state to \"closed\" upon "
 "ticket update."
 msgstr ""
 
-#: ../advanced/tabs.rst:58
+#: ../advanced/tabs.rst:57
 msgid "This does not apply for pending states that end in closed states."
 msgstr ""
 
-#: ../advanced/tabs.rst:66
+#: ../advanced/tabs.rst:65
 msgid "Next in overview"
 msgstr ""
 
-#: ../advanced/tabs.rst:61
+#: ../advanced/tabs.rst:60
 msgid ""
 "If you opened a ticket from any overview, Zammad will jump to the next "
 "ticket in said overview. Zammad recycles the open tab."
 msgstr ""
 
-#: ../advanced/tabs.rst:64
+#: ../advanced/tabs.rst:63
 msgid ""
 "This option is only available if you open the ticket from an overview. "
 "Zammad will ignore the setting if you opened the ticket directly and fall "
@@ -1680,12 +1674,20 @@ msgstr ""
 msgid "Stay on tab"
 msgstr ""
 
-#: ../advanced/tabs.rst:69
+#: ../advanced/tabs.rst:68
 msgid "Updating the ticket doesn't have any effect on the tab."
 msgstr ""
 
-#: ../advanced/tabs.rst:71
+#: ../advanced/tabs.rst:70
 msgid "*This is the default setting in Zammad installations.*"
+msgstr ""
+
+#: ../advanced/tabs.rst:72
+msgid ""
+"Now that you are an expert in tab handling, one more thing might be "
+"interesting as well: the maximum number of tabs is 30 due to performance "
+"reasons. In case you reach the limit and open another tab, the first opened "
+"tab gets closed automatically."
 msgstr ""
 
 #: ../advanced/text-modules.rst:2
@@ -8629,6 +8631,13 @@ msgstr ""
 "Şu anda Zammad kullanıcı belgelerini okumaktasınız. Ayrıca :docs:`system </"
 "index.html>` ve :admin-docs:`administration manuals </index.html>` da "
 "mevcuttur."
+
+#~ msgid ""
+#~ "As you click through Zammad, you will see a list of entries appear in the "
+#~ "main menu area. These are your **open tabs.**"
+#~ msgstr ""
+#~ "Zammad'a tıkladığınızda, ana menü alanında girişlerin bir listesinin "
+#~ "göründüğünü göreceksiniz. Bunlar **açık sekmelerinizdir.**"
 
 #~ msgid "article.attachment.content_type: string (File type e.g. PDF)"
 #~ msgstr "article.attachment.content_type: string (Dosya türü ör. PDF)"

--- a/locale/zh_Hans/LC_MESSAGES/user-docs.po
+++ b/locale/zh_Hans/LC_MESSAGES/user-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-09 08:29+0200\n"
+"POT-Creation-Date: 2025-11-04 07:08+0000\n"
 "PO-Revision-Date: 2022-11-04 15:14+0000\n"
 "Last-Translator: Never Min <59808@qq.com>\n"
 "Language-Team: Chinese (Simplified) <https://translations.zammad.org/"
@@ -1391,55 +1391,51 @@ msgstr ""
 #: ../advanced/tabs.rst:4
 msgid ""
 "As you click through Zammad, you will see a list of entries appear in the "
-"main menu area. These are your **open tabs.**"
+"main menu area. These are your **open tabs.** You can freely switch between "
+"open tabs without losing your work - all unsaved changes are automatically "
+"backed up to the server."
 msgstr ""
 
-#: ../advanced/tabs.rst:7
-msgid ""
-"You can freely switch between open tabs without losing your work - all "
-"unsaved changes are automatically backed up to the server."
-msgstr ""
-
-#: ../advanced/tabs.rst:13
+#: ../advanced/tabs.rst:12
 msgid "Sample view of Tabs"
 msgstr ""
 
-#: ../advanced/tabs.rst:13
+#: ../advanced/tabs.rst:12
 msgid ""
 "Tabs appear in the main menu as you visit different parts of the application."
 msgstr ""
 
-#: ../advanced/tabs.rst:16
+#: ../advanced/tabs.rst:15
 msgid "**What items open in a new “tab”?**"
 msgstr ""
 
-#: ../advanced/tabs.rst:18
+#: ../advanced/tabs.rst:17
 msgid "Existing tickets"
 msgstr ""
 
-#: ../advanced/tabs.rst:19
+#: ../advanced/tabs.rst:18
 msgid "New tickets"
 msgstr ""
 
-#: ../advanced/tabs.rst:20
+#: ../advanced/tabs.rst:19
 msgid "Users"
 msgstr ""
 
-#: ../advanced/tabs.rst:21 ../extras/organizations.rst:2
+#: ../advanced/tabs.rst:20 ../extras/organizations.rst:2
 msgid "Organizations"
 msgstr ""
 
-#: ../advanced/tabs.rst:22
+#: ../advanced/tabs.rst:21
 msgid "Omnisearch"
 msgstr ""
 
-#: ../advanced/tabs.rst:24 ../basics/find-ticket/browse.rst:27
+#: ../advanced/tabs.rst:23 ../basics/find-ticket/browse.rst:27
 #: ../basics/find-ticket/search.rst:33 ../basics/service-ticket/create.rst:47
 #: ../snippets/ui-protip-message-editor-features.rst:1
 msgid "**🖱️ UI Protip**"
 msgstr "**🖱️ UI 高级技巧**"
 
-#: ../advanced/tabs.rst:26
+#: ../advanced/tabs.rst:25
 msgid ""
 ":doc:`Ticket states </basics/service-ticket/settings/state>` are **color-"
 "coded:**"
@@ -1477,21 +1473,21 @@ msgstr ""
 msgid "**Immediate action needed** (ticket escalated due to an SLA violation)"
 msgstr ""
 
-#: ../advanced/tabs.rst:31
+#: ../advanced/tabs.rst:30
 msgid ""
 "A **pulsing dot** means that a ticket has new activity since you last viewed "
 "it."
 msgstr ""
 
-#: ../advanced/tabs.rst:33
+#: ../advanced/tabs.rst:32
 msgid "Drag and drop tabs to rearrange them."
 msgstr ""
 
-#: ../advanced/tabs.rst:36
+#: ../advanced/tabs.rst:35
 msgid "Tab Behavior in Ticket Zooms"
 msgstr ""
 
-#: ../advanced/tabs.rst:38
+#: ../advanced/tabs.rst:37
 msgid ""
 "You may have noticed the \"Stay on tab\" button next to \"Update\" on the "
 "lower right already. This behavior of a tab can be configured by your "
@@ -1503,47 +1499,47 @@ msgstr ""
 msgid "Tab behavior can be adjusted in tickets manually"
 msgstr ""
 
-#: ../advanced/tabs.rst:47
+#: ../advanced/tabs.rst:46
 msgid ""
 "To overrule your administrator's settings, simply choose the action you "
 "prefer. Zammad will remember this preference until you change its setting."
 msgstr ""
 
-#: ../advanced/tabs.rst:52
+#: ../advanced/tabs.rst:51
 msgid "Close tab"
 msgstr ""
 
-#: ../advanced/tabs.rst:51
+#: ../advanced/tabs.rst:50
 msgid ""
 "Upon updating the ticket, Zammad will automatically close the tab. You'll be "
 "returned to the last view that was open."
 msgstr ""
 
-#: ../advanced/tabs.rst:58
+#: ../advanced/tabs.rst:57
 msgid "Close tab on ticket close"
 msgstr ""
 
-#: ../advanced/tabs.rst:55
+#: ../advanced/tabs.rst:54
 msgid ""
 "Ticket tabs will be closed only if you change the state to \"closed\" upon "
 "ticket update."
 msgstr ""
 
-#: ../advanced/tabs.rst:58
+#: ../advanced/tabs.rst:57
 msgid "This does not apply for pending states that end in closed states."
 msgstr ""
 
-#: ../advanced/tabs.rst:66
+#: ../advanced/tabs.rst:65
 msgid "Next in overview"
 msgstr ""
 
-#: ../advanced/tabs.rst:61
+#: ../advanced/tabs.rst:60
 msgid ""
 "If you opened a ticket from any overview, Zammad will jump to the next "
 "ticket in said overview. Zammad recycles the open tab."
 msgstr ""
 
-#: ../advanced/tabs.rst:64
+#: ../advanced/tabs.rst:63
 msgid ""
 "This option is only available if you open the ticket from an overview. "
 "Zammad will ignore the setting if you opened the ticket directly and fall "
@@ -1554,12 +1550,20 @@ msgstr ""
 msgid "Stay on tab"
 msgstr ""
 
-#: ../advanced/tabs.rst:69
+#: ../advanced/tabs.rst:68
 msgid "Updating the ticket doesn't have any effect on the tab."
 msgstr ""
 
-#: ../advanced/tabs.rst:71
+#: ../advanced/tabs.rst:70
 msgid "*This is the default setting in Zammad installations.*"
+msgstr ""
+
+#: ../advanced/tabs.rst:72
+msgid ""
+"Now that you are an expert in tab handling, one more thing might be "
+"interesting as well: the maximum number of tabs is 30 due to performance "
+"reasons. In case you reach the limit and open another tab, the first opened "
+"tab gets closed automatically."
 msgstr ""
 
 #: ../advanced/text-modules.rst:2


### PR DESCRIPTION
Translations update from [Zammad-Translations](https://translations.zammad.org) for [Documentation/User Documentation (pre-release)](https://translations.zammad.org/projects/documentations/user-documentation-pre-release/).



Current translation status:

![Weblate translation status](https://translations.zammad.org/widget/documentations/user-documentation-pre-release/horizontal-auto.svg)