### PR TITLE
Translations update from Zammad-Translations

### DIFF
--- a/locale/de/LC_MESSAGES/user-docs.po
+++ b/locale/de/LC_MESSAGES/user-docs.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2026-04-29 16:40+0200\n"
-"PO-Revision-Date: 2026-04-30 12:02+0000\n"
+"PO-Revision-Date: 2026-05-05 10:02+0000\n"
 "Last-Translator: Ralf Schmid <rsc@zammad.com>\n"
 "Language-Team: German <https://translations.zammad.org/projects/"
 "documentations/user-documentation-pre-release/de/>\n"
@@ -2092,13 +2092,12 @@ msgstr ""
 "\"abspalten\" unter dem gewünschten Artikel:"
 
 #: ../advanced/ticket-actions/split.rst:None
-#, fuzzy
-#| msgid "Screenshot shows subscribe button in the ticket sidebar tab"
 msgid ""
 "Screenshot shows \"split\" button in the ticket detail view next to an "
 "article"
 msgstr ""
-"Screenshot zeigt die Schaltfläche Abonnieren in der Ticket-Seitenleiste"
+"Screenshot zeigt die Schaltfläche \"abspalten\" (split) in der Ticket-"
+"Detailansicht neben einem Artikel"
 
 #: ../advanced/ticket-actions/split.rst:15
 msgid ""
@@ -2109,10 +2108,8 @@ msgstr ""
 "ein Dialog zum Erstellen eines neuen Tickets angezeigt:"
 
 #: ../advanced/ticket-actions/split.rst:None
-#, fuzzy
-#| msgid "Screenshot shows the new ticket dialog."
 msgid "Screenshot shows split ticket dialog"
-msgstr "Der Screenshot zeigt einen Ticket-Erstellungsdialog."
+msgstr "Screenshot zeigt den Dialog zum Abspalten von Tickets"
 
 #: ../advanced/ticket-actions/split.rst:23
 msgid ""
@@ -7348,10 +7345,6 @@ msgstr ""
 "erwartet, dass der Entwurf nicht länger notwendig ist."
 
 #: ../extras/knowledge-base.rst:4
-#, fuzzy
-#| msgid ""
-#| "Manage, edit and organize your knowledge base content by opening the "
-#| "**Knowledge Base** tab in the navigation sidebar."
 msgid ""
 "Manage, edit and organize your knowledge base content by opening the "
 "``Knowledge Base`` tab in the navigation sidebar."


### PR DESCRIPTION
Translations update from [Zammad-Translations](https://translations.zammad.org) for [Documentation/User Documentation (pre-release)](https://translations.zammad.org/projects/documentations/user-documentation-pre-release/).



Current translation status:

![Weblate translation status](https://translations.zammad.org/widget/documentations/user-documentation-pre-release/horizontal-auto.svg)