### PR TITLE
Maintenance: Fix button label

### DIFF
--- a/extras/checklist.rst
+++ b/extras/checklist.rst
@@ -18,8 +18,8 @@ Basics
 ^^^^^^
 
 If you want to add a checklist to a ticket, go to the **Checklist** tab and
-click either on ``Add empty checklist`` (1) or ``Add from template`` (2) after
-selecting a template. If you can't see the ``Add from template`` area, there is
+click either on ``Add empty checklist`` (1) or ``Add from a template`` (2) after
+selecting a template. If you can't see the ``Add from a template`` area, there is
 no template available.
 
 .. figure:: /images/extras/checklist/checklist-creation.png

--- a/locale/user-docs.pot
+++ b/locale/user-docs.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad User Documentation pre-release\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-12 13:18+0200\n"
+"POT-Creation-Date: 2026-06-19 19:52+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -3895,7 +3895,7 @@ msgid "Basics"
 msgstr ""
 
 #: ../extras/checklist.rst:20
-msgid "If you want to add a checklist to a ticket, go to the **Checklist** tab and click either on ``Add empty checklist`` (1) or ``Add from template`` (2) after selecting a template. If you can't see the ``Add from template`` area, there is no template available."
+msgid "If you want to add a checklist to a ticket, go to the **Checklist** tab and click either on ``Add empty checklist`` (1) or ``Add from a template`` (2) after selecting a template. If you can't see the ``Add from a template`` area, there is no template available."
 msgstr ""
 
 #: ../extras/checklist.rst:30


### PR DESCRIPTION
The button label is "Add from **a** template" (see screenshot below the text in the documentation).