### PR TITLE
Translations update from Zammad-Translations

### DIFF
--- a/locale/cs/LC_MESSAGES/user-docs.po
+++ b/locale/cs/LC_MESSAGES/user-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-01 08:43+0200\n"
+"POT-Creation-Date: 2026-07-07 14:22+0200\n"
 "PO-Revision-Date: 2026-06-17 10:17+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Czech <https://translations.zammad.org/projects/"
@@ -1365,7 +1365,7 @@ msgstr ""
 msgid "**Paused, no action needed right now** (e.g. pending)"
 msgstr ""
 
-#: ../snippets/ticket-state-type-circles.rst:8 ../extras/knowledge-base.rst:204
+#: ../snippets/ticket-state-type-circles.rst:8 ../extras/knowledge-base.rst:221
 msgid "|grn|"
 msgstr ""
 
@@ -2434,6 +2434,7 @@ msgid ""
 msgstr ""
 
 #: ../basics/ticket-basics.rst:117 ../basics/zammad-glossary.rst:706
+#: ../extras/knowledge-base.rst:213
 msgid "Tags"
 msgstr ""
 
@@ -5707,7 +5708,7 @@ msgid ""
 msgstr ""
 
 #: ../extras/knowledge-base.rst:0
-msgid "Screenshot showing the modal for of the RSS button"
+msgid "Screenshot shows the modal for of the RSS button"
 msgstr ""
 
 #: ../extras/knowledge-base.rst:107
@@ -5719,7 +5720,7 @@ msgstr ""
 #: ../extras/knowledge-base.rst:110
 msgid ""
 "If you want to revoke the access and renew your token, you can do so in the "
-"RSS modal."
+"RSS dialog."
 msgstr ""
 
 #: ../extras/knowledge-base.rst:0
@@ -5777,9 +5778,7 @@ msgid ""
 msgstr ""
 
 #: ../extras/knowledge-base.rst:None
-msgid ""
-"Screencast showing the visibility option for categories for granular access "
-"permissions"
+msgid "Screenshot shows the granular category permissions for knowledge base"
 msgstr ""
 
 #: ../extras/knowledge-base.rst:153
@@ -5820,16 +5819,16 @@ msgid ""
 "The knowledge base editor comes equipped with the same **rich text editing "
 "capabilities** available in the Zammad ticket composer. That means you can "
 "use the same :doc:`keyboard shortcuts </advanced/keyboard-shortcuts>` to "
-"insert formatted text, bullet lists, and more. You can even add file "
+"insert formatted text, bullet lists and more. You can even add file "
 "attachments and links!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:196
+#: ../extras/knowledge-base.rst:213
 msgid "Different link types"
 msgstr ""
 
 #: ../extras/knowledge-base.rst:184
-msgid "**Web link**"
+msgid "Web link"
 msgstr ""
 
 #: ../extras/knowledge-base.rst:184
@@ -5837,7 +5836,7 @@ msgid "URLs pointing to other websites."
 msgstr ""
 
 #: ../extras/knowledge-base.rst:188
-msgid "**Link Answer**"
+msgid "Link Answer"
 msgstr ""
 
 #: ../extras/knowledge-base.rst:187
@@ -5847,62 +5846,91 @@ msgid ""
 msgstr ""
 
 #: ../extras/knowledge-base.rst:192
-msgid "**Linked Tickets**"
+msgid "Image"
 msgstr ""
 
 #: ../extras/knowledge-base.rst:191
+msgid ""
+"Include an image from your computer in the answer. Unlike file attachments, "
+"these images are embedded directly in the answer."
+msgstr ""
+
+#: ../extras/knowledge-base.rst:199
+msgid "Video"
+msgstr ""
+
+#: ../extras/knowledge-base.rst:195
+msgid ""
+"Include a video to embed in the answer. By default, you can embed videos "
+"from Vimeo and YouTube. Depending on your Zammad settings, MediaCMS and "
+"PeerTube instances can be enabled by your admin as well. A list of supported "
+"video services is displayed in the video dialog below the URL field."
+msgstr ""
+
+#: ../extras/knowledge-base.rst:203
+msgid "Linked Tickets"
+msgstr ""
+
+#: ../extras/knowledge-base.rst:202
 msgid ""
 "Internal references to Zammad tickets (visible only in preview and edit "
 "mode)."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:196
-msgid "**Tags**"
+#: ../extras/knowledge-base.rst:208
+msgid "Attachments"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:195
+#: ../extras/knowledge-base.rst:206
+msgid ""
+"Add any file as an attachment to your answer. Such an attachment isn't "
+"embedded in the body of the answer. Readers can download it by clicking on "
+"it in the attachment section."
+msgstr ""
+
+#: ../extras/knowledge-base.rst:211
 msgid ""
 "Can help to categorize or label answers for better search results. Please "
-"note that tags are visible publicly and can be the same like those in your "
+"note that tags are visible publicly and can be the same as those in your "
 "tickets."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:221
+#: ../extras/knowledge-base.rst:238
 msgid "Visibility"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:199
+#: ../extras/knowledge-base.rst:216
 msgid ""
 "Set the visibility of an answer to control who can see an article, or "
 "schedule it to be published at a later date. Articles are color-coded "
 "according to their visibility:"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:204
+#: ../extras/knowledge-base.rst:221
 msgid "**Public** (visible to everyone)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:206
+#: ../extras/knowledge-base.rst:223
 msgid "|blu|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:206
+#: ../extras/knowledge-base.rst:223
 msgid "**Internal** (visible to agents & editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:208
+#: ../extras/knowledge-base.rst:225
 msgid "|gry|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:208
+#: ../extras/knowledge-base.rst:225
 msgid "**Draft/Scheduled/Archived** (visible to editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:224
+#: ../extras/knowledge-base.rst:241
 msgid "Using Answers In Ticket Articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:226
+#: ../extras/knowledge-base.rst:243
 msgid ""
 "As soon as the knowledge base contains one or more answers, you can use "
 "these just like text modules. Instead of :kbd:`:`:kbd:`:` just use :kbd:`?"
@@ -7108,7 +7136,7 @@ msgstr ""
 
 #: ../extras/two-factor-authentication/security-keys-setup.rst:24
 msgid ""
-"Next, depending you your browser, you will be presented with different "
+"Next, depending on your browser, you will be presented with different "
 "options. Select one that refers to your chosen security key and follow the "
 "instructions on the screen."
 msgstr ""

--- a/locale/da/LC_MESSAGES/user-docs.po
+++ b/locale/da/LC_MESSAGES/user-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-01 08:43+0200\n"
+"POT-Creation-Date: 2026-07-07 14:22+0200\n"
 "PO-Revision-Date: 2026-06-17 10:17+0000\n"
 "Last-Translator: LomaxThomas <thomas.hartvig@lomax.dk>\n"
 "Language-Team: Danish <https://translations.zammad.org/projects/"
@@ -1365,7 +1365,7 @@ msgstr ""
 msgid "**Paused, no action needed right now** (e.g. pending)"
 msgstr ""
 
-#: ../snippets/ticket-state-type-circles.rst:8 ../extras/knowledge-base.rst:204
+#: ../snippets/ticket-state-type-circles.rst:8 ../extras/knowledge-base.rst:221
 msgid "|grn|"
 msgstr ""
 
@@ -2434,6 +2434,7 @@ msgid ""
 msgstr ""
 
 #: ../basics/ticket-basics.rst:117 ../basics/zammad-glossary.rst:706
+#: ../extras/knowledge-base.rst:213
 msgid "Tags"
 msgstr ""
 
@@ -5707,7 +5708,7 @@ msgid ""
 msgstr ""
 
 #: ../extras/knowledge-base.rst:0
-msgid "Screenshot showing the modal for of the RSS button"
+msgid "Screenshot shows the modal for of the RSS button"
 msgstr ""
 
 #: ../extras/knowledge-base.rst:107
@@ -5719,7 +5720,7 @@ msgstr ""
 #: ../extras/knowledge-base.rst:110
 msgid ""
 "If you want to revoke the access and renew your token, you can do so in the "
-"RSS modal."
+"RSS dialog."
 msgstr ""
 
 #: ../extras/knowledge-base.rst:0
@@ -5777,9 +5778,7 @@ msgid ""
 msgstr ""
 
 #: ../extras/knowledge-base.rst:None
-msgid ""
-"Screencast showing the visibility option for categories for granular access "
-"permissions"
+msgid "Screenshot shows the granular category permissions for knowledge base"
 msgstr ""
 
 #: ../extras/knowledge-base.rst:153
@@ -5820,16 +5819,16 @@ msgid ""
 "The knowledge base editor comes equipped with the same **rich text editing "
 "capabilities** available in the Zammad ticket composer. That means you can "
 "use the same :doc:`keyboard shortcuts </advanced/keyboard-shortcuts>` to "
-"insert formatted text, bullet lists, and more. You can even add file "
+"insert formatted text, bullet lists and more. You can even add file "
 "attachments and links!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:196
+#: ../extras/knowledge-base.rst:213
 msgid "Different link types"
 msgstr ""
 
 #: ../extras/knowledge-base.rst:184
-msgid "**Web link**"
+msgid "Web link"
 msgstr ""
 
 #: ../extras/knowledge-base.rst:184
@@ -5837,7 +5836,7 @@ msgid "URLs pointing to other websites."
 msgstr ""
 
 #: ../extras/knowledge-base.rst:188
-msgid "**Link Answer**"
+msgid "Link Answer"
 msgstr ""
 
 #: ../extras/knowledge-base.rst:187
@@ -5847,62 +5846,91 @@ msgid ""
 msgstr ""
 
 #: ../extras/knowledge-base.rst:192
-msgid "**Linked Tickets**"
+msgid "Image"
 msgstr ""
 
 #: ../extras/knowledge-base.rst:191
+msgid ""
+"Include an image from your computer in the answer. Unlike file attachments, "
+"these images are embedded directly in the answer."
+msgstr ""
+
+#: ../extras/knowledge-base.rst:199
+msgid "Video"
+msgstr ""
+
+#: ../extras/knowledge-base.rst:195
+msgid ""
+"Include a video to embed in the answer. By default, you can embed videos "
+"from Vimeo and YouTube. Depending on your Zammad settings, MediaCMS and "
+"PeerTube instances can be enabled by your admin as well. A list of supported "
+"video services is displayed in the video dialog below the URL field."
+msgstr ""
+
+#: ../extras/knowledge-base.rst:203
+msgid "Linked Tickets"
+msgstr ""
+
+#: ../extras/knowledge-base.rst:202
 msgid ""
 "Internal references to Zammad tickets (visible only in preview and edit "
 "mode)."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:196
-msgid "**Tags**"
+#: ../extras/knowledge-base.rst:208
+msgid "Attachments"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:195
+#: ../extras/knowledge-base.rst:206
+msgid ""
+"Add any file as an attachment to your answer. Such an attachment isn't "
+"embedded in the body of the answer. Readers can download it by clicking on "
+"it in the attachment section."
+msgstr ""
+
+#: ../extras/knowledge-base.rst:211
 msgid ""
 "Can help to categorize or label answers for better search results. Please "
-"note that tags are visible publicly and can be the same like those in your "
+"note that tags are visible publicly and can be the same as those in your "
 "tickets."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:221
+#: ../extras/knowledge-base.rst:238
 msgid "Visibility"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:199
+#: ../extras/knowledge-base.rst:216
 msgid ""
 "Set the visibility of an answer to control who can see an article, or "
 "schedule it to be published at a later date. Articles are color-coded "
 "according to their visibility:"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:204
+#: ../extras/knowledge-base.rst:221
 msgid "**Public** (visible to everyone)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:206
+#: ../extras/knowledge-base.rst:223
 msgid "|blu|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:206
+#: ../extras/knowledge-base.rst:223
 msgid "**Internal** (visible to agents & editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:208
+#: ../extras/knowledge-base.rst:225
 msgid "|gry|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:208
+#: ../extras/knowledge-base.rst:225
 msgid "**Draft/Scheduled/Archived** (visible to editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:224
+#: ../extras/knowledge-base.rst:241
 msgid "Using Answers In Ticket Articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:226
+#: ../extras/knowledge-base.rst:243
 msgid ""
 "As soon as the knowledge base contains one or more answers, you can use "
 "these just like text modules. Instead of :kbd:`:`:kbd:`:` just use :kbd:`?"
@@ -7108,7 +7136,7 @@ msgstr ""
 
 #: ../extras/two-factor-authentication/security-keys-setup.rst:24
 msgid ""
-"Next, depending you your browser, you will be presented with different "
+"Next, depending on your browser, you will be presented with different "
 "options. Select one that refers to your chosen security key and follow the "
 "instructions on the screen."
 msgstr ""

--- a/locale/de/LC_MESSAGES/user-docs.po
+++ b/locale/de/LC_MESSAGES/user-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-01 08:43+0200\n"
+"POT-Creation-Date: 2026-07-07 14:22+0200\n"
 "PO-Revision-Date: 2026-07-02 16:02+0000\n"
 "Last-Translator: Ralf Schmid <rsc@zammad.com>\n"
 "Language-Team: German <https://translations.zammad.org/projects/"
@@ -1586,7 +1586,7 @@ msgstr "|blk|"
 msgid "**Paused, no action needed right now** (e.g. pending)"
 msgstr "**Pausiert, im Moment keine Aktion erforderlich** (z.B. warten auf)"
 
-#: ../snippets/ticket-state-type-circles.rst:8 ../extras/knowledge-base.rst:204
+#: ../snippets/ticket-state-type-circles.rst:8 ../extras/knowledge-base.rst:221
 msgid "|grn|"
 msgstr "|grn|"
 
@@ -3024,6 +3024,7 @@ msgstr ""
 "auf eine sofortige Eskalation hoffen."
 
 #: ../basics/ticket-basics.rst:117 ../basics/zammad-glossary.rst:706
+#: ../extras/knowledge-base.rst:213
 msgid "Tags"
 msgstr "Tags"
 
@@ -7381,7 +7382,9 @@ msgstr ""
 "Abonnieren an."
 
 #: ../extras/knowledge-base.rst:0
-msgid "Screenshot showing the modal for of the RSS button"
+#, fuzzy
+#| msgid "Screenshot showing the modal for of the RSS button"
+msgid "Screenshot shows the modal for of the RSS button"
 msgstr "Bildschirmaufnahme zeigt den Dialog für den RSS-Knopf"
 
 #: ../extras/knowledge-base.rst:107
@@ -7393,9 +7396,13 @@ msgstr ""
 "enthalten**. Geben Sie diese URLs niemals weiter!"
 
 #: ../extras/knowledge-base.rst:110
+#, fuzzy
+#| msgid ""
+#| "If you want to revoke the access and renew your token, you can do so in "
+#| "the RSS modal."
 msgid ""
 "If you want to revoke the access and renew your token, you can do so in the "
-"RSS modal."
+"RSS dialog."
 msgstr ""
 "Falls Sie den Zugriff für den Token entziehen und ihn erneuenten möchte, "
 "können Sie das im RSS-Dialog tun."
@@ -7475,12 +7482,14 @@ msgstr ""
 "permissions.html>` entsprechend zu konfigurieren."
 
 #: ../extras/knowledge-base.rst:None
-msgid ""
-"Screencast showing the visibility option for categories for granular access "
-"permissions"
+#, fuzzy
+#| msgid ""
+#| "Your administrator has to provide the relevant groups with reader "
+#| "permissions for the knowledge base."
+msgid "Screenshot shows the granular category permissions for knowledge base"
 msgstr ""
-"Bildschirmaufzeichnung zeigt die Sichtbarkeitseinstellungen für Kategorien "
-"für differenzierte Kategorieberechtigungen"
+"Ihr Administrator muss die relevanten Gruppen mit Reader-Rechten für die "
+"Wissensdatenbank versehen."
 
 #: ../extras/knowledge-base.rst:153
 msgid ""
@@ -7531,11 +7540,18 @@ msgid "Edit answer"
 msgstr "Antwort editieren"
 
 #: ../extras/knowledge-base.rst:176
+#, fuzzy
+#| msgid ""
+#| "The knowledge base editor comes equipped with the same **rich text "
+#| "editing capabilities** available in the Zammad ticket composer. That "
+#| "means you can use the same :doc:`keyboard shortcuts </advanced/keyboard-"
+#| "shortcuts>` to insert formatted text, bullet lists, and more. You can "
+#| "even add file attachments and links!"
 msgid ""
 "The knowledge base editor comes equipped with the same **rich text editing "
 "capabilities** available in the Zammad ticket composer. That means you can "
 "use the same :doc:`keyboard shortcuts </advanced/keyboard-shortcuts>` to "
-"insert formatted text, bullet lists, and more. You can even add file "
+"insert formatted text, bullet lists and more. You can even add file "
 "attachments and links!"
 msgstr ""
 "Der Knowledge Base-Editor ist mit den gleichen **Bearbeitungsfunktionen** "
@@ -7544,12 +7560,14 @@ msgstr ""
 "shortcuts>` verwenden können, um Text-Formatierungen, Aufzählungszeichen und "
 "mehr zu nutzen. Es können sogar Dateianhänge und Links hinzugefügt werden!"
 
-#: ../extras/knowledge-base.rst:196
+#: ../extras/knowledge-base.rst:213
 msgid "Different link types"
 msgstr "Verschiedene Link-Typen"
 
 #: ../extras/knowledge-base.rst:184
-msgid "**Web link**"
+#, fuzzy
+#| msgid "**Web link**"
+msgid "Web link"
 msgstr "**Web-Link**"
 
 #: ../extras/knowledge-base.rst:184
@@ -7557,7 +7575,9 @@ msgid "URLs pointing to other websites."
 msgstr "URLs, die auf andere Websites verweisen."
 
 #: ../extras/knowledge-base.rst:188
-msgid "**Link Answer**"
+#, fuzzy
+#| msgid "**Link Answer**"
+msgid "Link Answer"
 msgstr "**Antwort verknüpfen**"
 
 #: ../extras/knowledge-base.rst:187
@@ -7569,10 +7589,34 @@ msgstr ""
 "funktionslos, wenn sich die Ziel-URL ändert)."
 
 #: ../extras/knowledge-base.rst:192
-msgid "**Linked Tickets**"
-msgstr "**Verknüpfte Tickets**"
+msgid "Image"
+msgstr ""
 
 #: ../extras/knowledge-base.rst:191
+msgid ""
+"Include an image from your computer in the answer. Unlike file attachments, "
+"these images are embedded directly in the answer."
+msgstr ""
+
+#: ../extras/knowledge-base.rst:199
+msgid "Video"
+msgstr ""
+
+#: ../extras/knowledge-base.rst:195
+msgid ""
+"Include a video to embed in the answer. By default, you can embed videos "
+"from Vimeo and YouTube. Depending on your Zammad settings, MediaCMS and "
+"PeerTube instances can be enabled by your admin as well. A list of supported "
+"video services is displayed in the video dialog below the URL field."
+msgstr ""
+
+#: ../extras/knowledge-base.rst:203
+#, fuzzy
+#| msgid "Link Tickets"
+msgid "Linked Tickets"
+msgstr "Tickets verknüpfen"
+
+#: ../extras/knowledge-base.rst:202
 msgid ""
 "Internal references to Zammad tickets (visible only in preview and edit "
 "mode)."
@@ -7580,25 +7624,37 @@ msgstr ""
 "Interne Verweise auf Zammad Tickets (nur in der Vorschau und im "
 "Bearbeitungsmodus sichtbar)."
 
-#: ../extras/knowledge-base.rst:196
-msgid "**Tags**"
-msgstr "**Tags**"
+#: ../extras/knowledge-base.rst:208
+msgid "Attachments"
+msgstr ""
 
-#: ../extras/knowledge-base.rst:195
+#: ../extras/knowledge-base.rst:206
+msgid ""
+"Add any file as an attachment to your answer. Such an attachment isn't "
+"embedded in the body of the answer. Readers can download it by clicking on "
+"it in the attachment section."
+msgstr ""
+
+#: ../extras/knowledge-base.rst:211
+#, fuzzy
+#| msgid ""
+#| "Can help to categorize or label answers for better search results. Please "
+#| "note that tags are visible publicly and can be the same like those in "
+#| "your tickets."
 msgid ""
 "Can help to categorize or label answers for better search results. Please "
-"note that tags are visible publicly and can be the same like those in your "
+"note that tags are visible publicly and can be the same as those in your "
 "tickets."
 msgstr ""
 "Dies kann dabei helfen, Antworten zu kategorisieren oder mit Tags zu "
 "versehen, um bessere Suchergebnisse zu erzielen. Bitte beachten Sie, dass "
 "Tags öffentlich sichtbar sind und dieselben wie in Ihren Tickets sind."
 
-#: ../extras/knowledge-base.rst:221
+#: ../extras/knowledge-base.rst:238
 msgid "Visibility"
 msgstr "Sichtbarkeit"
 
-#: ../extras/knowledge-base.rst:199
+#: ../extras/knowledge-base.rst:216
 msgid ""
 "Set the visibility of an answer to control who can see an article, or "
 "schedule it to be published at a later date. Articles are color-coded "
@@ -7609,31 +7665,31 @@ msgstr ""
 "späteren Zeitpunkt. Artikel sind entsprechend ihrer Sichtbarkeit farblich "
 "gekennzeichnet:"
 
-#: ../extras/knowledge-base.rst:204
+#: ../extras/knowledge-base.rst:221
 msgid "**Public** (visible to everyone)"
 msgstr "**Öffentlich** (für jeden sichtbar)"
 
-#: ../extras/knowledge-base.rst:206
+#: ../extras/knowledge-base.rst:223
 msgid "|blu|"
 msgstr "|blu|"
 
-#: ../extras/knowledge-base.rst:206
+#: ../extras/knowledge-base.rst:223
 msgid "**Internal** (visible to agents & editors only)"
 msgstr "**Intern** (nur sichtbar für Agenten und Bearbeiter)"
 
-#: ../extras/knowledge-base.rst:208
+#: ../extras/knowledge-base.rst:225
 msgid "|gry|"
 msgstr "|gry|"
 
-#: ../extras/knowledge-base.rst:208
+#: ../extras/knowledge-base.rst:225
 msgid "**Draft/Scheduled/Archived** (visible to editors only)"
 msgstr "**Entwurf / geplant / archiviert** (sichtbar nur für Bearbeiter)"
 
-#: ../extras/knowledge-base.rst:224
+#: ../extras/knowledge-base.rst:241
 msgid "Using Answers In Ticket Articles"
 msgstr "Antworten in Ticket-Artikeln benutzen"
 
-#: ../extras/knowledge-base.rst:226
+#: ../extras/knowledge-base.rst:243
 msgid ""
 "As soon as the knowledge base contains one or more answers, you can use "
 "these just like text modules. Instead of :kbd:`:`:kbd:`:` just use :kbd:`?"
@@ -9170,8 +9226,13 @@ msgid "Security Key Name"
 msgstr "Name Sicherheits-Schlüssel"
 
 #: ../extras/two-factor-authentication/security-keys-setup.rst:24
+#, fuzzy
+#| msgid ""
+#| "Next, depending you your browser, you will be presented with different "
+#| "options. Select one that refers to your chosen security key and follow "
+#| "the instructions on the screen."
 msgid ""
-"Next, depending you your browser, you will be presented with different "
+"Next, depending on your browser, you will be presented with different "
 "options. Select one that refers to your chosen security key and follow the "
 "instructions on the screen."
 msgstr ""
@@ -9718,6 +9779,19 @@ msgstr ""
 "Sie lesen gerade die Benutzerdokumentation von Zammad. Es sind "
 "außerdem :docs:`System- </index.html>` und :admin-docs:`Admin-"
 "Dokumentationen </index.html>` verfügbar."
+
+#~ msgid ""
+#~ "Screencast showing the visibility option for categories for granular "
+#~ "access permissions"
+#~ msgstr ""
+#~ "Bildschirmaufzeichnung zeigt die Sichtbarkeitseinstellungen für "
+#~ "Kategorien für differenzierte Kategorieberechtigungen"
+
+#~ msgid "**Linked Tickets**"
+#~ msgstr "**Verknüpfte Tickets**"
+
+#~ msgid "**Tags**"
+#~ msgstr "**Tags**"
 
 #~ msgid "Screencast demo of S/MIME features for both new tickets and replies"
 #~ msgstr ""
@@ -12139,13 +12213,6 @@ msgstr ""
 
 #~ msgid "**⚙️ Roles require knowledge base reader permission**"
 #~ msgstr "**⚙️ Rollen erfordern Wissensdatenbank-Reader-Rechte**"
-
-#~ msgid ""
-#~ "Your administrator has to provide the relevant groups with reader "
-#~ "permissions for the knowledge base."
-#~ msgstr ""
-#~ "Ihr Administrator muss die relevanten Gruppen mit Reader-Rechten für die "
-#~ "Wissensdatenbank versehen."
 
 #~ msgid "**🥵 Beware of visibility levels**"
 #~ msgstr "**🥵 Beachten Sie Sichtbarkeitsebenen**"

--- a/locale/es/LC_MESSAGES/user-docs.po
+++ b/locale/es/LC_MESSAGES/user-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-01 08:43+0200\n"
+"POT-Creation-Date: 2026-07-07 14:22+0200\n"
 "PO-Revision-Date: 2026-06-17 10:14+0000\n"
 "Last-Translator: Arturo <r2r0@posteo.de>\n"
 "Language-Team: Spanish <https://translations.zammad.org/projects/"
@@ -1470,7 +1470,7 @@ msgstr ""
 msgid "**Paused, no action needed right now** (e.g. pending)"
 msgstr ""
 
-#: ../snippets/ticket-state-type-circles.rst:8 ../extras/knowledge-base.rst:204
+#: ../snippets/ticket-state-type-circles.rst:8 ../extras/knowledge-base.rst:221
 msgid "|grn|"
 msgstr ""
 
@@ -2572,6 +2572,7 @@ msgid ""
 msgstr ""
 
 #: ../basics/ticket-basics.rst:117 ../basics/zammad-glossary.rst:706
+#: ../extras/knowledge-base.rst:213
 msgid "Tags"
 msgstr ""
 
@@ -5881,8 +5882,11 @@ msgid ""
 msgstr ""
 
 #: ../extras/knowledge-base.rst:0
-msgid "Screenshot showing the modal for of the RSS button"
+#, fuzzy
+msgid "Screenshot shows the modal for of the RSS button"
 msgstr ""
+"Captura de pantalla mostrando como guardar un boceto compartido dentro de un "
+"ticket"
 
 #: ../extras/knowledge-base.rst:107
 msgid ""
@@ -5893,7 +5897,7 @@ msgstr ""
 #: ../extras/knowledge-base.rst:110
 msgid ""
 "If you want to revoke the access and renew your token, you can do so in the "
-"RSS modal."
+"RSS dialog."
 msgstr ""
 
 #: ../extras/knowledge-base.rst:0
@@ -5951,9 +5955,7 @@ msgid ""
 msgstr ""
 
 #: ../extras/knowledge-base.rst:None
-msgid ""
-"Screencast showing the visibility option for categories for granular access "
-"permissions"
+msgid "Screenshot shows the granular category permissions for knowledge base"
 msgstr ""
 
 #: ../extras/knowledge-base.rst:153
@@ -5994,16 +5996,16 @@ msgid ""
 "The knowledge base editor comes equipped with the same **rich text editing "
 "capabilities** available in the Zammad ticket composer. That means you can "
 "use the same :doc:`keyboard shortcuts </advanced/keyboard-shortcuts>` to "
-"insert formatted text, bullet lists, and more. You can even add file "
+"insert formatted text, bullet lists and more. You can even add file "
 "attachments and links!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:196
+#: ../extras/knowledge-base.rst:213
 msgid "Different link types"
 msgstr ""
 
 #: ../extras/knowledge-base.rst:184
-msgid "**Web link**"
+msgid "Web link"
 msgstr ""
 
 #: ../extras/knowledge-base.rst:184
@@ -6011,7 +6013,7 @@ msgid "URLs pointing to other websites."
 msgstr ""
 
 #: ../extras/knowledge-base.rst:188
-msgid "**Link Answer**"
+msgid "Link Answer"
 msgstr ""
 
 #: ../extras/knowledge-base.rst:187
@@ -6021,63 +6023,92 @@ msgid ""
 msgstr ""
 
 #: ../extras/knowledge-base.rst:192
-#, fuzzy
-msgid "**Linked Tickets**"
-msgstr "Macros"
+msgid "Image"
+msgstr ""
 
 #: ../extras/knowledge-base.rst:191
+msgid ""
+"Include an image from your computer in the answer. Unlike file attachments, "
+"these images are embedded directly in the answer."
+msgstr ""
+
+#: ../extras/knowledge-base.rst:199
+msgid "Video"
+msgstr ""
+
+#: ../extras/knowledge-base.rst:195
+msgid ""
+"Include a video to embed in the answer. By default, you can embed videos "
+"from Vimeo and YouTube. Depending on your Zammad settings, MediaCMS and "
+"PeerTube instances can be enabled by your admin as well. A list of supported "
+"video services is displayed in the video dialog below the URL field."
+msgstr ""
+
+#: ../extras/knowledge-base.rst:203
+#, fuzzy
+msgid "Linked Tickets"
+msgstr "Macros"
+
+#: ../extras/knowledge-base.rst:202
 msgid ""
 "Internal references to Zammad tickets (visible only in preview and edit "
 "mode)."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:196
-msgid "**Tags**"
+#: ../extras/knowledge-base.rst:208
+msgid "Attachments"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:195
+#: ../extras/knowledge-base.rst:206
+msgid ""
+"Add any file as an attachment to your answer. Such an attachment isn't "
+"embedded in the body of the answer. Readers can download it by clicking on "
+"it in the attachment section."
+msgstr ""
+
+#: ../extras/knowledge-base.rst:211
 msgid ""
 "Can help to categorize or label answers for better search results. Please "
-"note that tags are visible publicly and can be the same like those in your "
+"note that tags are visible publicly and can be the same as those in your "
 "tickets."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:221
+#: ../extras/knowledge-base.rst:238
 msgid "Visibility"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:199
+#: ../extras/knowledge-base.rst:216
 msgid ""
 "Set the visibility of an answer to control who can see an article, or "
 "schedule it to be published at a later date. Articles are color-coded "
 "according to their visibility:"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:204
+#: ../extras/knowledge-base.rst:221
 msgid "**Public** (visible to everyone)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:206
+#: ../extras/knowledge-base.rst:223
 msgid "|blu|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:206
+#: ../extras/knowledge-base.rst:223
 msgid "**Internal** (visible to agents & editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:208
+#: ../extras/knowledge-base.rst:225
 msgid "|gry|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:208
+#: ../extras/knowledge-base.rst:225
 msgid "**Draft/Scheduled/Archived** (visible to editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:224
+#: ../extras/knowledge-base.rst:241
 msgid "Using Answers In Ticket Articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:226
+#: ../extras/knowledge-base.rst:243
 msgid ""
 "As soon as the knowledge base contains one or more answers, you can use "
 "these just like text modules. Instead of :kbd:`:`:kbd:`:` just use :kbd:`?"
@@ -7322,7 +7353,7 @@ msgstr ""
 
 #: ../extras/two-factor-authentication/security-keys-setup.rst:24
 msgid ""
-"Next, depending you your browser, you will be presented with different "
+"Next, depending on your browser, you will be presented with different "
 "options. Select one that refers to your chosen security key and follow the "
 "instructions on the screen."
 msgstr ""
@@ -7744,6 +7775,10 @@ msgid ""
 "also :docs:`system </index.html>` and :admin-docs:`administration manuals </"
 "index.html>` available."
 msgstr ""
+
+#, fuzzy
+#~ msgid "**Linked Tickets**"
+#~ msgstr "Macros"
 
 #, fuzzy
 #~ msgid "Split ticket button"

--- a/locale/es_CO/LC_MESSAGES/user-docs.po
+++ b/locale/es_CO/LC_MESSAGES/user-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-01 08:43+0200\n"
+"POT-Creation-Date: 2026-07-07 14:22+0200\n"
 "PO-Revision-Date: 2026-06-17 10:14+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Spanish (Colombia) <https://translations.zammad.org/projects/"
@@ -1365,7 +1365,7 @@ msgstr ""
 msgid "**Paused, no action needed right now** (e.g. pending)"
 msgstr ""
 
-#: ../snippets/ticket-state-type-circles.rst:8 ../extras/knowledge-base.rst:204
+#: ../snippets/ticket-state-type-circles.rst:8 ../extras/knowledge-base.rst:221
 msgid "|grn|"
 msgstr ""
 
@@ -2434,6 +2434,7 @@ msgid ""
 msgstr ""
 
 #: ../basics/ticket-basics.rst:117 ../basics/zammad-glossary.rst:706
+#: ../extras/knowledge-base.rst:213
 msgid "Tags"
 msgstr ""
 
@@ -5707,7 +5708,7 @@ msgid ""
 msgstr ""
 
 #: ../extras/knowledge-base.rst:0
-msgid "Screenshot showing the modal for of the RSS button"
+msgid "Screenshot shows the modal for of the RSS button"
 msgstr ""
 
 #: ../extras/knowledge-base.rst:107
@@ -5719,7 +5720,7 @@ msgstr ""
 #: ../extras/knowledge-base.rst:110
 msgid ""
 "If you want to revoke the access and renew your token, you can do so in the "
-"RSS modal."
+"RSS dialog."
 msgstr ""
 
 #: ../extras/knowledge-base.rst:0
@@ -5777,9 +5778,7 @@ msgid ""
 msgstr ""
 
 #: ../extras/knowledge-base.rst:None
-msgid ""
-"Screencast showing the visibility option for categories for granular access "
-"permissions"
+msgid "Screenshot shows the granular category permissions for knowledge base"
 msgstr ""
 
 #: ../extras/knowledge-base.rst:153
@@ -5820,16 +5819,16 @@ msgid ""
 "The knowledge base editor comes equipped with the same **rich text editing "
 "capabilities** available in the Zammad ticket composer. That means you can "
 "use the same :doc:`keyboard shortcuts </advanced/keyboard-shortcuts>` to "
-"insert formatted text, bullet lists, and more. You can even add file "
+"insert formatted text, bullet lists and more. You can even add file "
 "attachments and links!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:196
+#: ../extras/knowledge-base.rst:213
 msgid "Different link types"
 msgstr ""
 
 #: ../extras/knowledge-base.rst:184
-msgid "**Web link**"
+msgid "Web link"
 msgstr ""
 
 #: ../extras/knowledge-base.rst:184
@@ -5837,7 +5836,7 @@ msgid "URLs pointing to other websites."
 msgstr ""
 
 #: ../extras/knowledge-base.rst:188
-msgid "**Link Answer**"
+msgid "Link Answer"
 msgstr ""
 
 #: ../extras/knowledge-base.rst:187
@@ -5847,62 +5846,91 @@ msgid ""
 msgstr ""
 
 #: ../extras/knowledge-base.rst:192
-msgid "**Linked Tickets**"
+msgid "Image"
 msgstr ""
 
 #: ../extras/knowledge-base.rst:191
+msgid ""
+"Include an image from your computer in the answer. Unlike file attachments, "
+"these images are embedded directly in the answer."
+msgstr ""
+
+#: ../extras/knowledge-base.rst:199
+msgid "Video"
+msgstr ""
+
+#: ../extras/knowledge-base.rst:195
+msgid ""
+"Include a video to embed in the answer. By default, you can embed videos "
+"from Vimeo and YouTube. Depending on your Zammad settings, MediaCMS and "
+"PeerTube instances can be enabled by your admin as well. A list of supported "
+"video services is displayed in the video dialog below the URL field."
+msgstr ""
+
+#: ../extras/knowledge-base.rst:203
+msgid "Linked Tickets"
+msgstr ""
+
+#: ../extras/knowledge-base.rst:202
 msgid ""
 "Internal references to Zammad tickets (visible only in preview and edit "
 "mode)."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:196
-msgid "**Tags**"
+#: ../extras/knowledge-base.rst:208
+msgid "Attachments"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:195
+#: ../extras/knowledge-base.rst:206
+msgid ""
+"Add any file as an attachment to your answer. Such an attachment isn't "
+"embedded in the body of the answer. Readers can download it by clicking on "
+"it in the attachment section."
+msgstr ""
+
+#: ../extras/knowledge-base.rst:211
 msgid ""
 "Can help to categorize or label answers for better search results. Please "
-"note that tags are visible publicly and can be the same like those in your "
+"note that tags are visible publicly and can be the same as those in your "
 "tickets."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:221
+#: ../extras/knowledge-base.rst:238
 msgid "Visibility"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:199
+#: ../extras/knowledge-base.rst:216
 msgid ""
 "Set the visibility of an answer to control who can see an article, or "
 "schedule it to be published at a later date. Articles are color-coded "
 "according to their visibility:"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:204
+#: ../extras/knowledge-base.rst:221
 msgid "**Public** (visible to everyone)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:206
+#: ../extras/knowledge-base.rst:223
 msgid "|blu|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:206
+#: ../extras/knowledge-base.rst:223
 msgid "**Internal** (visible to agents & editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:208
+#: ../extras/knowledge-base.rst:225
 msgid "|gry|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:208
+#: ../extras/knowledge-base.rst:225
 msgid "**Draft/Scheduled/Archived** (visible to editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:224
+#: ../extras/knowledge-base.rst:241
 msgid "Using Answers In Ticket Articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:226
+#: ../extras/knowledge-base.rst:243
 msgid ""
 "As soon as the knowledge base contains one or more answers, you can use "
 "these just like text modules. Instead of :kbd:`:`:kbd:`:` just use :kbd:`?"
@@ -7108,7 +7136,7 @@ msgstr ""
 
 #: ../extras/two-factor-authentication/security-keys-setup.rst:24
 msgid ""
-"Next, depending you your browser, you will be presented with different "
+"Next, depending on your browser, you will be presented with different "
 "options. Select one that refers to your chosen security key and follow the "
 "instructions on the screen."
 msgstr ""

--- a/locale/es_MX/LC_MESSAGES/user-docs.po
+++ b/locale/es_MX/LC_MESSAGES/user-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-01 08:43+0200\n"
+"POT-Creation-Date: 2026-07-07 14:22+0200\n"
 "PO-Revision-Date: 2026-06-17 10:13+0000\n"
 "Last-Translator: Sebastian Diaz <sebdiazf@gmail.com>\n"
 "Language-Team: Spanish (Mexico) <https://translations.zammad.org/projects/"
@@ -1374,7 +1374,7 @@ msgstr ""
 msgid "**Paused, no action needed right now** (e.g. pending)"
 msgstr ""
 
-#: ../snippets/ticket-state-type-circles.rst:8 ../extras/knowledge-base.rst:204
+#: ../snippets/ticket-state-type-circles.rst:8 ../extras/knowledge-base.rst:221
 msgid "|grn|"
 msgstr ""
 
@@ -2444,6 +2444,7 @@ msgid ""
 msgstr ""
 
 #: ../basics/ticket-basics.rst:117 ../basics/zammad-glossary.rst:706
+#: ../extras/knowledge-base.rst:213
 msgid "Tags"
 msgstr ""
 
@@ -5717,7 +5718,7 @@ msgid ""
 msgstr ""
 
 #: ../extras/knowledge-base.rst:0
-msgid "Screenshot showing the modal for of the RSS button"
+msgid "Screenshot shows the modal for of the RSS button"
 msgstr ""
 
 #: ../extras/knowledge-base.rst:107
@@ -5729,7 +5730,7 @@ msgstr ""
 #: ../extras/knowledge-base.rst:110
 msgid ""
 "If you want to revoke the access and renew your token, you can do so in the "
-"RSS modal."
+"RSS dialog."
 msgstr ""
 
 #: ../extras/knowledge-base.rst:0
@@ -5787,9 +5788,7 @@ msgid ""
 msgstr ""
 
 #: ../extras/knowledge-base.rst:None
-msgid ""
-"Screencast showing the visibility option for categories for granular access "
-"permissions"
+msgid "Screenshot shows the granular category permissions for knowledge base"
 msgstr ""
 
 #: ../extras/knowledge-base.rst:153
@@ -5830,16 +5829,16 @@ msgid ""
 "The knowledge base editor comes equipped with the same **rich text editing "
 "capabilities** available in the Zammad ticket composer. That means you can "
 "use the same :doc:`keyboard shortcuts </advanced/keyboard-shortcuts>` to "
-"insert formatted text, bullet lists, and more. You can even add file "
+"insert formatted text, bullet lists and more. You can even add file "
 "attachments and links!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:196
+#: ../extras/knowledge-base.rst:213
 msgid "Different link types"
 msgstr ""
 
 #: ../extras/knowledge-base.rst:184
-msgid "**Web link**"
+msgid "Web link"
 msgstr ""
 
 #: ../extras/knowledge-base.rst:184
@@ -5847,7 +5846,7 @@ msgid "URLs pointing to other websites."
 msgstr ""
 
 #: ../extras/knowledge-base.rst:188
-msgid "**Link Answer**"
+msgid "Link Answer"
 msgstr ""
 
 #: ../extras/knowledge-base.rst:187
@@ -5857,62 +5856,91 @@ msgid ""
 msgstr ""
 
 #: ../extras/knowledge-base.rst:192
-msgid "**Linked Tickets**"
+msgid "Image"
 msgstr ""
 
 #: ../extras/knowledge-base.rst:191
+msgid ""
+"Include an image from your computer in the answer. Unlike file attachments, "
+"these images are embedded directly in the answer."
+msgstr ""
+
+#: ../extras/knowledge-base.rst:199
+msgid "Video"
+msgstr ""
+
+#: ../extras/knowledge-base.rst:195
+msgid ""
+"Include a video to embed in the answer. By default, you can embed videos "
+"from Vimeo and YouTube. Depending on your Zammad settings, MediaCMS and "
+"PeerTube instances can be enabled by your admin as well. A list of supported "
+"video services is displayed in the video dialog below the URL field."
+msgstr ""
+
+#: ../extras/knowledge-base.rst:203
+msgid "Linked Tickets"
+msgstr ""
+
+#: ../extras/knowledge-base.rst:202
 msgid ""
 "Internal references to Zammad tickets (visible only in preview and edit "
 "mode)."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:196
-msgid "**Tags**"
+#: ../extras/knowledge-base.rst:208
+msgid "Attachments"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:195
+#: ../extras/knowledge-base.rst:206
+msgid ""
+"Add any file as an attachment to your answer. Such an attachment isn't "
+"embedded in the body of the answer. Readers can download it by clicking on "
+"it in the attachment section."
+msgstr ""
+
+#: ../extras/knowledge-base.rst:211
 msgid ""
 "Can help to categorize or label answers for better search results. Please "
-"note that tags are visible publicly and can be the same like those in your "
+"note that tags are visible publicly and can be the same as those in your "
 "tickets."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:221
+#: ../extras/knowledge-base.rst:238
 msgid "Visibility"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:199
+#: ../extras/knowledge-base.rst:216
 msgid ""
 "Set the visibility of an answer to control who can see an article, or "
 "schedule it to be published at a later date. Articles are color-coded "
 "according to their visibility:"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:204
+#: ../extras/knowledge-base.rst:221
 msgid "**Public** (visible to everyone)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:206
+#: ../extras/knowledge-base.rst:223
 msgid "|blu|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:206
+#: ../extras/knowledge-base.rst:223
 msgid "**Internal** (visible to agents & editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:208
+#: ../extras/knowledge-base.rst:225
 msgid "|gry|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:208
+#: ../extras/knowledge-base.rst:225
 msgid "**Draft/Scheduled/Archived** (visible to editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:224
+#: ../extras/knowledge-base.rst:241
 msgid "Using Answers In Ticket Articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:226
+#: ../extras/knowledge-base.rst:243
 msgid ""
 "As soon as the knowledge base contains one or more answers, you can use "
 "these just like text modules. Instead of :kbd:`:`:kbd:`:` just use :kbd:`?"
@@ -7118,7 +7146,7 @@ msgstr ""
 
 #: ../extras/two-factor-authentication/security-keys-setup.rst:24
 msgid ""
-"Next, depending you your browser, you will be presented with different "
+"Next, depending on your browser, you will be presented with different "
 "options. Select one that refers to your chosen security key and follow the "
 "instructions on the screen."
 msgstr ""

--- a/locale/fa/LC_MESSAGES/user-docs.po
+++ b/locale/fa/LC_MESSAGES/user-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-01 08:43+0200\n"
+"POT-Creation-Date: 2026-07-07 14:22+0200\n"
 "PO-Revision-Date: 2026-06-17 10:15+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Persian <https://translations.zammad.org/projects/"
@@ -1365,7 +1365,7 @@ msgstr ""
 msgid "**Paused, no action needed right now** (e.g. pending)"
 msgstr ""
 
-#: ../snippets/ticket-state-type-circles.rst:8 ../extras/knowledge-base.rst:204
+#: ../snippets/ticket-state-type-circles.rst:8 ../extras/knowledge-base.rst:221
 msgid "|grn|"
 msgstr ""
 
@@ -2434,6 +2434,7 @@ msgid ""
 msgstr ""
 
 #: ../basics/ticket-basics.rst:117 ../basics/zammad-glossary.rst:706
+#: ../extras/knowledge-base.rst:213
 msgid "Tags"
 msgstr ""
 
@@ -5707,7 +5708,7 @@ msgid ""
 msgstr ""
 
 #: ../extras/knowledge-base.rst:0
-msgid "Screenshot showing the modal for of the RSS button"
+msgid "Screenshot shows the modal for of the RSS button"
 msgstr ""
 
 #: ../extras/knowledge-base.rst:107
@@ -5719,7 +5720,7 @@ msgstr ""
 #: ../extras/knowledge-base.rst:110
 msgid ""
 "If you want to revoke the access and renew your token, you can do so in the "
-"RSS modal."
+"RSS dialog."
 msgstr ""
 
 #: ../extras/knowledge-base.rst:0
@@ -5777,9 +5778,7 @@ msgid ""
 msgstr ""
 
 #: ../extras/knowledge-base.rst:None
-msgid ""
-"Screencast showing the visibility option for categories for granular access "
-"permissions"
+msgid "Screenshot shows the granular category permissions for knowledge base"
 msgstr ""
 
 #: ../extras/knowledge-base.rst:153
@@ -5820,16 +5819,16 @@ msgid ""
 "The knowledge base editor comes equipped with the same **rich text editing "
 "capabilities** available in the Zammad ticket composer. That means you can "
 "use the same :doc:`keyboard shortcuts </advanced/keyboard-shortcuts>` to "
-"insert formatted text, bullet lists, and more. You can even add file "
+"insert formatted text, bullet lists and more. You can even add file "
 "attachments and links!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:196
+#: ../extras/knowledge-base.rst:213
 msgid "Different link types"
 msgstr ""
 
 #: ../extras/knowledge-base.rst:184
-msgid "**Web link**"
+msgid "Web link"
 msgstr ""
 
 #: ../extras/knowledge-base.rst:184
@@ -5837,7 +5836,7 @@ msgid "URLs pointing to other websites."
 msgstr ""
 
 #: ../extras/knowledge-base.rst:188
-msgid "**Link Answer**"
+msgid "Link Answer"
 msgstr ""
 
 #: ../extras/knowledge-base.rst:187
@@ -5847,62 +5846,91 @@ msgid ""
 msgstr ""
 
 #: ../extras/knowledge-base.rst:192
-msgid "**Linked Tickets**"
+msgid "Image"
 msgstr ""
 
 #: ../extras/knowledge-base.rst:191
+msgid ""
+"Include an image from your computer in the answer. Unlike file attachments, "
+"these images are embedded directly in the answer."
+msgstr ""
+
+#: ../extras/knowledge-base.rst:199
+msgid "Video"
+msgstr ""
+
+#: ../extras/knowledge-base.rst:195
+msgid ""
+"Include a video to embed in the answer. By default, you can embed videos "
+"from Vimeo and YouTube. Depending on your Zammad settings, MediaCMS and "
+"PeerTube instances can be enabled by your admin as well. A list of supported "
+"video services is displayed in the video dialog below the URL field."
+msgstr ""
+
+#: ../extras/knowledge-base.rst:203
+msgid "Linked Tickets"
+msgstr ""
+
+#: ../extras/knowledge-base.rst:202
 msgid ""
 "Internal references to Zammad tickets (visible only in preview and edit "
 "mode)."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:196
-msgid "**Tags**"
+#: ../extras/knowledge-base.rst:208
+msgid "Attachments"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:195
+#: ../extras/knowledge-base.rst:206
+msgid ""
+"Add any file as an attachment to your answer. Such an attachment isn't "
+"embedded in the body of the answer. Readers can download it by clicking on "
+"it in the attachment section."
+msgstr ""
+
+#: ../extras/knowledge-base.rst:211
 msgid ""
 "Can help to categorize or label answers for better search results. Please "
-"note that tags are visible publicly and can be the same like those in your "
+"note that tags are visible publicly and can be the same as those in your "
 "tickets."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:221
+#: ../extras/knowledge-base.rst:238
 msgid "Visibility"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:199
+#: ../extras/knowledge-base.rst:216
 msgid ""
 "Set the visibility of an answer to control who can see an article, or "
 "schedule it to be published at a later date. Articles are color-coded "
 "according to their visibility:"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:204
+#: ../extras/knowledge-base.rst:221
 msgid "**Public** (visible to everyone)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:206
+#: ../extras/knowledge-base.rst:223
 msgid "|blu|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:206
+#: ../extras/knowledge-base.rst:223
 msgid "**Internal** (visible to agents & editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:208
+#: ../extras/knowledge-base.rst:225
 msgid "|gry|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:208
+#: ../extras/knowledge-base.rst:225
 msgid "**Draft/Scheduled/Archived** (visible to editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:224
+#: ../extras/knowledge-base.rst:241
 msgid "Using Answers In Ticket Articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:226
+#: ../extras/knowledge-base.rst:243
 msgid ""
 "As soon as the knowledge base contains one or more answers, you can use "
 "these just like text modules. Instead of :kbd:`:`:kbd:`:` just use :kbd:`?"
@@ -7108,7 +7136,7 @@ msgstr ""
 
 #: ../extras/two-factor-authentication/security-keys-setup.rst:24
 msgid ""
-"Next, depending you your browser, you will be presented with different "
+"Next, depending on your browser, you will be presented with different "
 "options. Select one that refers to your chosen security key and follow the "
 "instructions on the screen."
 msgstr ""

--- a/locale/fr/LC_MESSAGES/user-docs.po
+++ b/locale/fr/LC_MESSAGES/user-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-01 08:43+0200\n"
+"POT-Creation-Date: 2026-07-07 14:22+0200\n"
 "PO-Revision-Date: 2026-06-17 10:15+0000\n"
 "Last-Translator: Guy S <guy@bilog.fr>\n"
 "Language-Team: French <https://translations.zammad.org/projects/"
@@ -1549,7 +1549,7 @@ msgstr "|blk|"
 msgid "**Paused, no action needed right now** (e.g. pending)"
 msgstr ""
 
-#: ../snippets/ticket-state-type-circles.rst:8 ../extras/knowledge-base.rst:204
+#: ../snippets/ticket-state-type-circles.rst:8 ../extras/knowledge-base.rst:221
 msgid "|grn|"
 msgstr "|grn|"
 
@@ -2814,6 +2814,7 @@ msgid ""
 msgstr ""
 
 #: ../basics/ticket-basics.rst:117 ../basics/zammad-glossary.rst:706
+#: ../extras/knowledge-base.rst:213
 msgid "Tags"
 msgstr "Étiquettes"
 
@@ -6298,8 +6299,9 @@ msgid ""
 msgstr ""
 
 #: ../extras/knowledge-base.rst:0
-msgid "Screenshot showing the modal for of the RSS button"
-msgstr ""
+#, fuzzy
+msgid "Screenshot shows the modal for of the RSS button"
+msgstr "Capture d'écran montrant le temps compté dans un panneau de ticket"
 
 #: ../extras/knowledge-base.rst:107
 msgid ""
@@ -6310,7 +6312,7 @@ msgstr ""
 #: ../extras/knowledge-base.rst:110
 msgid ""
 "If you want to revoke the access and renew your token, you can do so in the "
-"RSS modal."
+"RSS dialog."
 msgstr ""
 
 #: ../extras/knowledge-base.rst:0
@@ -6374,9 +6376,7 @@ msgid ""
 msgstr ""
 
 #: ../extras/knowledge-base.rst:None
-msgid ""
-"Screencast showing the visibility option for categories for granular access "
-"permissions"
+msgid "Screenshot shows the granular category permissions for knowledge base"
 msgstr ""
 
 #: ../extras/knowledge-base.rst:153
@@ -6413,11 +6413,18 @@ msgid "Edit answer"
 msgstr ""
 
 #: ../extras/knowledge-base.rst:176
+#, fuzzy
+#| msgid ""
+#| "The knowledge base editor comes equipped with the same **rich text "
+#| "editing capabilities** available in the Zammad ticket composer. That "
+#| "means you can use the same :doc:`keyboard shortcuts </advanced/keyboard-"
+#| "shortcuts>` to insert formatted text, bullet lists, and more. You can "
+#| "even add file attachments and links!"
 msgid ""
 "The knowledge base editor comes equipped with the same **rich text editing "
 "capabilities** available in the Zammad ticket composer. That means you can "
 "use the same :doc:`keyboard shortcuts </advanced/keyboard-shortcuts>` to "
-"insert formatted text, bullet lists, and more. You can even add file "
+"insert formatted text, bullet lists and more. You can even add file "
 "attachments and links!"
 msgstr ""
 "L'éditeur de la base de connaissance dispose des mêmes **capacités d'édition "
@@ -6426,14 +6433,14 @@ msgstr ""
 "shortcuts>` pour insérer du texte formaté, des listes à puce, et plus "
 "encore. Vous pouvez même ajouter des pièces jointes et des liens !"
 
-#: ../extras/knowledge-base.rst:196
+#: ../extras/knowledge-base.rst:213
 msgid "Different link types"
 msgstr ""
 
 #: ../extras/knowledge-base.rst:184
 #, fuzzy
 #| msgid "🔗 **Weblink**"
-msgid "**Web link**"
+msgid "Web link"
 msgstr "🔗 **liens web**"
 
 #: ../extras/knowledge-base.rst:184
@@ -6443,7 +6450,7 @@ msgstr "URLs qui pointent vers d'autres sites web."
 #: ../extras/knowledge-base.rst:188
 #, fuzzy
 #| msgid "💡 **Link Answer**"
-msgid "**Link Answer**"
+msgid "Link Answer"
 msgstr "💡 **Lien réponse**"
 
 #: ../extras/knowledge-base.rst:187
@@ -6454,36 +6461,63 @@ msgid ""
 msgstr "Références internes vers d'autres réponses de la base de connaissance."
 
 #: ../extras/knowledge-base.rst:192
-#, fuzzy
-#| msgid "📋 **Linked Tickets**"
-msgid "**Linked Tickets**"
-msgstr "📋 **Tickets liés**"
+msgid "Image"
+msgstr ""
 
 #: ../extras/knowledge-base.rst:191
+msgid ""
+"Include an image from your computer in the answer. Unlike file attachments, "
+"these images are embedded directly in the answer."
+msgstr ""
+
+#: ../extras/knowledge-base.rst:199
+msgid "Video"
+msgstr ""
+
+#: ../extras/knowledge-base.rst:195
+msgid ""
+"Include a video to embed in the answer. By default, you can embed videos "
+"from Vimeo and YouTube. Depending on your Zammad settings, MediaCMS and "
+"PeerTube instances can be enabled by your admin as well. A list of supported "
+"video services is displayed in the video dialog below the URL field."
+msgstr ""
+
+#: ../extras/knowledge-base.rst:203
+#, fuzzy
+#| msgid "Linking Tickets"
+msgid "Linked Tickets"
+msgstr "Lier des tickets"
+
+#: ../extras/knowledge-base.rst:202
 #, fuzzy
 msgid ""
 "Internal references to Zammad tickets (visible only in preview and edit "
 "mode)."
 msgstr "Références internes vers des tickets Zammad."
 
-#: ../extras/knowledge-base.rst:196
-#, fuzzy
-#| msgid "Tags"
-msgid "**Tags**"
-msgstr "Étiquettes"
+#: ../extras/knowledge-base.rst:208
+msgid "Attachments"
+msgstr ""
 
-#: ../extras/knowledge-base.rst:195
+#: ../extras/knowledge-base.rst:206
+msgid ""
+"Add any file as an attachment to your answer. Such an attachment isn't "
+"embedded in the body of the answer. Readers can download it by clicking on "
+"it in the attachment section."
+msgstr ""
+
+#: ../extras/knowledge-base.rst:211
 msgid ""
 "Can help to categorize or label answers for better search results. Please "
-"note that tags are visible publicly and can be the same like those in your "
+"note that tags are visible publicly and can be the same as those in your "
 "tickets."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:221
+#: ../extras/knowledge-base.rst:238
 msgid "Visibility"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:199
+#: ../extras/knowledge-base.rst:216
 #, fuzzy
 msgid ""
 "Set the visibility of an answer to control who can see an article, or "
@@ -6494,31 +6528,31 @@ msgstr ""
 "article ou planifier sa publication à une date ultérieure. Les articles ont "
 "des **codes couleurs** en fonction de leur visibilité :"
 
-#: ../extras/knowledge-base.rst:204
+#: ../extras/knowledge-base.rst:221
 msgid "**Public** (visible to everyone)"
 msgstr "**Public** (visible pour tout le monde)"
 
-#: ../extras/knowledge-base.rst:206
+#: ../extras/knowledge-base.rst:223
 msgid "|blu|"
 msgstr "|blu|"
 
-#: ../extras/knowledge-base.rst:206
+#: ../extras/knowledge-base.rst:223
 msgid "**Internal** (visible to agents & editors only)"
 msgstr "**Interne** (visible seulement pour les opérateurs & rédacteurs)"
 
-#: ../extras/knowledge-base.rst:208
+#: ../extras/knowledge-base.rst:225
 msgid "|gry|"
 msgstr "|gry|"
 
-#: ../extras/knowledge-base.rst:208
+#: ../extras/knowledge-base.rst:225
 msgid "**Draft/Scheduled/Archived** (visible to editors only)"
 msgstr "**Brouillon/planifié/archivé** (visible seulement pour les rédacteurs)"
 
-#: ../extras/knowledge-base.rst:224
+#: ../extras/knowledge-base.rst:241
 msgid "Using Answers In Ticket Articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:226
+#: ../extras/knowledge-base.rst:243
 msgid ""
 "As soon as the knowledge base contains one or more answers, you can use "
 "these just like text modules. Instead of :kbd:`:`:kbd:`:` just use :kbd:`?"
@@ -7781,7 +7815,7 @@ msgstr ""
 
 #: ../extras/two-factor-authentication/security-keys-setup.rst:24
 msgid ""
-"Next, depending you your browser, you will be presented with different "
+"Next, depending on your browser, you will be presented with different "
 "options. Select one that refers to your chosen security key and follow the "
 "instructions on the screen."
 msgstr ""
@@ -8254,6 +8288,16 @@ msgid ""
 "also :docs:`system </index.html>` and :admin-docs:`administration manuals </"
 "index.html>` available."
 msgstr ""
+
+#, fuzzy
+#~| msgid "📋 **Linked Tickets**"
+#~ msgid "**Linked Tickets**"
+#~ msgstr "📋 **Tickets liés**"
+
+#, fuzzy
+#~| msgid "Tags"
+#~ msgid "**Tags**"
+#~ msgstr "Étiquettes"
 
 #, fuzzy
 #~| msgid "Split ticket dialog"

--- a/locale/fr_CA/LC_MESSAGES/user-docs.po
+++ b/locale/fr_CA/LC_MESSAGES/user-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-01 08:43+0200\n"
+"POT-Creation-Date: 2026-07-07 14:22+0200\n"
 "PO-Revision-Date: 2026-06-17 10:16+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: French (Canada) <https://translations.zammad.org/projects/"
@@ -1468,7 +1468,7 @@ msgstr "|blk|"
 msgid "**Paused, no action needed right now** (e.g. pending)"
 msgstr ""
 
-#: ../snippets/ticket-state-type-circles.rst:8 ../extras/knowledge-base.rst:204
+#: ../snippets/ticket-state-type-circles.rst:8 ../extras/knowledge-base.rst:221
 msgid "|grn|"
 msgstr "|grn|"
 
@@ -2606,6 +2606,7 @@ msgid ""
 msgstr ""
 
 #: ../basics/ticket-basics.rst:117 ../basics/zammad-glossary.rst:706
+#: ../extras/knowledge-base.rst:213
 msgid "Tags"
 msgstr ""
 
@@ -5913,8 +5914,9 @@ msgid ""
 msgstr ""
 
 #: ../extras/knowledge-base.rst:0
-msgid "Screenshot showing the modal for of the RSS button"
-msgstr ""
+#, fuzzy
+msgid "Screenshot shows the modal for of the RSS button"
+msgstr "Nouveaux billets"
 
 #: ../extras/knowledge-base.rst:107
 msgid ""
@@ -5925,7 +5927,7 @@ msgstr ""
 #: ../extras/knowledge-base.rst:110
 msgid ""
 "If you want to revoke the access and renew your token, you can do so in the "
-"RSS modal."
+"RSS dialog."
 msgstr ""
 
 #: ../extras/knowledge-base.rst:0
@@ -5983,9 +5985,7 @@ msgid ""
 msgstr ""
 
 #: ../extras/knowledge-base.rst:None
-msgid ""
-"Screencast showing the visibility option for categories for granular access "
-"permissions"
+msgid "Screenshot shows the granular category permissions for knowledge base"
 msgstr ""
 
 #: ../extras/knowledge-base.rst:153
@@ -6026,16 +6026,16 @@ msgid ""
 "The knowledge base editor comes equipped with the same **rich text editing "
 "capabilities** available in the Zammad ticket composer. That means you can "
 "use the same :doc:`keyboard shortcuts </advanced/keyboard-shortcuts>` to "
-"insert formatted text, bullet lists, and more. You can even add file "
+"insert formatted text, bullet lists and more. You can even add file "
 "attachments and links!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:196
+#: ../extras/knowledge-base.rst:213
 msgid "Different link types"
 msgstr ""
 
 #: ../extras/knowledge-base.rst:184
-msgid "**Web link**"
+msgid "Web link"
 msgstr ""
 
 #: ../extras/knowledge-base.rst:184
@@ -6043,7 +6043,7 @@ msgid "URLs pointing to other websites."
 msgstr ""
 
 #: ../extras/knowledge-base.rst:188
-msgid "**Link Answer**"
+msgid "Link Answer"
 msgstr ""
 
 #: ../extras/knowledge-base.rst:187
@@ -6053,63 +6053,93 @@ msgid ""
 msgstr ""
 
 #: ../extras/knowledge-base.rst:192
-#, fuzzy
-msgid "**Linked Tickets**"
-msgstr "Trouver des billets"
+msgid "Image"
+msgstr ""
 
 #: ../extras/knowledge-base.rst:191
+msgid ""
+"Include an image from your computer in the answer. Unlike file attachments, "
+"these images are embedded directly in the answer."
+msgstr ""
+
+#: ../extras/knowledge-base.rst:199
+msgid "Video"
+msgstr ""
+
+#: ../extras/knowledge-base.rst:195
+msgid ""
+"Include a video to embed in the answer. By default, you can embed videos "
+"from Vimeo and YouTube. Depending on your Zammad settings, MediaCMS and "
+"PeerTube instances can be enabled by your admin as well. A list of supported "
+"video services is displayed in the video dialog below the URL field."
+msgstr ""
+
+#: ../extras/knowledge-base.rst:203
+#, fuzzy
+#| msgid "Linking Tickets"
+msgid "Linked Tickets"
+msgstr "Lier des billets"
+
+#: ../extras/knowledge-base.rst:202
 msgid ""
 "Internal references to Zammad tickets (visible only in preview and edit "
 "mode)."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:196
-msgid "**Tags**"
+#: ../extras/knowledge-base.rst:208
+msgid "Attachments"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:195
+#: ../extras/knowledge-base.rst:206
+msgid ""
+"Add any file as an attachment to your answer. Such an attachment isn't "
+"embedded in the body of the answer. Readers can download it by clicking on "
+"it in the attachment section."
+msgstr ""
+
+#: ../extras/knowledge-base.rst:211
 msgid ""
 "Can help to categorize or label answers for better search results. Please "
-"note that tags are visible publicly and can be the same like those in your "
+"note that tags are visible publicly and can be the same as those in your "
 "tickets."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:221
+#: ../extras/knowledge-base.rst:238
 msgid "Visibility"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:199
+#: ../extras/knowledge-base.rst:216
 msgid ""
 "Set the visibility of an answer to control who can see an article, or "
 "schedule it to be published at a later date. Articles are color-coded "
 "according to their visibility:"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:204
+#: ../extras/knowledge-base.rst:221
 msgid "**Public** (visible to everyone)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:206
+#: ../extras/knowledge-base.rst:223
 msgid "|blu|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:206
+#: ../extras/knowledge-base.rst:223
 msgid "**Internal** (visible to agents & editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:208
+#: ../extras/knowledge-base.rst:225
 msgid "|gry|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:208
+#: ../extras/knowledge-base.rst:225
 msgid "**Draft/Scheduled/Archived** (visible to editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:224
+#: ../extras/knowledge-base.rst:241
 msgid "Using Answers In Ticket Articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:226
+#: ../extras/knowledge-base.rst:243
 msgid ""
 "As soon as the knowledge base contains one or more answers, you can use "
 "these just like text modules. Instead of :kbd:`:`:kbd:`:` just use :kbd:`?"
@@ -7336,7 +7366,7 @@ msgstr ""
 
 #: ../extras/two-factor-authentication/security-keys-setup.rst:24
 msgid ""
-"Next, depending you your browser, you will be presented with different "
+"Next, depending on your browser, you will be presented with different "
 "options. Select one that refers to your chosen security key and follow the "
 "instructions on the screen."
 msgstr ""
@@ -7757,6 +7787,10 @@ msgid ""
 "also :docs:`system </index.html>` and :admin-docs:`administration manuals </"
 "index.html>` available."
 msgstr ""
+
+#, fuzzy
+#~ msgid "**Linked Tickets**"
+#~ msgstr "Trouver des billets"
 
 #, fuzzy
 #~ msgid "Split ticket button"

--- a/locale/hr/LC_MESSAGES/user-docs.po
+++ b/locale/hr/LC_MESSAGES/user-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-01 08:43+0200\n"
+"POT-Creation-Date: 2026-07-07 14:22+0200\n"
 "PO-Revision-Date: 2026-06-17 10:19+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Croatian <https://translations.zammad.org/projects/"
@@ -1459,7 +1459,7 @@ msgstr ""
 msgid "**Paused, no action needed right now** (e.g. pending)"
 msgstr ""
 
-#: ../snippets/ticket-state-type-circles.rst:8 ../extras/knowledge-base.rst:204
+#: ../snippets/ticket-state-type-circles.rst:8 ../extras/knowledge-base.rst:221
 msgid "|grn|"
 msgstr ""
 
@@ -2545,6 +2545,7 @@ msgid ""
 msgstr ""
 
 #: ../basics/ticket-basics.rst:117 ../basics/zammad-glossary.rst:706
+#: ../extras/knowledge-base.rst:213
 msgid "Tags"
 msgstr ""
 
@@ -5841,8 +5842,9 @@ msgid ""
 msgstr ""
 
 #: ../extras/knowledge-base.rst:0
-msgid "Screenshot showing the modal for of the RSS button"
-msgstr ""
+#, fuzzy
+msgid "Screenshot shows the modal for of the RSS button"
+msgstr "Screencast pokazuje kako izvršiti makro-naredbu u ticketu."
 
 #: ../extras/knowledge-base.rst:107
 msgid ""
@@ -5853,7 +5855,7 @@ msgstr ""
 #: ../extras/knowledge-base.rst:110
 msgid ""
 "If you want to revoke the access and renew your token, you can do so in the "
-"RSS modal."
+"RSS dialog."
 msgstr ""
 
 #: ../extras/knowledge-base.rst:0
@@ -5911,9 +5913,7 @@ msgid ""
 msgstr ""
 
 #: ../extras/knowledge-base.rst:None
-msgid ""
-"Screencast showing the visibility option for categories for granular access "
-"permissions"
+msgid "Screenshot shows the granular category permissions for knowledge base"
 msgstr ""
 
 #: ../extras/knowledge-base.rst:153
@@ -5954,16 +5954,16 @@ msgid ""
 "The knowledge base editor comes equipped with the same **rich text editing "
 "capabilities** available in the Zammad ticket composer. That means you can "
 "use the same :doc:`keyboard shortcuts </advanced/keyboard-shortcuts>` to "
-"insert formatted text, bullet lists, and more. You can even add file "
+"insert formatted text, bullet lists and more. You can even add file "
 "attachments and links!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:196
+#: ../extras/knowledge-base.rst:213
 msgid "Different link types"
 msgstr ""
 
 #: ../extras/knowledge-base.rst:184
-msgid "**Web link**"
+msgid "Web link"
 msgstr ""
 
 #: ../extras/knowledge-base.rst:184
@@ -5971,7 +5971,7 @@ msgid "URLs pointing to other websites."
 msgstr ""
 
 #: ../extras/knowledge-base.rst:188
-msgid "**Link Answer**"
+msgid "Link Answer"
 msgstr ""
 
 #: ../extras/knowledge-base.rst:187
@@ -5981,63 +5981,92 @@ msgid ""
 msgstr ""
 
 #: ../extras/knowledge-base.rst:192
-#, fuzzy
-msgid "**Linked Tickets**"
-msgstr "Makro-naredbe"
+msgid "Image"
+msgstr ""
 
 #: ../extras/knowledge-base.rst:191
+msgid ""
+"Include an image from your computer in the answer. Unlike file attachments, "
+"these images are embedded directly in the answer."
+msgstr ""
+
+#: ../extras/knowledge-base.rst:199
+msgid "Video"
+msgstr ""
+
+#: ../extras/knowledge-base.rst:195
+msgid ""
+"Include a video to embed in the answer. By default, you can embed videos "
+"from Vimeo and YouTube. Depending on your Zammad settings, MediaCMS and "
+"PeerTube instances can be enabled by your admin as well. A list of supported "
+"video services is displayed in the video dialog below the URL field."
+msgstr ""
+
+#: ../extras/knowledge-base.rst:203
+#, fuzzy
+msgid "Linked Tickets"
+msgstr "Makro-naredbe"
+
+#: ../extras/knowledge-base.rst:202
 msgid ""
 "Internal references to Zammad tickets (visible only in preview and edit "
 "mode)."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:196
-msgid "**Tags**"
+#: ../extras/knowledge-base.rst:208
+msgid "Attachments"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:195
+#: ../extras/knowledge-base.rst:206
+msgid ""
+"Add any file as an attachment to your answer. Such an attachment isn't "
+"embedded in the body of the answer. Readers can download it by clicking on "
+"it in the attachment section."
+msgstr ""
+
+#: ../extras/knowledge-base.rst:211
 msgid ""
 "Can help to categorize or label answers for better search results. Please "
-"note that tags are visible publicly and can be the same like those in your "
+"note that tags are visible publicly and can be the same as those in your "
 "tickets."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:221
+#: ../extras/knowledge-base.rst:238
 msgid "Visibility"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:199
+#: ../extras/knowledge-base.rst:216
 msgid ""
 "Set the visibility of an answer to control who can see an article, or "
 "schedule it to be published at a later date. Articles are color-coded "
 "according to their visibility:"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:204
+#: ../extras/knowledge-base.rst:221
 msgid "**Public** (visible to everyone)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:206
+#: ../extras/knowledge-base.rst:223
 msgid "|blu|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:206
+#: ../extras/knowledge-base.rst:223
 msgid "**Internal** (visible to agents & editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:208
+#: ../extras/knowledge-base.rst:225
 msgid "|gry|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:208
+#: ../extras/knowledge-base.rst:225
 msgid "**Draft/Scheduled/Archived** (visible to editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:224
+#: ../extras/knowledge-base.rst:241
 msgid "Using Answers In Ticket Articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:226
+#: ../extras/knowledge-base.rst:243
 msgid ""
 "As soon as the knowledge base contains one or more answers, you can use "
 "these just like text modules. Instead of :kbd:`:`:kbd:`:` just use :kbd:`?"
@@ -7257,7 +7286,7 @@ msgstr ""
 
 #: ../extras/two-factor-authentication/security-keys-setup.rst:24
 msgid ""
-"Next, depending you your browser, you will be presented with different "
+"Next, depending on your browser, you will be presented with different "
 "options. Select one that refers to your chosen security key and follow the "
 "instructions on the screen."
 msgstr ""
@@ -7678,6 +7707,10 @@ msgid ""
 "also :docs:`system </index.html>` and :admin-docs:`administration manuals </"
 "index.html>` available."
 msgstr ""
+
+#, fuzzy
+#~ msgid "**Linked Tickets**"
+#~ msgstr "Makro-naredbe"
 
 #, fuzzy
 #~ msgid "Split ticket button"

--- a/locale/hu/LC_MESSAGES/user-docs.po
+++ b/locale/hu/LC_MESSAGES/user-docs.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-01 08:43+0200\n"
-"PO-Revision-Date: 2026-07-02 16:02+0000\n"
+"POT-Creation-Date: 2026-07-07 14:22+0200\n"
+"PO-Revision-Date: 2026-07-08 05:07+0000\n"
 "Last-Translator: Balázs Úr <balazs@urbalazs.hu>\n"
 "Language-Team: Hungarian <https://translations.zammad.org/projects/"
 "documentations/user-documentation-pre-release/hu/>\n"
@@ -581,8 +581,8 @@ msgid ""
 "and :kbd:`ctrl` :kbd:`option` instead of :kbd:`shift` :kbd:`ctrl`."
 msgstr ""
 "Ha Ön Mac felhasználó, akkor használja a :kbd:`cmd` billentyűt a :kbd:`ctrl` "
-"billentyű helyett és a :kbd:`ctrl` :kbd:`option` billentyűkombinációt a "
-":kbd:`shift` :kbd:`ctrl` billentyűkombináció helyett."
+"billentyű helyett és a :kbd:`ctrl` :kbd:`option` billentyűkombinációt "
+"a :kbd:`shift` :kbd:`ctrl` billentyűkombináció helyett."
 
 #: ../advanced/macros.rst:2
 msgid "Macros"
@@ -604,9 +604,9 @@ msgstr ""
 "kattintással alkalmazhat. Például a Zammad alapértelmezetten biztosít egy "
 "**Lezárás és levélszemétként címkézés** makrót. Ha alkalmazásra kerül, akkor "
 "a makrót futtató felhasználó tulajdonosként lesz hozzárendelve, egy "
-"``levélszemét`` címke lesz hozzáadva, és a jegy lezárásra kerül. Még egy "
-":ref:`MI-ügyintéző <ai-agents>` futtatása is lehetséges egy makróban igény "
-"szerint. Olvasson tovább, hogy megtudja, hogyan futtathat makrókat két "
+"``levélszemét`` címke lesz hozzáadva, és a jegy lezárásra kerül. Még "
+"egy :ref:`MI-ügyintéző <ai-agents>` futtatása is lehetséges egy makróban "
+"igény szerint. Olvasson tovább, hogy megtudja, hogyan futtathat makrókat két "
 "különböző módon."
 
 #: ../advanced/macros.rst:13
@@ -657,7 +657,8 @@ msgstr "Válassza ki a kívánt jegyeket"
 
 #: ../advanced/macros.rst:35
 msgid "Drag the tickets to the top and hover over the ``Run Macro`` action"
-msgstr "Húzza a jegyeket felülre, majd húzza rá a ``Makró futtatása`` műveletre"
+msgstr ""
+"Húzza a jegyeket felülre, majd húzza rá a ``Makró futtatása`` műveletre"
 
 #: ../advanced/macros.rst:36
 msgid "Drop the tickets on your target macro."
@@ -863,8 +864,8 @@ msgid ""
 "article_count:5 |br|\\ article_count: [5 TO 10] |br|\\ article_count:[5 TO "
 "\\*] |br|\\ article_count:[\\* TO 5]"
 msgstr ""
-"article_count:5 |br|\\ article_count: [5 TO 10] |br|\\ article_count:[5 TO \\"
-"*] |br|\\ article_count:[\\* TO 5]"
+"article_count:5 |br|\\ article_count: [5 TO 10] |br|\\ article_count:[5 TO "
+"\\*] |br|\\ article_count:[\\* TO 5]"
 
 #: ../advanced/search.rst:1
 msgid ""
@@ -907,8 +908,8 @@ msgid ""
 "article.body:heat |br|\\ article.body:heat~ |br|\\ articlebody:/joh?"
 "n(ath[oa]n)/"
 msgstr ""
-"article.body:heat |br|\\ article.body:heat~ |br|\\ articlebody:/joh?n"
-"(ath[oa]n)/"
+"article.body:heat |br|\\ article.body:heat~ |br|\\ articlebody:/joh?"
+"n(ath[oa]n)/"
 
 #: ../advanced/search.rst:1
 msgid ""
@@ -1220,8 +1221,8 @@ msgid ""
 "in two </advanced/ticket-actions/split>`, then assign each ticket to its "
 "respective “group” (department)."
 msgstr ""
-"Ha egy jegy valójában két különböző problémát érint, akkor "
-":doc:`feloszthatja két részre </advanced/ticket-actions/split>`, majd "
+"Ha egy jegy valójában két különböző problémát érint, "
+"akkor :doc:`feloszthatja két részre </advanced/ticket-actions/split>`, majd "
 "mindkét jegyet a megfelelő „csoporthoz” (osztályhoz) rendelheti."
 
 #: ../advanced/suggested-workflows.rst:16
@@ -1586,7 +1587,7 @@ msgstr ""
 "**Szüneteltetve, jelenleg nincs szükség intézkedésre** (például "
 "felfüggesztve)"
 
-#: ../snippets/ticket-state-type-circles.rst:8 ../extras/knowledge-base.rst:204
+#: ../snippets/ticket-state-type-circles.rst:8 ../extras/knowledge-base.rst:221
 msgid "|grn|"
 msgstr "|grn|"
 
@@ -1787,8 +1788,8 @@ msgid ""
 "You can use text modules on ticket creation as well. On ticket creation, "
 "our :ref:`ticket_templates` might get handy too."
 msgstr ""
-"Szövegmodulokat a jegy létrehozásakor is használhat. A jegy létrehozásakor a "
-":ref:`ticket_templates` is hasznosak lehetnek."
+"Szövegmodulokat a jegy létrehozásakor is használhat. A jegy létrehozásakor "
+"a :ref:`ticket_templates` is hasznosak lehetnek."
 
 #: ../advanced/text-modules.rst:36
 msgid "Customizing Text Modules"
@@ -1828,9 +1829,9 @@ msgid ""
 msgstr ""
 "Ha kapcsolódó ügyekkel kapcsolatos jegyek merülnek fel, akkor azok egymáshoz "
 "kapcsolhatók az egyszerűbb hivatkozáshoz. Ez például akkor lehet hasznos, ha "
-"több ügyfélpanasz érkezik ugyanazon szállítmánnyal kapcsolatban. Az "
-":doc:`egyesített <merge>` és :doc:`felosztott <split>` jegyek automatikusan "
-"összekapcsolásra kerülnek."
+"több ügyfélpanasz érkezik ugyanazon szállítmánnyal kapcsolatban. "
+"Az :doc:`egyesített <merge>` és :doc:`felosztott <split>` jegyek "
+"automatikusan összekapcsolásra kerülnek."
 
 #: ../advanced/ticket-actions/link.rst:16
 msgid "Link types"
@@ -2068,8 +2069,8 @@ msgid ""
 "Screenshot shows \"split\" button in the ticket detail view next to an "
 "article"
 msgstr ""
-"A képernyőkép a jegy részletes nézetében egy bejegyzés mellett lévő „"
-"felosztás” gombot jeleníti meg"
+"A képernyőkép a jegy részletes nézetében egy bejegyzés mellett lévő "
+"„felosztás” gombot jeleníti meg"
 
 #: ../advanced/ticket-actions/split.rst:15
 msgid ""
@@ -2478,8 +2479,8 @@ msgid ""
 "basics` yet, check it out to learn more."
 msgstr ""
 "Mint azt talán tudja, vannak további beállítható jegyattribútumok is, mint "
-"például csoport, prioritás és tulajdonos. Ha még nem olvasta el a "
-":doc:`ticket-basics` fejezetet, akkor olvassa el, hogy többet tudjon meg "
+"például csoport, prioritás és tulajdonos. Ha még nem olvasta el "
+"a :doc:`ticket-basics` fejezetet, akkor olvassa el, hogy többet tudjon meg "
 "erről."
 
 #: ../basics/create-tickets.rst:84
@@ -2624,8 +2625,8 @@ msgid ""
 "If you spot a circle with a blue/pink gradient, it indicates that "
 "an :doc:`AI agent </extras/ai-features>` is currently working on the ticket."
 msgstr ""
-"Ha kék-rózsaszín színátmenetes kört lát, az azt jelzi, hogy jelenleg egy "
-":doc:`MI-ügyintéző </extras/ai-features>` dolgozik az jegyen."
+"Ha kék-rózsaszín színátmenetes kört lát, az azt jelzi, hogy jelenleg "
+"egy :doc:`MI-ügyintéző </extras/ai-features>` dolgozik az jegyen."
 
 #: ../basics/find-tickets.rst:57
 msgid ""
@@ -2650,8 +2651,8 @@ msgid ""
 "keyboard shortcut :kbd:`s`."
 msgstr ""
 "Ha egy bizonyos jegyet keres, akkor használhatja a keresőt. Kattintson a bal "
-"oldali navigációs oldalsáv tetején lévő keresősávra, vagy használja az "
-":kbd:`s` gyorsbillentyűt."
+"oldali navigációs oldalsáv tetején lévő keresősávra, vagy használja "
+"az :kbd:`s` gyorsbillentyűt."
 
 #: ../basics/find-tickets.rst:None
 msgid ""
@@ -2730,14 +2731,14 @@ msgid ""
 "learn how to search for specific attributes like creation date or the ticket "
 "owner's email address."
 msgstr ""
-"A keresést úgy szűkítheti, hogy kiválaszt egy adott objektumtípust (például „"
-"Felhasználó”) a keresősáv alatti lapsávon. A találatok oszlopértékek alapján "
-"történő rendezéséhez kattintson egy oszlopfejlécre. A rendezést egy nyíl "
-"jelzi. Kattintson újra az oszlopra, hogy megváltoztassa a rendezés irányát "
-"növekvőről csökkenőre vagy fordítva. Ha még mindig nem találja, amit keres, "
-"akkor nézze meg a :doc:`speciális keresés oldalt </advanced/search>`, ahol "
-"megtudhatja, hogyan kell bizonyos attribútumokra keresni, mint például a "
-"létrehozás dátumára vagy a jegy tulajdonosának e-mail-címére."
+"A keresést úgy szűkítheti, hogy kiválaszt egy adott objektumtípust (például "
+"„Felhasználó”) a keresősáv alatti lapsávon. A találatok oszlopértékek "
+"alapján történő rendezéséhez kattintson egy oszlopfejlécre. A rendezést egy "
+"nyíl jelzi. Kattintson újra az oszlopra, hogy megváltoztassa a rendezés "
+"irányát növekvőről csökkenőre vagy fordítva. Ha még mindig nem találja, amit "
+"keres, akkor nézze meg a :doc:`speciális keresés oldalt </advanced/search>`, "
+"ahol megtudhatja, hogyan kell bizonyos attribútumokra keresni, mint például "
+"a létrehozás dátumára vagy a jegy tulajdonosának e-mail-címére."
 
 #: ../basics/find-tickets.rst:113
 msgid ""
@@ -2985,10 +2986,11 @@ msgid ""
 "coded:"
 msgstr ""
 "Abban az esetben, ha ezek a prioritások nem lennének elegendőek, kérje meg a "
-"Zammad adminisztrátorát, hogy hozzon létre továbbiakat. Az adminisztrátorok "
-":admin-docs:`itt találhatnak </system/objects.html#ticket-priority>` további "
-"információkat. Az alapértelmezett prioritások lehetővé teszik, hogy azonnal "
-"felismerje a jegyek fontosságát, mivel azok színkóddal vannak jelölve:"
+"Zammad adminisztrátorát, hogy hozzon létre továbbiakat. Az "
+"adminisztrátorok :admin-docs:`itt találhatnak </system/objects.html#ticket-"
+"priority>` további információkat. Az alapértelmezett prioritások lehetővé "
+"teszik, hogy azonnal felismerje a jegyek fontosságát, mivel azok színkóddal "
+"vannak jelölve:"
 
 #: ../basics/ticket-basics.rst:108
 msgid ""
@@ -3013,6 +3015,7 @@ msgstr ""
 "állítanák be, és azonnali eszkalációban bíznának."
 
 #: ../basics/ticket-basics.rst:117 ../basics/zammad-glossary.rst:706
+#: ../extras/knowledge-base.rst:213
 msgid "Tags"
 msgstr "Címkék"
 
@@ -3093,9 +3096,9 @@ msgid ""
 "Now that you know the basics, check how to :doc:`create <create-tickets>` "
 "or :doc:`work with <work-with-tickets>` tickets."
 msgstr ""
-"Most, hogy már tudja az alapokat, olvassa el, hogyan kell jegyeket "
-":doc:`létrehozni <create-tickets>` vagy :doc:`dolgozni velük <work-with-"
-"tickets>`."
+"Most, hogy már tudja az alapokat, olvassa el, hogyan kell "
+"jegyeket :doc:`létrehozni <create-tickets>` vagy :doc:`dolgozni velük <work-"
+"with-tickets>`."
 
 #: ../basics/work-with-tickets.rst:2
 msgid "Work with Tickets"
@@ -3407,11 +3410,11 @@ msgid ""
 "to your clipboard. To include the ticket title as well, press :kbd:`.` "
 "twice. Example: ``Ticket#50071: Coffee grinder broken``."
 msgstr ""
-"De várjon csak, erre még :doc:`gyorsbillentyű </advanced/keyboard-shortcuts>"
-"` is van! Egyszerűen nyomja meg a :kbd:`.` billentyűt, és a jegyszám a "
-"vágólapra lesz másolva. Ahhoz, hogy a jegy címét is tartalmazza, nyomja meg "
-"a :kbd:`.` billentyűt kétszer. Példa: ``Jegy#50071: Meghibásodott a "
-"kávédaráló``."
+"De várjon csak, erre még :doc:`gyorsbillentyű </advanced/keyboard-"
+"shortcuts>` is van! Egyszerűen nyomja meg a :kbd:`.` billentyűt, és a "
+"jegyszám a vágólapra lesz másolva. Ahhoz, hogy a jegy címét is tartalmazza, "
+"nyomja meg a :kbd:`.` billentyűt kétszer. Példa: ``Jegy#50071: Meghibásodott "
+"a kávédaráló``."
 
 #: ../basics/work-with-tickets.rst:167
 msgid "Simultaneous Ticket Processing"
@@ -3543,8 +3546,8 @@ msgid ""
 msgstr ""
 "A Zammad alapértelmezetten értesíti Önt, ha a jegyek megközelítik vagy "
 "túllépik a határidőket. Ezeket az értesítéseket a :doc:`profilbeállításokban "
-"</extras/user-menu-profile-settings>` állíthatja be. A Zammad emellett egy „"
-"Eszkalált jegyek” nevű alapértelmezett áttekintést is biztosít. Ez az "
+"</extras/user-menu-profile-settings>` állíthatja be. A Zammad emellett egy "
+"„Eszkalált jegyek” nevű alapértelmezett áttekintést is biztosít. Ez az "
 "áttekintés tartalmazza a már eszkalált jegyeket, valamint azokat a jegyeket, "
 "amelyek várhatóan eszkalálódnak a következő 10 percen belül."
 
@@ -3772,9 +3775,9 @@ msgid ""
 msgstr ""
 "A Zammad képes automatikusan előállított válaszokat küldeni az ügyfeleknek. "
 "Alapértelmezetten ez az újonnan létrehozott jegyeknél van beállítva (hogy "
-"visszaigazolja az e-mail beérkezését, és megadja az ügyfélnek a jegy számát)"
-". Az adminisztrátor megváltoztathatja ezt, vagy akár további automatikusan "
-"előállított üzeneteket is hozzáadhat."
+"visszaigazolja az e-mail beérkezését, és megadja az ügyfélnek a jegy "
+"számát). Az adminisztrátor megváltoztathatja ezt, vagy akár további "
+"automatikusan előállított üzeneteket is hozzáadhat."
 
 #: ../basics/zammad-glossary.rst:60
 msgid "Automation"
@@ -3829,8 +3832,8 @@ msgid ""
 msgstr ""
 "A profilkép alapvetően egy felhasználó grafikus ábrázolása. "
 "Alapértelmezetten a felhasználó profilképe a felhasználó nevének "
-"kezdőbetűiből áll. De lehet egy kép is. A személyre szabásához menjen a "
-":doc:`felhasználói profiljában </extras/user-menu-profile-settings>` lévő "
+"kezdőbetűiből áll. De lehet egy kép is. A személyre szabásához menjen "
+"a :doc:`felhasználói profiljában </extras/user-menu-profile-settings>` lévő "
 "profilkép szakaszhoz."
 
 #: ../basics/zammad-glossary.rst:78
@@ -4161,8 +4164,8 @@ msgid ""
 "Documentation </>`, and the :docs:`Zammad System Documentation </>`."
 msgstr ""
 "Három különböző dokumentációnk van: :doc:`/index`, :admin-docs:`Zammad "
-"adminisztrátori dokumentáció </>` és a :docs:`Zammad rendszer-dokumentáció "
-"</>`."
+"adminisztrátori dokumentáció </>` és a :docs:`Zammad rendszer-dokumentáció </"
+">`."
 
 #: ../basics/zammad-glossary.rst:208
 msgid "E"
@@ -4473,8 +4476,8 @@ msgstr ""
 "jegyek ezekhez kerülnek hozzárendelésre. A megfelelő csoport felel a "
 "feldolgozásért. A csoporton belül meghatározható egy felelős, aki ezután "
 "felel a jegyért. A jegyekhez való hozzáférési jogosultságok is a csoportokon "
-"keresztül vannak szabályozva. A lehetséges jogosultságok a „teljes hozzáférés"
-"”, a „csak olvasás” és a „nincs hozzáférés”."
+"keresztül vannak szabályozva. A lehetséges jogosultságok a „teljes "
+"hozzáférés”, a „csak olvasás” és a „nincs hozzáférés”."
 
 #: ../basics/zammad-glossary.rst:332
 msgid ""
@@ -4482,8 +4485,8 @@ msgid ""
 "principle of \"queues\". The groups in Zammad are the same as the queues in "
 "OTRS."
 msgstr ""
-"Ha korábban már dolgozott az OTRS rendszerrel, akkor talán emlékszik a „"
-"várólisták” alapelvére. A Zammadban lévő csoportok ugyanazok, mint az OTRS-"
+"Ha korábban már dolgozott az OTRS rendszerrel, akkor talán emlékszik a "
+"„várólisták” alapelvére. A Zammadban lévő csoportok ugyanazok, mint az OTRS-"
 "ben a várólisták."
 
 #: ../basics/zammad-glossary.rst:336
@@ -4645,9 +4648,9 @@ msgid ""
 "processes or team info)."
 msgstr ""
 "A tudásbázis-bejegyzések lehetnek belsők vagy külsők, így akár megmutathatja "
-"azokat az egész világnak (ez például jó a termékénél vagy a szolgáltatásánál)"
-", vagy megtarthatja a csapatának (például belső folyamatokat vagy csapaton "
-"belüli információkat)."
+"azokat az egész világnak (ez például jó a termékénél vagy a "
+"szolgáltatásánál), vagy megtarthatja a csapatának (például belső "
+"folyamatokat vagy csapaton belüli információkat)."
 
 #: ../basics/zammad-glossary.rst:406
 msgid ""
@@ -5036,8 +5039,8 @@ msgid ""
 msgstr ""
 "Minden kiadás új funkciókat ad a szoftverünkhöz. Vannak nagyobb és kisebb "
 "kiadások: a nagyobb kiadások (például a Zammad 1.0, 2.0 stb.) jelentős "
-"változásokat hoznak. A kisebb kiadások ezekre épülnek (például 1.1, 2.1 stb.)"
-", és kisebb frissítéseket tartalmaznak."
+"változásokat hoznak. A kisebb kiadások ezekre épülnek (például 1.1, 2.1 "
+"stb.), és kisebb frissítéseket tartalmaznak."
 
 #: ../basics/zammad-glossary.rst:577 ../basics/zammad-glossary.rst:618
 #: ../extras/reporting.rst:2
@@ -5185,16 +5188,16 @@ msgid ""
 "contain your :ref:`avatar image <glossary-avatar>`."
 msgstr ""
 "Az aláírás a kimenő üzenetekben lévő lábléc. Az ügyfelek itt találhatják meg "
-"kapcsolatfelvételi adatokat és a vállalat vagy osztály nevét. Akár a "
-":ref:`profilképét <glossary-avatar>` is tartalmazhatja."
+"kapcsolatfelvételi adatokat és a vállalat vagy osztály nevét. Akár "
+"a :ref:`profilképét <glossary-avatar>` is tartalmazhatja."
 
 #: ../basics/zammad-glossary.rst:628
 msgid ""
 "It can be customized by your admin. Further information can be found :admin-"
 "docs:`here </channels/email/signatures.html>`."
 msgstr ""
-"Az aláírást az adminisztrátor tudja személyre szabni. További információk "
-":admin-docs:`itt találhatók </channels/email/signatures.html>`."
+"Az aláírást az adminisztrátor tudja személyre szabni. További "
+"információk :admin-docs:`itt találhatók </channels/email/signatures.html>`."
 
 #: ../basics/zammad-glossary.rst:640
 msgid "Sipgate"
@@ -5350,9 +5353,9 @@ msgid ""
 "secure-email`."
 msgstr ""
 "Az adminisztrátorok többet is megtudhatnak az S/MIME-ról az :admin-"
-"docs:`adminisztrátori dokumentációban </system/integrations/smime/index.html>"
-"`. Ha Ön ügyintéző, akkor a funkcionalitásról a :doc:`/extras/secure-email` "
-"oldalon tudhat meg többet."
+"docs:`adminisztrátori dokumentációban </system/integrations/smime/"
+"index.html>`. Ha Ön ügyintéző, akkor a funkcionalitásról a :doc:`/extras/"
+"secure-email` oldalon tudhat meg többet."
 
 #: ../basics/zammad-glossary.rst:693
 msgid "T"
@@ -5379,9 +5382,9 @@ msgid ""
 "tags.html>`. Agents can learn more about this function on this "
 "page: :ref:`ticket-attributes`"
 msgstr ""
-"Az adminisztrátorok :admin-docs:`itt tudhatnak meg többet </manage/tags.html>"
-"` a címkékről. Az ügyintézők a :ref:`ticket-attributes` szakaszban tudhatnak "
-"meg többet erről a funkcióról."
+"Az adminisztrátorok :admin-docs:`itt tudhatnak meg többet </manage/"
+"tags.html>` a címkékről. Az ügyintézők a :ref:`ticket-attributes` szakaszban "
+"tudhatnak meg többet erről a funkcióról."
 
 #: ../basics/zammad-glossary.rst:720
 msgid "Text module"
@@ -6642,9 +6645,9 @@ msgid ""
 "manually checkable but reflects the state of the referenced ticket."
 msgstr ""
 "Hozzáadhat egy másik jegyet ellenőrzőlista-elemként úgy, hogy beírja vagy "
-"beilleszti a horgát és a számát az elem címkéjébe (például ``Ticket#423456``)"
-". Ez az elem nem jelölhető be kézzel, hanem a hivatkozott jegy állapotát "
-"tükrözi."
+"beilleszti a horgát és a számát az elem címkéjébe (például "
+"``Ticket#423456``). Ez az elem nem jelölhető be kézzel, hanem a hivatkozott "
+"jegy állapotát tükrözi."
 
 #: ../extras/checklist.rst:63
 msgid "**Copying ticket hook and number**"
@@ -6771,8 +6774,8 @@ msgid ""
 "Customers can optionally belong to organizations. Head over to "
 "the :doc:`organization page <organizations>` to learn more."
 msgstr ""
-"Az ügyfelek választhatóan szervezetekhez tartozhatnak. Olvassa el a "
-":doc:`szervezeti oldalt <organizations>`, hogy többet tudjon meg."
+"Az ügyfelek választhatóan szervezetekhez tartozhatnak. Olvassa el "
+"a :doc:`szervezeti oldalt <organizations>`, hogy többet tudjon meg."
 
 #: ../extras/customers.rst:0
 msgid "Secondary Organizations"
@@ -7082,7 +7085,8 @@ msgstr "A Zammadban: i-doit eszközök hozzákapcsolása a jegyekhez"
 
 #: ../extras/i-doit-track-company-property.rst:41
 msgid "First, add i-doit assets to a ticket in the ticket sidebar:"
-msgstr "Először adja hozzá az i-doit-eszközöket egy jegyhez a jegy oldalsávján:"
+msgstr ""
+"Először adja hozzá az i-doit-eszközöket egy jegyhez a jegy oldalsávján:"
 
 #: ../extras/i-doit-track-company-property.rst:47
 msgid "(Screencast) Create a new ticket and link it to an i-doit asset"
@@ -7374,7 +7378,9 @@ msgstr ""
 "amelyekre feliratkozhat."
 
 #: ../extras/knowledge-base.rst:0
-msgid "Screenshot showing the modal for of the RSS button"
+#, fuzzy
+#| msgid "Screenshot showing the modal for of the RSS button"
+msgid "Screenshot shows the modal for of the RSS button"
 msgstr "A képernyőkép az RSS-gomb kizárólagos párbeszédablakát jeleníti meg"
 
 #: ../extras/knowledge-base.rst:107
@@ -7386,9 +7392,13 @@ msgstr ""
 "tokeneket** tartalmaznak. Soha ne ossza meg ezeket az URL-eket senki mással!"
 
 #: ../extras/knowledge-base.rst:110
+#, fuzzy
+#| msgid ""
+#| "If you want to revoke the access and renew your token, you can do so in "
+#| "the RSS modal."
 msgid ""
 "If you want to revoke the access and renew your token, you can do so in the "
-"RSS modal."
+"RSS dialog."
 msgstr ""
 "Ha vissza szeretné vonni a hozzáférést és megújítani a tokent, akkor ezt az "
 "RSS kizárólagos párbeszédablakban teheti meg."
@@ -7467,12 +7477,8 @@ msgstr ""
 "manage/roles/agent-permissions.html>` ennek megfelelően."
 
 #: ../extras/knowledge-base.rst:None
-msgid ""
-"Screencast showing the visibility option for categories for granular access "
-"permissions"
+msgid "Screenshot shows the granular category permissions for knowledge base"
 msgstr ""
-"A képernyőfelvétel a kategóriák láthatósági lehetőségeit jeleníti meg a "
-"részletes hozzáférési jogosultságokhoz"
 
 #: ../extras/knowledge-base.rst:153
 msgid ""
@@ -7494,10 +7500,11 @@ msgstr ""
 "jogosultságok megadására is, ami gyakorlatilag elrejti az adott "
 "alkategóriát. Fordított irányban ez nem lehetséges. A „szerkesztő” "
 "jogosultsággal rendelkező szerep teljes hozzáféréssel rendelkezik az "
-"alkategóriáihoz, ezért értelmetlen a jogosultságainak a korlátozása. A „nincs"
-"” jogosultságok szintén nem változtathatók meg a fa alacsonyabb szintjein, "
-"mivel így nem lenne útvonal a megengedett alkategóriák eléréséhez. Ha nem "
-"tudja kiválasztani a jogosultságokat a táblázatban, annak ez lehet az oka."
+"alkategóriáihoz, ezért értelmetlen a jogosultságainak a korlátozása. A "
+"„nincs” jogosultságok szintén nem változtathatók meg a fa alacsonyabb "
+"szintjein, mivel így nem lenne útvonal a megengedett alkategóriák "
+"eléréséhez. Ha nem tudja kiválasztani a jogosultságokat a táblázatban, annak "
+"ez lehet az oka."
 
 #: ../extras/knowledge-base.rst:164
 msgid "Be aware that public answers are always available!"
@@ -7522,11 +7529,18 @@ msgid "Edit answer"
 msgstr "Válasz szerkesztése"
 
 #: ../extras/knowledge-base.rst:176
+#, fuzzy
+#| msgid ""
+#| "The knowledge base editor comes equipped with the same **rich text "
+#| "editing capabilities** available in the Zammad ticket composer. That "
+#| "means you can use the same :doc:`keyboard shortcuts </advanced/keyboard-"
+#| "shortcuts>` to insert formatted text, bullet lists, and more. You can "
+#| "even add file attachments and links!"
 msgid ""
 "The knowledge base editor comes equipped with the same **rich text editing "
 "capabilities** available in the Zammad ticket composer. That means you can "
 "use the same :doc:`keyboard shortcuts </advanced/keyboard-shortcuts>` to "
-"insert formatted text, bullet lists, and more. You can even add file "
+"insert formatted text, bullet lists and more. You can even add file "
 "attachments and links!"
 msgstr ""
 "A tudásbázis-szerkesztő ugyanazokkal a **formázottszöveg-szerkesztési "
@@ -7536,12 +7550,14 @@ msgstr ""
 "és egyéb elemek beszúrásához. Akár fájlmellékleteket és hivatkozásokat is "
 "hozzáadhat!"
 
-#: ../extras/knowledge-base.rst:196
+#: ../extras/knowledge-base.rst:213
 msgid "Different link types"
 msgstr "Különböző hivatkozástípusok"
 
 #: ../extras/knowledge-base.rst:184
-msgid "**Web link**"
+#, fuzzy
+#| msgid "**Web link**"
+msgid "Web link"
 msgstr "**Webhivatkozás**"
 
 #: ../extras/knowledge-base.rst:184
@@ -7549,7 +7565,9 @@ msgid "URLs pointing to other websites."
 msgstr "Más webhelyekre mutató URL-ek."
 
 #: ../extras/knowledge-base.rst:188
-msgid "**Link Answer**"
+#, fuzzy
+#| msgid "**Link Answer**"
+msgid "Link Answer"
 msgstr "**Válasz hozzákapcsolása**"
 
 #: ../extras/knowledge-base.rst:187
@@ -7561,10 +7579,34 @@ msgstr ""
 "cél-URL megváltozik)."
 
 #: ../extras/knowledge-base.rst:192
-msgid "**Linked Tickets**"
-msgstr "**Kapcsolt jegyek**"
+msgid "Image"
+msgstr ""
 
 #: ../extras/knowledge-base.rst:191
+msgid ""
+"Include an image from your computer in the answer. Unlike file attachments, "
+"these images are embedded directly in the answer."
+msgstr ""
+
+#: ../extras/knowledge-base.rst:199
+msgid "Video"
+msgstr ""
+
+#: ../extras/knowledge-base.rst:195
+msgid ""
+"Include a video to embed in the answer. By default, you can embed videos "
+"from Vimeo and YouTube. Depending on your Zammad settings, MediaCMS and "
+"PeerTube instances can be enabled by your admin as well. A list of supported "
+"video services is displayed in the video dialog below the URL field."
+msgstr ""
+
+#: ../extras/knowledge-base.rst:203
+#, fuzzy
+#| msgid "Link Tickets"
+msgid "Linked Tickets"
+msgstr "Jegyek összekapcsolása"
+
+#: ../extras/knowledge-base.rst:202
 msgid ""
 "Internal references to Zammad tickets (visible only in preview and edit "
 "mode)."
@@ -7572,25 +7614,37 @@ msgstr ""
 "Zammad-jegyekre mutató belső hivatkozások (csak előnézeti és szerkesztési "
 "módban látható)."
 
-#: ../extras/knowledge-base.rst:196
-msgid "**Tags**"
-msgstr "**Címkék**"
+#: ../extras/knowledge-base.rst:208
+msgid "Attachments"
+msgstr ""
 
-#: ../extras/knowledge-base.rst:195
+#: ../extras/knowledge-base.rst:206
+msgid ""
+"Add any file as an attachment to your answer. Such an attachment isn't "
+"embedded in the body of the answer. Readers can download it by clicking on "
+"it in the attachment section."
+msgstr ""
+
+#: ../extras/knowledge-base.rst:211
+#, fuzzy
+#| msgid ""
+#| "Can help to categorize or label answers for better search results. Please "
+#| "note that tags are visible publicly and can be the same like those in "
+#| "your tickets."
 msgid ""
 "Can help to categorize or label answers for better search results. Please "
-"note that tags are visible publicly and can be the same like those in your "
+"note that tags are visible publicly and can be the same as those in your "
 "tickets."
 msgstr ""
 "Segíthet a válaszok kategorizálásában vagy címkézésében a jobb keresési "
 "eredményekért. Ne feledje, hogy a címkék nyilvánosan láthatók, és "
 "megegyezhetnek a jegyekben lévőkkel."
 
-#: ../extras/knowledge-base.rst:221
+#: ../extras/knowledge-base.rst:238
 msgid "Visibility"
 msgstr "Láthatóság"
 
-#: ../extras/knowledge-base.rst:199
+#: ../extras/knowledge-base.rst:216
 msgid ""
 "Set the visibility of an answer to control who can see an article, or "
 "schedule it to be published at a later date. Articles are color-coded "
@@ -7600,31 +7654,31 @@ msgstr ""
 "egy bejegyzést, vagy ütemezze, hogy egy későbbi időpontban legyen közzétéve. "
 "A bejegyzések színkóddal vannak jelölve a láthatóságuk szerint:"
 
-#: ../extras/knowledge-base.rst:204
+#: ../extras/knowledge-base.rst:221
 msgid "**Public** (visible to everyone)"
 msgstr "**Nyilvános** (mindenkinek látható)"
 
-#: ../extras/knowledge-base.rst:206
+#: ../extras/knowledge-base.rst:223
 msgid "|blu|"
 msgstr "|blu|"
 
-#: ../extras/knowledge-base.rst:206
+#: ../extras/knowledge-base.rst:223
 msgid "**Internal** (visible to agents & editors only)"
 msgstr "**Belső** (csak ügyintézőknek és szerkesztőknek látható)"
 
-#: ../extras/knowledge-base.rst:208
+#: ../extras/knowledge-base.rst:225
 msgid "|gry|"
 msgstr "|gry|"
 
-#: ../extras/knowledge-base.rst:208
+#: ../extras/knowledge-base.rst:225
 msgid "**Draft/Scheduled/Archived** (visible to editors only)"
 msgstr "**Piszkozat/ütemezett/archivált** (csak szerkesztőknek látható)"
 
-#: ../extras/knowledge-base.rst:224
+#: ../extras/knowledge-base.rst:241
 msgid "Using Answers In Ticket Articles"
 msgstr "Válaszok használata a jegy bejegyzéseiben"
 
-#: ../extras/knowledge-base.rst:226
+#: ../extras/knowledge-base.rst:243
 msgid ""
 "As soon as the knowledge base contains one or more answers, you can use "
 "these just like text modules. Instead of :kbd:`:`:kbd:`:` just use :kbd:`?"
@@ -7890,7 +7944,8 @@ msgstr "„Folytatás asztali gépen” hivatkozás a bejelentkezési képernyő
 
 #: ../extras/mobile-view.rst:0
 msgid "Continue to Desktop Link in User Account Overview"
-msgstr "„Folytatás asztali gépen” hivatkozás a felhasználói fiók áttekintésében"
+msgstr ""
+"„Folytatás asztali gépen” hivatkozás a felhasználói fiók áttekintésében"
 
 #: ../extras/mobile-view.rst:170
 msgid "User Account Overview"
@@ -8031,7 +8086,8 @@ msgstr "Menüsáv kiemelt jelentéskészítéssel"
 
 #: ../extras/reporting.rst:12
 msgid "If you can't see the reporting button, you have no permission for it."
-msgstr "Ha nem látja a jelentéskészítés gombot, akkor nincs jogosultsága hozzá."
+msgstr ""
+"Ha nem látja a jelentéskészítés gombot, akkor nincs jogosultsága hozzá."
 
 #: ../extras/reporting.rst:14
 msgid "The reporting screen consists of various sections:"
@@ -8490,7 +8546,8 @@ msgstr "A Zammad műszakilag két piszkozatfunkcióval rendelkezik:"
 
 #: ../extras/shared-drafts.rst:15
 msgid "Shared drafts (allow others to load the draft)"
-msgstr "Megosztott piszkozatok (lehetővé teszi másoknak a piszkozat betöltését)"
+msgstr ""
+"Megosztott piszkozatok (lehetővé teszi másoknak a piszkozat betöltését)"
 
 #: ../extras/shared-drafts.rst:16
 msgid "User drafts"
@@ -9029,8 +9086,8 @@ msgid ""
 "app-351498fc-850a-45da-b7b6-27e523b8702a>`_"
 msgstr ""
 "`Microsoft Hitelesítő <https://support.microsoft.com/en-us/account-billing/"
-"download-and-install-the-microsoft-authenticator-app-351498fc-850a-45da-b7b6-"
-"27e523b8702a>`_"
+"download-and-install-the-microsoft-authenticator-app-351498fc-850a-45da-"
+"b7b6-27e523b8702a>`_"
 
 #: ../extras/two-factor-authentication/authenticator-app-setup.rst:20
 msgid ""
@@ -9150,7 +9207,7 @@ msgstr "Biztonsági kulcs neve"
 
 #: ../extras/two-factor-authentication/security-keys-setup.rst:24
 msgid ""
-"Next, depending you your browser, you will be presented with different "
+"Next, depending on your browser, you will be presented with different "
 "options. Select one that refers to your chosen security key and follow the "
 "instructions on the screen."
 msgstr ""
@@ -9322,10 +9379,11 @@ msgid ""
 "overviews. Since this list is limited, old items will automatically "
 "disappear."
 msgstr ""
-"A korábban megtekintett összes információ (jegyek, felhasználók, szervezetek)"
-". Segít abban, hogy egyszerűen hozzáférhessen az elemekhez anélkül, hogy "
-"keresnie kellene vagy végig kellene görgetnie az áttekintéseket. Mivel ez a "
-"lista korlátozott, a régebbi elemek automatikusan eltűnnek."
+"A korábban megtekintett összes információ (jegyek, felhasználók, "
+"szervezetek). Segít abban, hogy egyszerűen hozzáférhessen az elemekhez "
+"anélkül, hogy keresnie kellene vagy végig kellene görgetnie az "
+"áttekintéseket. Mivel ez a lista korlátozott, a régebbi elemek automatikusan "
+"eltűnnek."
 
 #: ../extras/user-menu-profile-settings.rst:42
 msgid "Further actions"
@@ -9697,6 +9755,19 @@ msgstr ""
 "Jelenleg a Zammad felhasználói dokumentációját olvassa. :docs:`Rendszer- </"
 "index.html>` és :admin-docs:`adminisztrátori kézikönyvek</index.html>` is "
 "elérhetők."
+
+#~ msgid ""
+#~ "Screencast showing the visibility option for categories for granular "
+#~ "access permissions"
+#~ msgstr ""
+#~ "A képernyőfelvétel a kategóriák láthatósági lehetőségeit jeleníti meg a "
+#~ "részletes hozzáférési jogosultságokhoz"
+
+#~ msgid "**Linked Tickets**"
+#~ msgstr "**Kapcsolt jegyek**"
+
+#~ msgid "**Tags**"
+#~ msgstr "**Címkék**"
 
 #~ msgid "General"
 #~ msgstr "Általános"

--- a/locale/it/LC_MESSAGES/user-docs.po
+++ b/locale/it/LC_MESSAGES/user-docs.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-01 08:43+0200\n"
-"PO-Revision-Date: 2026-07-02 16:02+0000\n"
+"POT-Creation-Date: 2026-07-07 14:22+0200\n"
+"PO-Revision-Date: 2026-07-09 16:07+0000\n"
 "Last-Translator: albanobattistella <albanobattistella@gmail.com>\n"
 "Language-Team: Italian <https://translations.zammad.org/projects/"
 "documentations/user-documentation-pre-release/it/>\n"
@@ -1572,7 +1572,7 @@ msgstr ""
 "**In pausa, al momento non è necessaria alcuna azione.** (ad esempio in "
 "sospeso)"
 
-#: ../snippets/ticket-state-type-circles.rst:8 ../extras/knowledge-base.rst:204
+#: ../snippets/ticket-state-type-circles.rst:8 ../extras/knowledge-base.rst:221
 msgid "|grn|"
 msgstr "|grn|"
 
@@ -2999,6 +2999,7 @@ msgstr ""
 "sperare in una escalation immediata."
 
 #: ../basics/ticket-basics.rst:117 ../basics/zammad-glossary.rst:706
+#: ../extras/knowledge-base.rst:213
 msgid "Tags"
 msgstr "Etichette"
 
@@ -7301,8 +7302,8 @@ msgstr ""
 "iscriversi."
 
 #: ../extras/knowledge-base.rst:0
-msgid "Screenshot showing the modal for of the RSS button"
-msgstr "Screenshot che mostra il modale del pulsante RSS"
+msgid "Screenshot shows the modal for of the RSS button"
+msgstr "Lo screenshot mostra la finestra modale del pulsante RSS"
 
 #: ../extras/knowledge-base.rst:107
 msgid ""
@@ -7315,10 +7316,10 @@ msgstr ""
 #: ../extras/knowledge-base.rst:110
 msgid ""
 "If you want to revoke the access and renew your token, you can do so in the "
-"RSS modal."
+"RSS dialog."
 msgstr ""
-"Se vuoi revocare l'accesso e rinnovare il tuo token, puoi farlo nel modale "
-"RSS."
+"Se desideri revocare l'accesso e rinnovare il tuo token, puoi farlo nella "
+"finestra di dialogo RSS."
 
 #: ../extras/knowledge-base.rst:0
 msgid ""
@@ -7395,12 +7396,10 @@ msgstr ""
 "ruoli :admin-docs:`</manage/roles/agent-permissions.html>`."
 
 #: ../extras/knowledge-base.rst:None
-msgid ""
-"Screencast showing the visibility option for categories for granular access "
-"permissions"
+msgid "Screenshot shows the granular category permissions for knowledge base"
 msgstr ""
-"Screencast che mostra l'opzione di visibilità per categorie per permessi di "
-"accesso granulari"
+"Lo screenshot mostra le autorizzazioni di categoria granulari per la "
+"knowledge base"
 
 #: ../extras/knowledge-base.rst:153
 msgid ""
@@ -7454,30 +7453,30 @@ msgid ""
 "The knowledge base editor comes equipped with the same **rich text editing "
 "capabilities** available in the Zammad ticket composer. That means you can "
 "use the same :doc:`keyboard shortcuts </advanced/keyboard-shortcuts>` to "
-"insert formatted text, bullet lists, and more. You can even add file "
+"insert formatted text, bullet lists and more. You can even add file "
 "attachments and links!"
 msgstr ""
 "L'editor della knowledge base è dotato delle stesse **funzionalità di "
-"modifica testo ricco** disponibili nel compositore ticket di Zammad. Ciò "
-"significa che puoi usare le stesse :doc:`scorciatoie da tastiera </advanced/"
-"keyboard-shortcuts>` per inserire testo formattato, elenchi puntati e altro. "
-"Puoi persino aggiungere allegati file e link!"
+"modifica del testo avanzato** disponibili nel compositore di ticket di "
+"Zammad. Ciò significa che puoi utilizzare le stesse :doc:`scorciatoie da "
+"tastiera </advanced/keyboard-shortcuts>` per inserire testo formattato, "
+"elenchi puntati e altro ancora. Puoi persino aggiungere allegati e link!"
 
-#: ../extras/knowledge-base.rst:196
+#: ../extras/knowledge-base.rst:213
 msgid "Different link types"
 msgstr "Diversi tipi di link"
 
 #: ../extras/knowledge-base.rst:184
-msgid "**Web link**"
-msgstr "**Link web**"
+msgid "Web link"
+msgstr "Link web"
 
 #: ../extras/knowledge-base.rst:184
 msgid "URLs pointing to other websites."
 msgstr "URL che puntano ad altri siti web."
 
 #: ../extras/knowledge-base.rst:188
-msgid "**Link Answer**"
-msgstr "**Collega risposta**"
+msgid "Link Answer"
+msgstr "Link di risposta"
 
 #: ../extras/knowledge-base.rst:187
 msgid ""
@@ -7486,34 +7485,74 @@ msgid ""
 msgstr "Riferimenti interni ad altre risposte della knowledge base."
 
 #: ../extras/knowledge-base.rst:192
-msgid "**Linked Tickets**"
-msgstr "**Ticket collegati**"
+msgid "Image"
+msgstr "Immagine"
 
 #: ../extras/knowledge-base.rst:191
+msgid ""
+"Include an image from your computer in the answer. Unlike file attachments, "
+"these images are embedded directly in the answer."
+msgstr ""
+"Includi un'immagine dal tuo computer nella risposta. A differenza degli "
+"allegati, queste immagini vengono incorporate direttamente nella risposta."
+
+#: ../extras/knowledge-base.rst:199
+msgid "Video"
+msgstr "Video"
+
+#: ../extras/knowledge-base.rst:195
+msgid ""
+"Include a video to embed in the answer. By default, you can embed videos "
+"from Vimeo and YouTube. Depending on your Zammad settings, MediaCMS and "
+"PeerTube instances can be enabled by your admin as well. A list of supported "
+"video services is displayed in the video dialog below the URL field."
+msgstr ""
+"Includi un video da incorporare nella risposta. Per impostazione "
+"predefinita, puoi incorporare video da Vimeo e YouTube. A seconda delle "
+"impostazioni di Zammad, l'amministratore potrebbe anche abilitare le istanze "
+"di MediaCMS e PeerTube. Un elenco dei servizi video supportati viene "
+"visualizzato nella finestra di dialogo del video sotto il campo URL."
+
+#: ../extras/knowledge-base.rst:203
+msgid "Linked Tickets"
+msgstr "Ticket collegati"
+
+#: ../extras/knowledge-base.rst:202
 msgid ""
 "Internal references to Zammad tickets (visible only in preview and edit "
 "mode)."
 msgstr "Riferimenti interni ai ticket di Zammad."
 
-#: ../extras/knowledge-base.rst:196
-msgid "**Tags**"
-msgstr "**Tag**"
+#: ../extras/knowledge-base.rst:208
+msgid "Attachments"
+msgstr "Allegati"
 
-#: ../extras/knowledge-base.rst:195
+#: ../extras/knowledge-base.rst:206
+msgid ""
+"Add any file as an attachment to your answer. Such an attachment isn't "
+"embedded in the body of the answer. Readers can download it by clicking on "
+"it in the attachment section."
+msgstr ""
+"È possibile allegare un file alla risposta. L'allegato non verrà incorporato "
+"nel corpo della risposta. I lettori potranno scaricarlo cliccandoci sopra "
+"nella sezione allegati."
+
+#: ../extras/knowledge-base.rst:211
 msgid ""
 "Can help to categorize or label answers for better search results. Please "
-"note that tags are visible publicly and can be the same like those in your "
+"note that tags are visible publicly and can be the same as those in your "
 "tickets."
 msgstr ""
-"Possono aiutare a categorizzare o etichettare le risposte per ottenere "
-"risultati di ricerca migliori. Tieni presente che i tag sono visibili "
-"pubblicamente e possono essere gli stessi presenti nei tuoi ticket."
+"Può essere utile per categorizzare o etichettare le risposte al fine di "
+"ottenere risultati di ricerca migliori. Si prega di notare che i tag sono "
+"visibili pubblicamente e possono essere gli stessi utilizzati nei ticket di "
+"assistenza."
 
-#: ../extras/knowledge-base.rst:221
+#: ../extras/knowledge-base.rst:238
 msgid "Visibility"
 msgstr "Visibilità"
 
-#: ../extras/knowledge-base.rst:199
+#: ../extras/knowledge-base.rst:216
 msgid ""
 "Set the visibility of an answer to control who can see an article, or "
 "schedule it to be published at a later date. Articles are color-coded "
@@ -7524,31 +7563,31 @@ msgstr ""
 "una data successiva. Gli articoli sono **contrassegnati da colori** diversi "
 "in base alla loro visibilità:"
 
-#: ../extras/knowledge-base.rst:204
+#: ../extras/knowledge-base.rst:221
 msgid "**Public** (visible to everyone)"
 msgstr "**Pubblico** (visibile a tutti)"
 
-#: ../extras/knowledge-base.rst:206
+#: ../extras/knowledge-base.rst:223
 msgid "|blu|"
 msgstr "|blu|"
 
-#: ../extras/knowledge-base.rst:206
+#: ../extras/knowledge-base.rst:223
 msgid "**Internal** (visible to agents & editors only)"
 msgstr "**Interno** (visibile solo ad agenti e editor)"
 
-#: ../extras/knowledge-base.rst:208
+#: ../extras/knowledge-base.rst:225
 msgid "|gry|"
 msgstr "|gry|"
 
-#: ../extras/knowledge-base.rst:208
+#: ../extras/knowledge-base.rst:225
 msgid "**Draft/Scheduled/Archived** (visible to editors only)"
 msgstr "**Bozza/Programmato/Archiviato** (visibile solo agli editor)"
 
-#: ../extras/knowledge-base.rst:224
+#: ../extras/knowledge-base.rst:241
 msgid "Using Answers In Ticket Articles"
 msgstr "Usare le Risposte negli Articoli Ticket"
 
-#: ../extras/knowledge-base.rst:226
+#: ../extras/knowledge-base.rst:243
 msgid ""
 "As soon as the knowledge base contains one or more answers, you can use "
 "these just like text modules. Instead of :kbd:`:`:kbd:`:` just use :kbd:`?"
@@ -9075,12 +9114,12 @@ msgstr "Nome chiave di sicurezza"
 
 #: ../extras/two-factor-authentication/security-keys-setup.rst:24
 msgid ""
-"Next, depending you your browser, you will be presented with different "
+"Next, depending on your browser, you will be presented with different "
 "options. Select one that refers to your chosen security key and follow the "
 "instructions on the screen."
 msgstr ""
-"Successivamente, a seconda del tuo browser, ti verranno presentate diverse "
-"opzioni. Seleziona quella che fa riferimento alla tua chiave di sicurezza "
+"Successivamente, a seconda del browser utilizzato, verranno visualizzate "
+"diverse opzioni. Seleziona quella corrispondente alla chiave di sicurezza "
 "scelta e segui le istruzioni sullo schermo."
 
 #: ../extras/two-factor-authentication/security-keys-setup.rst:None
@@ -9619,6 +9658,19 @@ msgstr ""
 "Stai leggendo la documentazione utente di Zammad. Sono anche disponibili i "
 "manuali :docs:`di sistema </index.html>` e :admin-docs:`di amministrazione </"
 "index.html>`."
+
+#~ msgid ""
+#~ "Screencast showing the visibility option for categories for granular "
+#~ "access permissions"
+#~ msgstr ""
+#~ "Screencast che mostra l'opzione di visibilità per categorie per permessi "
+#~ "di accesso granulari"
+
+#~ msgid "**Linked Tickets**"
+#~ msgstr "**Ticket collegati**"
+
+#~ msgid "**Tags**"
+#~ msgstr "**Tag**"
 
 #~ msgid "Screencast demo of S/MIME features for both new tickets and replies"
 #~ msgstr ""

--- a/locale/nl/LC_MESSAGES/user-docs.po
+++ b/locale/nl/LC_MESSAGES/user-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-01 08:43+0200\n"
+"POT-Creation-Date: 2026-07-07 14:22+0200\n"
 "PO-Revision-Date: 2026-06-17 10:19+0000\n"
 "Last-Translator: Alivion <dani-pranger@live.nl>\n"
 "Language-Team: Dutch <https://translations.zammad.org/projects/"
@@ -1368,7 +1368,7 @@ msgstr ""
 msgid "**Paused, no action needed right now** (e.g. pending)"
 msgstr ""
 
-#: ../snippets/ticket-state-type-circles.rst:8 ../extras/knowledge-base.rst:204
+#: ../snippets/ticket-state-type-circles.rst:8 ../extras/knowledge-base.rst:221
 msgid "|grn|"
 msgstr ""
 
@@ -2437,6 +2437,7 @@ msgid ""
 msgstr ""
 
 #: ../basics/ticket-basics.rst:117 ../basics/zammad-glossary.rst:706
+#: ../extras/knowledge-base.rst:213
 msgid "Tags"
 msgstr ""
 
@@ -5710,7 +5711,7 @@ msgid ""
 msgstr ""
 
 #: ../extras/knowledge-base.rst:0
-msgid "Screenshot showing the modal for of the RSS button"
+msgid "Screenshot shows the modal for of the RSS button"
 msgstr ""
 
 #: ../extras/knowledge-base.rst:107
@@ -5722,7 +5723,7 @@ msgstr ""
 #: ../extras/knowledge-base.rst:110
 msgid ""
 "If you want to revoke the access and renew your token, you can do so in the "
-"RSS modal."
+"RSS dialog."
 msgstr ""
 
 #: ../extras/knowledge-base.rst:0
@@ -5780,9 +5781,7 @@ msgid ""
 msgstr ""
 
 #: ../extras/knowledge-base.rst:None
-msgid ""
-"Screencast showing the visibility option for categories for granular access "
-"permissions"
+msgid "Screenshot shows the granular category permissions for knowledge base"
 msgstr ""
 
 #: ../extras/knowledge-base.rst:153
@@ -5823,16 +5822,16 @@ msgid ""
 "The knowledge base editor comes equipped with the same **rich text editing "
 "capabilities** available in the Zammad ticket composer. That means you can "
 "use the same :doc:`keyboard shortcuts </advanced/keyboard-shortcuts>` to "
-"insert formatted text, bullet lists, and more. You can even add file "
+"insert formatted text, bullet lists and more. You can even add file "
 "attachments and links!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:196
+#: ../extras/knowledge-base.rst:213
 msgid "Different link types"
 msgstr ""
 
 #: ../extras/knowledge-base.rst:184
-msgid "**Web link**"
+msgid "Web link"
 msgstr ""
 
 #: ../extras/knowledge-base.rst:184
@@ -5840,7 +5839,7 @@ msgid "URLs pointing to other websites."
 msgstr ""
 
 #: ../extras/knowledge-base.rst:188
-msgid "**Link Answer**"
+msgid "Link Answer"
 msgstr ""
 
 #: ../extras/knowledge-base.rst:187
@@ -5850,62 +5849,91 @@ msgid ""
 msgstr ""
 
 #: ../extras/knowledge-base.rst:192
-msgid "**Linked Tickets**"
+msgid "Image"
 msgstr ""
 
 #: ../extras/knowledge-base.rst:191
+msgid ""
+"Include an image from your computer in the answer. Unlike file attachments, "
+"these images are embedded directly in the answer."
+msgstr ""
+
+#: ../extras/knowledge-base.rst:199
+msgid "Video"
+msgstr ""
+
+#: ../extras/knowledge-base.rst:195
+msgid ""
+"Include a video to embed in the answer. By default, you can embed videos "
+"from Vimeo and YouTube. Depending on your Zammad settings, MediaCMS and "
+"PeerTube instances can be enabled by your admin as well. A list of supported "
+"video services is displayed in the video dialog below the URL field."
+msgstr ""
+
+#: ../extras/knowledge-base.rst:203
+msgid "Linked Tickets"
+msgstr ""
+
+#: ../extras/knowledge-base.rst:202
 msgid ""
 "Internal references to Zammad tickets (visible only in preview and edit "
 "mode)."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:196
-msgid "**Tags**"
+#: ../extras/knowledge-base.rst:208
+msgid "Attachments"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:195
+#: ../extras/knowledge-base.rst:206
+msgid ""
+"Add any file as an attachment to your answer. Such an attachment isn't "
+"embedded in the body of the answer. Readers can download it by clicking on "
+"it in the attachment section."
+msgstr ""
+
+#: ../extras/knowledge-base.rst:211
 msgid ""
 "Can help to categorize or label answers for better search results. Please "
-"note that tags are visible publicly and can be the same like those in your "
+"note that tags are visible publicly and can be the same as those in your "
 "tickets."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:221
+#: ../extras/knowledge-base.rst:238
 msgid "Visibility"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:199
+#: ../extras/knowledge-base.rst:216
 msgid ""
 "Set the visibility of an answer to control who can see an article, or "
 "schedule it to be published at a later date. Articles are color-coded "
 "according to their visibility:"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:204
+#: ../extras/knowledge-base.rst:221
 msgid "**Public** (visible to everyone)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:206
+#: ../extras/knowledge-base.rst:223
 msgid "|blu|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:206
+#: ../extras/knowledge-base.rst:223
 msgid "**Internal** (visible to agents & editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:208
+#: ../extras/knowledge-base.rst:225
 msgid "|gry|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:208
+#: ../extras/knowledge-base.rst:225
 msgid "**Draft/Scheduled/Archived** (visible to editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:224
+#: ../extras/knowledge-base.rst:241
 msgid "Using Answers In Ticket Articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:226
+#: ../extras/knowledge-base.rst:243
 msgid ""
 "As soon as the knowledge base contains one or more answers, you can use "
 "these just like text modules. Instead of :kbd:`:`:kbd:`:` just use :kbd:`?"
@@ -7111,7 +7139,7 @@ msgstr ""
 
 #: ../extras/two-factor-authentication/security-keys-setup.rst:24
 msgid ""
-"Next, depending you your browser, you will be presented with different "
+"Next, depending on your browser, you will be presented with different "
 "options. Select one that refers to your chosen security key and follow the "
 "instructions on the screen."
 msgstr ""

--- a/locale/pl/LC_MESSAGES/user-docs.po
+++ b/locale/pl/LC_MESSAGES/user-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-01 08:43+0200\n"
+"POT-Creation-Date: 2026-07-07 14:22+0200\n"
 "PO-Revision-Date: 2026-06-17 10:14+0000\n"
 "Last-Translator: SamolJacek <samol.jacek@gmail.com>\n"
 "Language-Team: Polish <https://translations.zammad.org/projects/"
@@ -1502,7 +1502,7 @@ msgstr ""
 msgid "**Paused, no action needed right now** (e.g. pending)"
 msgstr ""
 
-#: ../snippets/ticket-state-type-circles.rst:8 ../extras/knowledge-base.rst:204
+#: ../snippets/ticket-state-type-circles.rst:8 ../extras/knowledge-base.rst:221
 msgid "|grn|"
 msgstr ""
 
@@ -2599,6 +2599,7 @@ msgid ""
 msgstr ""
 
 #: ../basics/ticket-basics.rst:117 ../basics/zammad-glossary.rst:706
+#: ../extras/knowledge-base.rst:213
 msgid "Tags"
 msgstr ""
 
@@ -5941,8 +5942,11 @@ msgid ""
 msgstr ""
 
 #: ../extras/knowledge-base.rst:0
-msgid "Screenshot showing the modal for of the RSS button"
+#, fuzzy
+msgid "Screenshot shows the modal for of the RSS button"
 msgstr ""
+"Zrzut ekranu przedstawiający wyszukiwanie klienta podczas tworzenia nowego "
+"zgłoszenia"
 
 #: ../extras/knowledge-base.rst:107
 msgid ""
@@ -5953,7 +5957,7 @@ msgstr ""
 #: ../extras/knowledge-base.rst:110
 msgid ""
 "If you want to revoke the access and renew your token, you can do so in the "
-"RSS modal."
+"RSS dialog."
 msgstr ""
 
 #: ../extras/knowledge-base.rst:0
@@ -6011,9 +6015,7 @@ msgid ""
 msgstr ""
 
 #: ../extras/knowledge-base.rst:None
-msgid ""
-"Screencast showing the visibility option for categories for granular access "
-"permissions"
+msgid "Screenshot shows the granular category permissions for knowledge base"
 msgstr ""
 
 #: ../extras/knowledge-base.rst:153
@@ -6054,16 +6056,16 @@ msgid ""
 "The knowledge base editor comes equipped with the same **rich text editing "
 "capabilities** available in the Zammad ticket composer. That means you can "
 "use the same :doc:`keyboard shortcuts </advanced/keyboard-shortcuts>` to "
-"insert formatted text, bullet lists, and more. You can even add file "
+"insert formatted text, bullet lists and more. You can even add file "
 "attachments and links!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:196
+#: ../extras/knowledge-base.rst:213
 msgid "Different link types"
 msgstr ""
 
 #: ../extras/knowledge-base.rst:184
-msgid "**Web link**"
+msgid "Web link"
 msgstr ""
 
 #: ../extras/knowledge-base.rst:184
@@ -6071,7 +6073,7 @@ msgid "URLs pointing to other websites."
 msgstr ""
 
 #: ../extras/knowledge-base.rst:188
-msgid "**Link Answer**"
+msgid "Link Answer"
 msgstr ""
 
 #: ../extras/knowledge-base.rst:187
@@ -6081,63 +6083,92 @@ msgid ""
 msgstr ""
 
 #: ../extras/knowledge-base.rst:192
-#, fuzzy
-msgid "**Linked Tickets**"
-msgstr "Na jednym zgłoszeniu"
+msgid "Image"
+msgstr ""
 
 #: ../extras/knowledge-base.rst:191
+msgid ""
+"Include an image from your computer in the answer. Unlike file attachments, "
+"these images are embedded directly in the answer."
+msgstr ""
+
+#: ../extras/knowledge-base.rst:199
+msgid "Video"
+msgstr ""
+
+#: ../extras/knowledge-base.rst:195
+msgid ""
+"Include a video to embed in the answer. By default, you can embed videos "
+"from Vimeo and YouTube. Depending on your Zammad settings, MediaCMS and "
+"PeerTube instances can be enabled by your admin as well. A list of supported "
+"video services is displayed in the video dialog below the URL field."
+msgstr ""
+
+#: ../extras/knowledge-base.rst:203
+#, fuzzy
+msgid "Linked Tickets"
+msgstr "Na jednym zgłoszeniu"
+
+#: ../extras/knowledge-base.rst:202
 msgid ""
 "Internal references to Zammad tickets (visible only in preview and edit "
 "mode)."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:196
-msgid "**Tags**"
+#: ../extras/knowledge-base.rst:208
+msgid "Attachments"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:195
+#: ../extras/knowledge-base.rst:206
+msgid ""
+"Add any file as an attachment to your answer. Such an attachment isn't "
+"embedded in the body of the answer. Readers can download it by clicking on "
+"it in the attachment section."
+msgstr ""
+
+#: ../extras/knowledge-base.rst:211
 msgid ""
 "Can help to categorize or label answers for better search results. Please "
-"note that tags are visible publicly and can be the same like those in your "
+"note that tags are visible publicly and can be the same as those in your "
 "tickets."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:221
+#: ../extras/knowledge-base.rst:238
 msgid "Visibility"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:199
+#: ../extras/knowledge-base.rst:216
 msgid ""
 "Set the visibility of an answer to control who can see an article, or "
 "schedule it to be published at a later date. Articles are color-coded "
 "according to their visibility:"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:204
+#: ../extras/knowledge-base.rst:221
 msgid "**Public** (visible to everyone)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:206
+#: ../extras/knowledge-base.rst:223
 msgid "|blu|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:206
+#: ../extras/knowledge-base.rst:223
 msgid "**Internal** (visible to agents & editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:208
+#: ../extras/knowledge-base.rst:225
 msgid "|gry|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:208
+#: ../extras/knowledge-base.rst:225
 msgid "**Draft/Scheduled/Archived** (visible to editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:224
+#: ../extras/knowledge-base.rst:241
 msgid "Using Answers In Ticket Articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:226
+#: ../extras/knowledge-base.rst:243
 msgid ""
 "As soon as the knowledge base contains one or more answers, you can use "
 "these just like text modules. Instead of :kbd:`:`:kbd:`:` just use :kbd:`?"
@@ -7357,7 +7388,7 @@ msgstr ""
 
 #: ../extras/two-factor-authentication/security-keys-setup.rst:24
 msgid ""
-"Next, depending you your browser, you will be presented with different "
+"Next, depending on your browser, you will be presented with different "
 "options. Select one that refers to your chosen security key and follow the "
 "instructions on the screen."
 msgstr ""
@@ -7777,6 +7808,10 @@ msgid ""
 "also :docs:`system </index.html>` and :admin-docs:`administration manuals </"
 "index.html>` available."
 msgstr ""
+
+#, fuzzy
+#~ msgid "**Linked Tickets**"
+#~ msgstr "Na jednym zgłoszeniu"
 
 #, fuzzy
 #~ msgid "Split ticket button"

--- a/locale/pt_BR/LC_MESSAGES/user-docs.po
+++ b/locale/pt_BR/LC_MESSAGES/user-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-01 08:43+0200\n"
+"POT-Creation-Date: 2026-07-07 14:22+0200\n"
 "PO-Revision-Date: 2026-06-17 10:15+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Portuguese (Brazil) <https://translations.zammad.org/projects/"
@@ -1483,7 +1483,7 @@ msgstr "|blk|"
 msgid "**Paused, no action needed right now** (e.g. pending)"
 msgstr ""
 
-#: ../snippets/ticket-state-type-circles.rst:8 ../extras/knowledge-base.rst:204
+#: ../snippets/ticket-state-type-circles.rst:8 ../extras/knowledge-base.rst:221
 msgid "|grn|"
 msgstr "|grn|"
 
@@ -2661,6 +2661,7 @@ msgid ""
 msgstr ""
 
 #: ../basics/ticket-basics.rst:117 ../basics/zammad-glossary.rst:706
+#: ../extras/knowledge-base.rst:213
 msgid "Tags"
 msgstr "Tags"
 
@@ -6127,8 +6128,9 @@ msgid ""
 msgstr ""
 
 #: ../extras/knowledge-base.rst:0
-msgid "Screenshot showing the modal for of the RSS button"
-msgstr ""
+#, fuzzy
+msgid "Screenshot shows the modal for of the RSS button"
+msgstr "Novos chamados"
 
 #: ../extras/knowledge-base.rst:107
 msgid ""
@@ -6139,7 +6141,7 @@ msgstr ""
 #: ../extras/knowledge-base.rst:110
 msgid ""
 "If you want to revoke the access and renew your token, you can do so in the "
-"RSS modal."
+"RSS dialog."
 msgstr ""
 
 #: ../extras/knowledge-base.rst:0
@@ -6197,9 +6199,7 @@ msgid ""
 msgstr ""
 
 #: ../extras/knowledge-base.rst:None
-msgid ""
-"Screencast showing the visibility option for categories for granular access "
-"permissions"
+msgid "Screenshot shows the granular category permissions for knowledge base"
 msgstr ""
 
 #: ../extras/knowledge-base.rst:153
@@ -6240,16 +6240,16 @@ msgid ""
 "The knowledge base editor comes equipped with the same **rich text editing "
 "capabilities** available in the Zammad ticket composer. That means you can "
 "use the same :doc:`keyboard shortcuts </advanced/keyboard-shortcuts>` to "
-"insert formatted text, bullet lists, and more. You can even add file "
+"insert formatted text, bullet lists and more. You can even add file "
 "attachments and links!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:196
+#: ../extras/knowledge-base.rst:213
 msgid "Different link types"
 msgstr ""
 
 #: ../extras/knowledge-base.rst:184
-msgid "**Web link**"
+msgid "Web link"
 msgstr ""
 
 #: ../extras/knowledge-base.rst:184
@@ -6257,8 +6257,10 @@ msgid "URLs pointing to other websites."
 msgstr ""
 
 #: ../extras/knowledge-base.rst:188
-msgid "**Link Answer**"
-msgstr ""
+#, fuzzy
+#| msgid "Linked Accounts"
+msgid "Link Answer"
+msgstr "Contas vinculadas"
 
 #: ../extras/knowledge-base.rst:187
 msgid ""
@@ -6267,65 +6269,93 @@ msgid ""
 msgstr ""
 
 #: ../extras/knowledge-base.rst:192
-#, fuzzy
-msgid "**Linked Tickets**"
-msgstr "Encontrando chamados"
+msgid "Image"
+msgstr ""
 
 #: ../extras/knowledge-base.rst:191
+msgid ""
+"Include an image from your computer in the answer. Unlike file attachments, "
+"these images are embedded directly in the answer."
+msgstr ""
+
+#: ../extras/knowledge-base.rst:199
+msgid "Video"
+msgstr ""
+
+#: ../extras/knowledge-base.rst:195
+msgid ""
+"Include a video to embed in the answer. By default, you can embed videos "
+"from Vimeo and YouTube. Depending on your Zammad settings, MediaCMS and "
+"PeerTube instances can be enabled by your admin as well. A list of supported "
+"video services is displayed in the video dialog below the URL field."
+msgstr ""
+
+#: ../extras/knowledge-base.rst:203
+#, fuzzy
+#| msgid "Linking Tickets"
+msgid "Linked Tickets"
+msgstr "Associando chamados"
+
+#: ../extras/knowledge-base.rst:202
 msgid ""
 "Internal references to Zammad tickets (visible only in preview and edit "
 "mode)."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:196
-#, fuzzy
-#| msgid "Tags"
-msgid "**Tags**"
-msgstr "Tags"
+#: ../extras/knowledge-base.rst:208
+msgid "Attachments"
+msgstr ""
 
-#: ../extras/knowledge-base.rst:195
+#: ../extras/knowledge-base.rst:206
+msgid ""
+"Add any file as an attachment to your answer. Such an attachment isn't "
+"embedded in the body of the answer. Readers can download it by clicking on "
+"it in the attachment section."
+msgstr ""
+
+#: ../extras/knowledge-base.rst:211
 msgid ""
 "Can help to categorize or label answers for better search results. Please "
-"note that tags are visible publicly and can be the same like those in your "
+"note that tags are visible publicly and can be the same as those in your "
 "tickets."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:221
+#: ../extras/knowledge-base.rst:238
 msgid "Visibility"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:199
+#: ../extras/knowledge-base.rst:216
 msgid ""
 "Set the visibility of an answer to control who can see an article, or "
 "schedule it to be published at a later date. Articles are color-coded "
 "according to their visibility:"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:204
+#: ../extras/knowledge-base.rst:221
 msgid "**Public** (visible to everyone)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:206
+#: ../extras/knowledge-base.rst:223
 msgid "|blu|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:206
+#: ../extras/knowledge-base.rst:223
 msgid "**Internal** (visible to agents & editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:208
+#: ../extras/knowledge-base.rst:225
 msgid "|gry|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:208
+#: ../extras/knowledge-base.rst:225
 msgid "**Draft/Scheduled/Archived** (visible to editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:224
+#: ../extras/knowledge-base.rst:241
 msgid "Using Answers In Ticket Articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:226
+#: ../extras/knowledge-base.rst:243
 msgid ""
 "As soon as the knowledge base contains one or more answers, you can use "
 "these just like text modules. Instead of :kbd:`:`:kbd:`:` just use :kbd:`?"
@@ -7589,7 +7619,7 @@ msgstr ""
 
 #: ../extras/two-factor-authentication/security-keys-setup.rst:24
 msgid ""
-"Next, depending you your browser, you will be presented with different "
+"Next, depending on your browser, you will be presented with different "
 "options. Select one that refers to your chosen security key and follow the "
 "instructions on the screen."
 msgstr ""
@@ -8058,6 +8088,15 @@ msgid ""
 "also :docs:`system </index.html>` and :admin-docs:`administration manuals </"
 "index.html>` available."
 msgstr ""
+
+#, fuzzy
+#~ msgid "**Linked Tickets**"
+#~ msgstr "Encontrando chamados"
+
+#, fuzzy
+#~| msgid "Tags"
+#~ msgid "**Tags**"
+#~ msgstr "Tags"
 
 #, fuzzy
 #~ msgid "Split ticket button"

--- a/locale/ru/LC_MESSAGES/user-docs.po
+++ b/locale/ru/LC_MESSAGES/user-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-01 08:43+0200\n"
+"POT-Creation-Date: 2026-07-07 14:22+0200\n"
 "PO-Revision-Date: 2026-06-17 10:18+0000\n"
 "Last-Translator: ElectroKos <kosapashennyh@gmail.com>\n"
 "Language-Team: Russian <https://translations.zammad.org/projects/"
@@ -1538,7 +1538,7 @@ msgstr "|blk|"
 msgid "**Paused, no action needed right now** (e.g. pending)"
 msgstr ""
 
-#: ../snippets/ticket-state-type-circles.rst:8 ../extras/knowledge-base.rst:204
+#: ../snippets/ticket-state-type-circles.rst:8 ../extras/knowledge-base.rst:221
 msgid "|grn|"
 msgstr "|grn|"
 
@@ -2824,6 +2824,7 @@ msgid ""
 msgstr ""
 
 #: ../basics/ticket-basics.rst:117 ../basics/zammad-glossary.rst:706
+#: ../extras/knowledge-base.rst:213
 msgid "Tags"
 msgstr "Теги"
 
@@ -6197,8 +6198,9 @@ msgid ""
 msgstr ""
 
 #: ../extras/knowledge-base.rst:0
-msgid "Screenshot showing the modal for of the RSS button"
-msgstr ""
+#, fuzzy
+msgid "Screenshot shows the modal for of the RSS button"
+msgstr "Снимок экрана, демонстрирующий учтенное время в панели заявки"
 
 #: ../extras/knowledge-base.rst:107
 msgid ""
@@ -6209,7 +6211,7 @@ msgstr ""
 #: ../extras/knowledge-base.rst:110
 msgid ""
 "If you want to revoke the access and renew your token, you can do so in the "
-"RSS modal."
+"RSS dialog."
 msgstr ""
 
 #: ../extras/knowledge-base.rst:0
@@ -6267,9 +6269,7 @@ msgid ""
 msgstr ""
 
 #: ../extras/knowledge-base.rst:None
-msgid ""
-"Screencast showing the visibility option for categories for granular access "
-"permissions"
+msgid "Screenshot shows the granular category permissions for knowledge base"
 msgstr ""
 
 #: ../extras/knowledge-base.rst:153
@@ -6310,16 +6310,16 @@ msgid ""
 "The knowledge base editor comes equipped with the same **rich text editing "
 "capabilities** available in the Zammad ticket composer. That means you can "
 "use the same :doc:`keyboard shortcuts </advanced/keyboard-shortcuts>` to "
-"insert formatted text, bullet lists, and more. You can even add file "
+"insert formatted text, bullet lists and more. You can even add file "
 "attachments and links!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:196
+#: ../extras/knowledge-base.rst:213
 msgid "Different link types"
 msgstr ""
 
 #: ../extras/knowledge-base.rst:184
-msgid "**Web link**"
+msgid "Web link"
 msgstr ""
 
 #: ../extras/knowledge-base.rst:184
@@ -6327,7 +6327,7 @@ msgid "URLs pointing to other websites."
 msgstr ""
 
 #: ../extras/knowledge-base.rst:188
-msgid "**Link Answer**"
+msgid "Link Answer"
 msgstr ""
 
 #: ../extras/knowledge-base.rst:187
@@ -6337,65 +6337,93 @@ msgid ""
 msgstr ""
 
 #: ../extras/knowledge-base.rst:192
-#, fuzzy
-msgid "**Linked Tickets**"
-msgstr "Поиск Тикетов"
+msgid "Image"
+msgstr ""
 
 #: ../extras/knowledge-base.rst:191
+msgid ""
+"Include an image from your computer in the answer. Unlike file attachments, "
+"these images are embedded directly in the answer."
+msgstr ""
+
+#: ../extras/knowledge-base.rst:199
+msgid "Video"
+msgstr ""
+
+#: ../extras/knowledge-base.rst:195
+msgid ""
+"Include a video to embed in the answer. By default, you can embed videos "
+"from Vimeo and YouTube. Depending on your Zammad settings, MediaCMS and "
+"PeerTube instances can be enabled by your admin as well. A list of supported "
+"video services is displayed in the video dialog below the URL field."
+msgstr ""
+
+#: ../extras/knowledge-base.rst:203
+#, fuzzy
+#| msgid "Linking Tickets"
+msgid "Linked Tickets"
+msgstr "Связывание заявок"
+
+#: ../extras/knowledge-base.rst:202
 msgid ""
 "Internal references to Zammad tickets (visible only in preview and edit "
 "mode)."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:196
-#, fuzzy
-#| msgid "Tags"
-msgid "**Tags**"
-msgstr "Теги"
+#: ../extras/knowledge-base.rst:208
+msgid "Attachments"
+msgstr ""
 
-#: ../extras/knowledge-base.rst:195
+#: ../extras/knowledge-base.rst:206
+msgid ""
+"Add any file as an attachment to your answer. Such an attachment isn't "
+"embedded in the body of the answer. Readers can download it by clicking on "
+"it in the attachment section."
+msgstr ""
+
+#: ../extras/knowledge-base.rst:211
 msgid ""
 "Can help to categorize or label answers for better search results. Please "
-"note that tags are visible publicly and can be the same like those in your "
+"note that tags are visible publicly and can be the same as those in your "
 "tickets."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:221
+#: ../extras/knowledge-base.rst:238
 msgid "Visibility"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:199
+#: ../extras/knowledge-base.rst:216
 msgid ""
 "Set the visibility of an answer to control who can see an article, or "
 "schedule it to be published at a later date. Articles are color-coded "
 "according to their visibility:"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:204
+#: ../extras/knowledge-base.rst:221
 msgid "**Public** (visible to everyone)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:206
+#: ../extras/knowledge-base.rst:223
 msgid "|blu|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:206
+#: ../extras/knowledge-base.rst:223
 msgid "**Internal** (visible to agents & editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:208
+#: ../extras/knowledge-base.rst:225
 msgid "|gry|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:208
+#: ../extras/knowledge-base.rst:225
 msgid "**Draft/Scheduled/Archived** (visible to editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:224
+#: ../extras/knowledge-base.rst:241
 msgid "Using Answers In Ticket Articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:226
+#: ../extras/knowledge-base.rst:243
 msgid ""
 "As soon as the knowledge base contains one or more answers, you can use "
 "these just like text modules. Instead of :kbd:`:`:kbd:`:` just use :kbd:`?"
@@ -7625,7 +7653,7 @@ msgstr ""
 
 #: ../extras/two-factor-authentication/security-keys-setup.rst:24
 msgid ""
-"Next, depending you your browser, you will be presented with different "
+"Next, depending on your browser, you will be presented with different "
 "options. Select one that refers to your chosen security key and follow the "
 "instructions on the screen."
 msgstr ""
@@ -8047,6 +8075,15 @@ msgid ""
 "also :docs:`system </index.html>` and :admin-docs:`administration manuals </"
 "index.html>` available."
 msgstr ""
+
+#, fuzzy
+#~ msgid "**Linked Tickets**"
+#~ msgstr "Поиск Тикетов"
+
+#, fuzzy
+#~| msgid "Tags"
+#~ msgid "**Tags**"
+#~ msgstr "Теги"
 
 #~ msgid "Split ticket button"
 #~ msgstr "Кнопка разделения заявки"

--- a/locale/sr/LC_MESSAGES/user-docs.po
+++ b/locale/sr/LC_MESSAGES/user-docs.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-01 08:43+0200\n"
-"PO-Revision-Date: 2026-07-02 16:02+0000\n"
+"POT-Creation-Date: 2026-07-07 14:22+0200\n"
+"PO-Revision-Date: 2026-07-09 16:07+0000\n"
 "Last-Translator: Dusan Vuckovic <dv@zammad.com>\n"
 "Language-Team: Serbian <https://translations.zammad.org/projects/"
 "documentations/user-documentation-pre-release/sr/>\n"
@@ -1542,7 +1542,7 @@ msgstr "|blk|"
 msgid "**Paused, no action needed right now** (e.g. pending)"
 msgstr "**На паузи, не захтева обраду** (нпр. на чекању)"
 
-#: ../snippets/ticket-state-type-circles.rst:8 ../extras/knowledge-base.rst:204
+#: ../snippets/ticket-state-type-circles.rst:8 ../extras/knowledge-base.rst:221
 msgid "|grn|"
 msgstr "|grn|"
 
@@ -2916,6 +2916,7 @@ msgstr ""
 "моменталној ескалацији."
 
 #: ../basics/ticket-basics.rst:117 ../basics/zammad-glossary.rst:706
+#: ../extras/knowledge-base.rst:213
 msgid "Tags"
 msgstr "Ознаке"
 
@@ -7118,7 +7119,7 @@ msgstr ""
 "претплатити."
 
 #: ../extras/knowledge-base.rst:0
-msgid "Screenshot showing the modal for of the RSS button"
+msgid "Screenshot shows the modal for of the RSS button"
 msgstr "Снимак екрана који приказује дијалог RSS дугмета"
 
 #: ../extras/knowledge-base.rst:107
@@ -7132,7 +7133,7 @@ msgstr ""
 #: ../extras/knowledge-base.rst:110
 msgid ""
 "If you want to revoke the access and renew your token, you can do so in the "
-"RSS modal."
+"RSS dialog."
 msgstr ""
 "Ако желите да опозовете приступ и обновите свој токен, то можете учинити у "
 "RSS дијалогу."
@@ -7209,12 +7210,8 @@ msgstr ""
 "docs:`дозволе улоге </manage/roles/agent-permissions.html>`."
 
 #: ../extras/knowledge-base.rst:None
-msgid ""
-"Screencast showing the visibility option for categories for granular access "
-"permissions"
-msgstr ""
-"Снимак екрана који приказује опцију видљивости за ограничене дозволе "
-"категорије"
+msgid "Screenshot shows the granular category permissions for knowledge base"
+msgstr "Снимак екрана који приказује грануларне дозволе категорије базе знања"
 
 #: ../extras/knowledge-base.rst:153
 msgid ""
@@ -7265,7 +7262,7 @@ msgid ""
 "The knowledge base editor comes equipped with the same **rich text editing "
 "capabilities** available in the Zammad ticket composer. That means you can "
 "use the same :doc:`keyboard shortcuts </advanced/keyboard-shortcuts>` to "
-"insert formatted text, bullet lists, and more. You can even add file "
+"insert formatted text, bullet lists and more. You can even add file "
 "attachments and links!"
 msgstr ""
 "Уредник базе знања је опремљен истим **могућностима за уређивање богатог "
@@ -7274,21 +7271,21 @@ msgstr ""
 "бисте уметнули форматирани текст, листе са ознакама и још много тога. Можете "
 "чак додати датотеке прилога и везе!"
 
-#: ../extras/knowledge-base.rst:196
+#: ../extras/knowledge-base.rst:213
 msgid "Different link types"
 msgstr "Различите врсте веза"
 
 #: ../extras/knowledge-base.rst:184
-msgid "**Web link**"
-msgstr "**Интернет линк**"
+msgid "Web link"
+msgstr "Интернет линк"
 
 #: ../extras/knowledge-base.rst:184
 msgid "URLs pointing to other websites."
 msgstr "URL адресе које упућују на друге интернет локације."
 
 #: ../extras/knowledge-base.rst:188
-msgid "**Link Answer**"
-msgstr "**Веза ка чланку**"
+msgid "Link Answer"
+msgstr "Веза ка чланку"
 
 #: ../extras/knowledge-base.rst:187
 msgid ""
@@ -7299,10 +7296,39 @@ msgstr ""
 "се циљна URL путања промени)."
 
 #: ../extras/knowledge-base.rst:192
-msgid "**Linked Tickets**"
-msgstr "**Повезани тикети**"
+msgid "Image"
+msgstr "Слика"
 
 #: ../extras/knowledge-base.rst:191
+msgid ""
+"Include an image from your computer in the answer. Unlike file attachments, "
+"these images are embedded directly in the answer."
+msgstr ""
+"Убаците слику у чланак отпремањем са вашег рачунара. За разлику од датотека "
+"прилога, ове слике ће бити интегрисане директно у чланак."
+
+#: ../extras/knowledge-base.rst:199
+msgid "Video"
+msgstr "Видео"
+
+#: ../extras/knowledge-base.rst:195
+msgid ""
+"Include a video to embed in the answer. By default, you can embed videos "
+"from Vimeo and YouTube. Depending on your Zammad settings, MediaCMS and "
+"PeerTube instances can be enabled by your admin as well. A list of supported "
+"video services is displayed in the video dialog below the URL field."
+msgstr ""
+"Убаците интегрисани видео у чланак. Подразумевано, можете убацити видео са "
+"Vimeo и YouTube сервиса. У зависности од ваших Zammad подешавања, и MediaCMS "
+"и PeerTube инстанце могу бити укључене од стране вашег администратора. Листа "
+"подржаних видео сервиса ће бити приказана у видео дијалогу испод поља URL "
+"адресе."
+
+#: ../extras/knowledge-base.rst:203
+msgid "Linked Tickets"
+msgstr "Повезани тикети"
+
+#: ../extras/knowledge-base.rst:202
 msgid ""
 "Internal references to Zammad tickets (visible only in preview and edit "
 "mode)."
@@ -7310,25 +7336,35 @@ msgstr ""
 "Интерне референце на Zammad тикете (видљиве само у режиму приказа и "
 "уређивања)."
 
-#: ../extras/knowledge-base.rst:196
-msgid "**Tags**"
-msgstr "**Ознаке**"
+#: ../extras/knowledge-base.rst:208
+msgid "Attachments"
+msgstr "Прилози"
 
-#: ../extras/knowledge-base.rst:195
+#: ../extras/knowledge-base.rst:206
+msgid ""
+"Add any file as an attachment to your answer. Such an attachment isn't "
+"embedded in the body of the answer. Readers can download it by clicking on "
+"it in the attachment section."
+msgstr ""
+"Додајте било коју датотеку као прилог вашем чланку. Овакви прилози неће бити "
+"интегрисани у тело чланка. Читаоци ће моћи да их преузму кликом унутар "
+"одељка прилога."
+
+#: ../extras/knowledge-base.rst:211
 msgid ""
 "Can help to categorize or label answers for better search results. Please "
-"note that tags are visible publicly and can be the same like those in your "
+"note that tags are visible publicly and can be the same as those in your "
 "tickets."
 msgstr ""
 "Може помоћи приликом категоризације или обележавања чланака за бољу "
 "претрагу. Имајте на уму да су ознаке јавно видљиве и да могу бити исте као и "
 "оне у вашим тикетима."
 
-#: ../extras/knowledge-base.rst:221
+#: ../extras/knowledge-base.rst:238
 msgid "Visibility"
 msgstr "Видљивост"
 
-#: ../extras/knowledge-base.rst:199
+#: ../extras/knowledge-base.rst:216
 msgid ""
 "Set the visibility of an answer to control who can see an article, or "
 "schedule it to be published at a later date. Articles are color-coded "
@@ -7338,31 +7374,31 @@ msgstr ""
 "закажите његово објављивање за касније. Чланци су означени бојама према "
 "њиховој видљивости:"
 
-#: ../extras/knowledge-base.rst:204
+#: ../extras/knowledge-base.rst:221
 msgid "**Public** (visible to everyone)"
 msgstr "**Јавно** (видљиво свима)"
 
-#: ../extras/knowledge-base.rst:206
+#: ../extras/knowledge-base.rst:223
 msgid "|blu|"
 msgstr "|blu|"
 
-#: ../extras/knowledge-base.rst:206
+#: ../extras/knowledge-base.rst:223
 msgid "**Internal** (visible to agents & editors only)"
 msgstr "**Интерно** (видљиво само оператерима и уредницима)"
 
-#: ../extras/knowledge-base.rst:208
+#: ../extras/knowledge-base.rst:225
 msgid "|gry|"
 msgstr "|gry|"
 
-#: ../extras/knowledge-base.rst:208
+#: ../extras/knowledge-base.rst:225
 msgid "**Draft/Scheduled/Archived** (visible to editors only)"
 msgstr "**Нацрт/Заказано/Архивирано** (видљиво само уредницима)"
 
-#: ../extras/knowledge-base.rst:224
+#: ../extras/knowledge-base.rst:241
 msgid "Using Answers In Ticket Articles"
 msgstr "Коришћење чланака у тикетима"
 
-#: ../extras/knowledge-base.rst:226
+#: ../extras/knowledge-base.rst:243
 msgid ""
 "As soon as the knowledge base contains one or more answers, you can use "
 "these just like text modules. Instead of :kbd:`:`:kbd:`:` just use :kbd:`?"
@@ -8856,7 +8892,7 @@ msgstr "Назив безбедносног кључа"
 
 #: ../extras/two-factor-authentication/security-keys-setup.rst:24
 msgid ""
-"Next, depending you your browser, you will be presented with different "
+"Next, depending on your browser, you will be presented with different "
 "options. Select one that refers to your chosen security key and follow the "
 "instructions on the screen."
 msgstr ""
@@ -9389,6 +9425,19 @@ msgstr ""
 "Тренутно читате Zammad корисничку документацију. Такође су "
 "доступни :docs:`системски </index.html>` и :admin-docs:`администраторски </"
 "index.html>` приручници."
+
+#~ msgid ""
+#~ "Screencast showing the visibility option for categories for granular "
+#~ "access permissions"
+#~ msgstr ""
+#~ "Снимак екрана који приказује опцију видљивости за ограничене дозволе "
+#~ "категорије"
+
+#~ msgid "**Linked Tickets**"
+#~ msgstr "**Повезани тикети**"
+
+#~ msgid "**Tags**"
+#~ msgstr "**Ознаке**"
 
 #~ msgid "Screencast demo of S/MIME features for both new tickets and replies"
 #~ msgstr "Снимак екрана са S/MIME функцијом за нове тикете и одговоре"
@@ -11665,13 +11714,6 @@ msgstr ""
 
 #~ msgid "**⚙️ Roles require knowledge base reader permission**"
 #~ msgstr "**⚙️ Улоге захтевају дозволу за читање базе знања**"
-
-#~ msgid ""
-#~ "Your administrator has to provide the relevant groups with reader "
-#~ "permissions for the knowledge base."
-#~ msgstr ""
-#~ "Ваш администратор мора да обезбеди релевантним групама дозволе за читање "
-#~ "за базу знања."
 
 #~ msgid "**🥵 Beware of visibility levels**"
 #~ msgstr "**🥵 Пазите на нивое видљивости**"

--- a/locale/sv/LC_MESSAGES/user-docs.po
+++ b/locale/sv/LC_MESSAGES/user-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-01 08:43+0200\n"
+"POT-Creation-Date: 2026-07-07 14:22+0200\n"
 "PO-Revision-Date: 2026-06-17 10:18+0000\n"
 "Last-Translator: Mattias Blomqvist <terminatorr__@hotmail.com>\n"
 "Language-Team: Swedish <https://translations.zammad.org/projects/"
@@ -1404,7 +1404,7 @@ msgstr ""
 msgid "**Paused, no action needed right now** (e.g. pending)"
 msgstr ""
 
-#: ../snippets/ticket-state-type-circles.rst:8 ../extras/knowledge-base.rst:204
+#: ../snippets/ticket-state-type-circles.rst:8 ../extras/knowledge-base.rst:221
 msgid "|grn|"
 msgstr ""
 
@@ -2485,6 +2485,7 @@ msgid ""
 msgstr ""
 
 #: ../basics/ticket-basics.rst:117 ../basics/zammad-glossary.rst:706
+#: ../extras/knowledge-base.rst:213
 msgid "Tags"
 msgstr ""
 
@@ -5778,8 +5779,9 @@ msgid ""
 msgstr ""
 
 #: ../extras/knowledge-base.rst:0
-msgid "Screenshot showing the modal for of the RSS button"
-msgstr ""
+#, fuzzy
+msgid "Screenshot shows the modal for of the RSS button"
+msgstr "Screencast som visar hur man kör ett makro i ett ärende."
 
 #: ../extras/knowledge-base.rst:107
 msgid ""
@@ -5790,7 +5792,7 @@ msgstr ""
 #: ../extras/knowledge-base.rst:110
 msgid ""
 "If you want to revoke the access and renew your token, you can do so in the "
-"RSS modal."
+"RSS dialog."
 msgstr ""
 
 #: ../extras/knowledge-base.rst:0
@@ -5848,9 +5850,7 @@ msgid ""
 msgstr ""
 
 #: ../extras/knowledge-base.rst:None
-msgid ""
-"Screencast showing the visibility option for categories for granular access "
-"permissions"
+msgid "Screenshot shows the granular category permissions for knowledge base"
 msgstr ""
 
 #: ../extras/knowledge-base.rst:153
@@ -5891,16 +5891,16 @@ msgid ""
 "The knowledge base editor comes equipped with the same **rich text editing "
 "capabilities** available in the Zammad ticket composer. That means you can "
 "use the same :doc:`keyboard shortcuts </advanced/keyboard-shortcuts>` to "
-"insert formatted text, bullet lists, and more. You can even add file "
+"insert formatted text, bullet lists and more. You can even add file "
 "attachments and links!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:196
+#: ../extras/knowledge-base.rst:213
 msgid "Different link types"
 msgstr ""
 
 #: ../extras/knowledge-base.rst:184
-msgid "**Web link**"
+msgid "Web link"
 msgstr ""
 
 #: ../extras/knowledge-base.rst:184
@@ -5908,7 +5908,7 @@ msgid "URLs pointing to other websites."
 msgstr ""
 
 #: ../extras/knowledge-base.rst:188
-msgid "**Link Answer**"
+msgid "Link Answer"
 msgstr ""
 
 #: ../extras/knowledge-base.rst:187
@@ -5918,63 +5918,92 @@ msgid ""
 msgstr ""
 
 #: ../extras/knowledge-base.rst:192
-#, fuzzy
-msgid "**Linked Tickets**"
-msgstr "Ärenden"
+msgid "Image"
+msgstr ""
 
 #: ../extras/knowledge-base.rst:191
+msgid ""
+"Include an image from your computer in the answer. Unlike file attachments, "
+"these images are embedded directly in the answer."
+msgstr ""
+
+#: ../extras/knowledge-base.rst:199
+msgid "Video"
+msgstr ""
+
+#: ../extras/knowledge-base.rst:195
+msgid ""
+"Include a video to embed in the answer. By default, you can embed videos "
+"from Vimeo and YouTube. Depending on your Zammad settings, MediaCMS and "
+"PeerTube instances can be enabled by your admin as well. A list of supported "
+"video services is displayed in the video dialog below the URL field."
+msgstr ""
+
+#: ../extras/knowledge-base.rst:203
+#, fuzzy
+msgid "Linked Tickets"
+msgstr "Ärenden"
+
+#: ../extras/knowledge-base.rst:202
 msgid ""
 "Internal references to Zammad tickets (visible only in preview and edit "
 "mode)."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:196
-msgid "**Tags**"
+#: ../extras/knowledge-base.rst:208
+msgid "Attachments"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:195
+#: ../extras/knowledge-base.rst:206
+msgid ""
+"Add any file as an attachment to your answer. Such an attachment isn't "
+"embedded in the body of the answer. Readers can download it by clicking on "
+"it in the attachment section."
+msgstr ""
+
+#: ../extras/knowledge-base.rst:211
 msgid ""
 "Can help to categorize or label answers for better search results. Please "
-"note that tags are visible publicly and can be the same like those in your "
+"note that tags are visible publicly and can be the same as those in your "
 "tickets."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:221
+#: ../extras/knowledge-base.rst:238
 msgid "Visibility"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:199
+#: ../extras/knowledge-base.rst:216
 msgid ""
 "Set the visibility of an answer to control who can see an article, or "
 "schedule it to be published at a later date. Articles are color-coded "
 "according to their visibility:"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:204
+#: ../extras/knowledge-base.rst:221
 msgid "**Public** (visible to everyone)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:206
+#: ../extras/knowledge-base.rst:223
 msgid "|blu|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:206
+#: ../extras/knowledge-base.rst:223
 msgid "**Internal** (visible to agents & editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:208
+#: ../extras/knowledge-base.rst:225
 msgid "|gry|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:208
+#: ../extras/knowledge-base.rst:225
 msgid "**Draft/Scheduled/Archived** (visible to editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:224
+#: ../extras/knowledge-base.rst:241
 msgid "Using Answers In Ticket Articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:226
+#: ../extras/knowledge-base.rst:243
 msgid ""
 "As soon as the knowledge base contains one or more answers, you can use "
 "these just like text modules. Instead of :kbd:`:`:kbd:`:` just use :kbd:`?"
@@ -7182,7 +7211,7 @@ msgstr ""
 
 #: ../extras/two-factor-authentication/security-keys-setup.rst:24
 msgid ""
-"Next, depending you your browser, you will be presented with different "
+"Next, depending on your browser, you will be presented with different "
 "options. Select one that refers to your chosen security key and follow the "
 "instructions on the screen."
 msgstr ""
@@ -7598,6 +7627,10 @@ msgid ""
 "also :docs:`system </index.html>` and :admin-docs:`administration manuals </"
 "index.html>` available."
 msgstr ""
+
+#, fuzzy
+#~ msgid "**Linked Tickets**"
+#~ msgstr "Ärenden"
 
 #, fuzzy
 #~ msgid "Split ticket button"

--- a/locale/th/LC_MESSAGES/user-docs.po
+++ b/locale/th/LC_MESSAGES/user-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-01 08:43+0200\n"
+"POT-Creation-Date: 2026-07-07 14:22+0200\n"
 "PO-Revision-Date: 2026-06-17 10:18+0000\n"
 "Last-Translator: Sumonchai Wongphithak <sumonchai@gmail.com>\n"
 "Language-Team: Thai <https://translations.zammad.org/projects/documentations/"
@@ -1383,7 +1383,7 @@ msgstr "|blk|"
 msgid "**Paused, no action needed right now** (e.g. pending)"
 msgstr ""
 
-#: ../snippets/ticket-state-type-circles.rst:8 ../extras/knowledge-base.rst:204
+#: ../snippets/ticket-state-type-circles.rst:8 ../extras/knowledge-base.rst:221
 msgid "|grn|"
 msgstr "|grn|"
 
@@ -2467,6 +2467,7 @@ msgid ""
 msgstr ""
 
 #: ../basics/ticket-basics.rst:117 ../basics/zammad-glossary.rst:706
+#: ../extras/knowledge-base.rst:213
 msgid "Tags"
 msgstr ""
 
@@ -5773,8 +5774,9 @@ msgid ""
 msgstr ""
 
 #: ../extras/knowledge-base.rst:0
-msgid "Screenshot showing the modal for of the RSS button"
-msgstr ""
+#, fuzzy
+msgid "Screenshot shows the modal for of the RSS button"
+msgstr "สร้างใบแจ้งซ่อม"
 
 #: ../extras/knowledge-base.rst:107
 msgid ""
@@ -5785,7 +5787,7 @@ msgstr ""
 #: ../extras/knowledge-base.rst:110
 msgid ""
 "If you want to revoke the access and renew your token, you can do so in the "
-"RSS modal."
+"RSS dialog."
 msgstr ""
 
 #: ../extras/knowledge-base.rst:0
@@ -5843,9 +5845,7 @@ msgid ""
 msgstr ""
 
 #: ../extras/knowledge-base.rst:None
-msgid ""
-"Screencast showing the visibility option for categories for granular access "
-"permissions"
+msgid "Screenshot shows the granular category permissions for knowledge base"
 msgstr ""
 
 #: ../extras/knowledge-base.rst:153
@@ -5886,18 +5886,18 @@ msgid ""
 "The knowledge base editor comes equipped with the same **rich text editing "
 "capabilities** available in the Zammad ticket composer. That means you can "
 "use the same :doc:`keyboard shortcuts </advanced/keyboard-shortcuts>` to "
-"insert formatted text, bullet lists, and more. You can even add file "
+"insert formatted text, bullet lists and more. You can even add file "
 "attachments and links!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:196
+#: ../extras/knowledge-base.rst:213
 msgid "Different link types"
 msgstr ""
 
 #: ../extras/knowledge-base.rst:184
 #, fuzzy
 #| msgid "🔗 **Weblink**"
-msgid "**Web link**"
+msgid "Web link"
 msgstr "🔗 **ลิ้งเข้าถึง**"
 
 #: ../extras/knowledge-base.rst:184
@@ -5907,7 +5907,7 @@ msgstr ""
 #: ../extras/knowledge-base.rst:188
 #, fuzzy
 #| msgid "💡 **Link Answer**"
-msgid "**Link Answer**"
+msgid "Link Answer"
 msgstr "💡 **ไป ดูคำตอบ**"
 
 #: ../extras/knowledge-base.rst:187
@@ -5917,64 +5917,92 @@ msgid ""
 msgstr ""
 
 #: ../extras/knowledge-base.rst:192
-#, fuzzy
-#| msgid "📋 **Linked Tickets**"
-msgid "**Linked Tickets**"
-msgstr "📋 **เชื่อม ใบแจ้งซ่อม**"
+msgid "Image"
+msgstr ""
 
 #: ../extras/knowledge-base.rst:191
+msgid ""
+"Include an image from your computer in the answer. Unlike file attachments, "
+"these images are embedded directly in the answer."
+msgstr ""
+
+#: ../extras/knowledge-base.rst:199
+msgid "Video"
+msgstr ""
+
+#: ../extras/knowledge-base.rst:195
+msgid ""
+"Include a video to embed in the answer. By default, you can embed videos "
+"from Vimeo and YouTube. Depending on your Zammad settings, MediaCMS and "
+"PeerTube instances can be enabled by your admin as well. A list of supported "
+"video services is displayed in the video dialog below the URL field."
+msgstr ""
+
+#: ../extras/knowledge-base.rst:203
+#, fuzzy
+msgid "Linked Tickets"
+msgstr "กำลังค้นหา ใบแจ้งซ่อม"
+
+#: ../extras/knowledge-base.rst:202
 msgid ""
 "Internal references to Zammad tickets (visible only in preview and edit "
 "mode)."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:196
-msgid "**Tags**"
+#: ../extras/knowledge-base.rst:208
+msgid "Attachments"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:195
+#: ../extras/knowledge-base.rst:206
+msgid ""
+"Add any file as an attachment to your answer. Such an attachment isn't "
+"embedded in the body of the answer. Readers can download it by clicking on "
+"it in the attachment section."
+msgstr ""
+
+#: ../extras/knowledge-base.rst:211
 msgid ""
 "Can help to categorize or label answers for better search results. Please "
-"note that tags are visible publicly and can be the same like those in your "
+"note that tags are visible publicly and can be the same as those in your "
 "tickets."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:221
+#: ../extras/knowledge-base.rst:238
 msgid "Visibility"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:199
+#: ../extras/knowledge-base.rst:216
 msgid ""
 "Set the visibility of an answer to control who can see an article, or "
 "schedule it to be published at a later date. Articles are color-coded "
 "according to their visibility:"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:204
+#: ../extras/knowledge-base.rst:221
 msgid "**Public** (visible to everyone)"
 msgstr "**เผยแพร่** (ทุกคนเข้าดูได้)"
 
-#: ../extras/knowledge-base.rst:206
+#: ../extras/knowledge-base.rst:223
 msgid "|blu|"
 msgstr "|blu|"
 
-#: ../extras/knowledge-base.rst:206
+#: ../extras/knowledge-base.rst:223
 msgid "**Internal** (visible to agents & editors only)"
 msgstr "**ภายใน** (เจ้าหน้าที่ และผู้แก้ไข)"
 
-#: ../extras/knowledge-base.rst:208
+#: ../extras/knowledge-base.rst:225
 msgid "|gry|"
 msgstr "|gry|"
 
-#: ../extras/knowledge-base.rst:208
+#: ../extras/knowledge-base.rst:225
 msgid "**Draft/Scheduled/Archived** (visible to editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:224
+#: ../extras/knowledge-base.rst:241
 msgid "Using Answers In Ticket Articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:226
+#: ../extras/knowledge-base.rst:243
 msgid ""
 "As soon as the knowledge base contains one or more answers, you can use "
 "these just like text modules. Instead of :kbd:`:`:kbd:`:` just use :kbd:`?"
@@ -7197,7 +7225,7 @@ msgstr ""
 
 #: ../extras/two-factor-authentication/security-keys-setup.rst:24
 msgid ""
-"Next, depending you your browser, you will be presented with different "
+"Next, depending on your browser, you will be presented with different "
 "options. Select one that refers to your chosen security key and follow the "
 "instructions on the screen."
 msgstr ""
@@ -7624,6 +7652,11 @@ msgid ""
 "also :docs:`system </index.html>` and :admin-docs:`administration manuals </"
 "index.html>` available."
 msgstr ""
+
+#, fuzzy
+#~| msgid "📋 **Linked Tickets**"
+#~ msgid "**Linked Tickets**"
+#~ msgstr "📋 **เชื่อม ใบแจ้งซ่อม**"
 
 #, fuzzy
 #~ msgid "Split ticket button"

--- a/locale/tr/LC_MESSAGES/user-docs.po
+++ b/locale/tr/LC_MESSAGES/user-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-01 08:43+0200\n"
+"POT-Creation-Date: 2026-07-07 14:22+0200\n"
 "PO-Revision-Date: 2026-06-17 10:17+0000\n"
 "Last-Translator: Suat VARLIKLI <suatvarlikli89@gmail.com>\n"
 "Language-Team: Turkish <https://translations.zammad.org/projects/"
@@ -1537,7 +1537,7 @@ msgstr "|blk|"
 msgid "**Paused, no action needed right now** (e.g. pending)"
 msgstr ""
 
-#: ../snippets/ticket-state-type-circles.rst:8 ../extras/knowledge-base.rst:204
+#: ../snippets/ticket-state-type-circles.rst:8 ../extras/knowledge-base.rst:221
 msgid "|grn|"
 msgstr "|grn|"
 
@@ -2713,6 +2713,7 @@ msgid ""
 msgstr ""
 
 #: ../basics/ticket-basics.rst:117 ../basics/zammad-glossary.rst:706
+#: ../extras/knowledge-base.rst:213
 msgid "Tags"
 msgstr "Etiketler"
 
@@ -6291,8 +6292,9 @@ msgid ""
 msgstr ""
 
 #: ../extras/knowledge-base.rst:0
-msgid "Screenshot showing the modal for of the RSS button"
-msgstr ""
+#, fuzzy
+msgid "Screenshot shows the modal for of the RSS button"
+msgstr "Yeni biletler"
 
 #: ../extras/knowledge-base.rst:107
 msgid ""
@@ -6303,7 +6305,7 @@ msgstr ""
 #: ../extras/knowledge-base.rst:110
 msgid ""
 "If you want to revoke the access and renew your token, you can do so in the "
-"RSS modal."
+"RSS dialog."
 msgstr ""
 
 #: ../extras/knowledge-base.rst:0
@@ -6367,9 +6369,7 @@ msgid ""
 msgstr ""
 
 #: ../extras/knowledge-base.rst:None
-msgid ""
-"Screencast showing the visibility option for categories for granular access "
-"permissions"
+msgid "Screenshot shows the granular category permissions for knowledge base"
 msgstr ""
 
 #: ../extras/knowledge-base.rst:153
@@ -6406,11 +6406,18 @@ msgid "Edit answer"
 msgstr ""
 
 #: ../extras/knowledge-base.rst:176
+#, fuzzy
+#| msgid ""
+#| "The knowledge base editor comes equipped with the same **rich text "
+#| "editing capabilities** available in the Zammad ticket composer. That "
+#| "means you can use the same :doc:`keyboard shortcuts </advanced/keyboard-"
+#| "shortcuts>` to insert formatted text, bullet lists, and more. You can "
+#| "even add file attachments and links!"
 msgid ""
 "The knowledge base editor comes equipped with the same **rich text editing "
 "capabilities** available in the Zammad ticket composer. That means you can "
 "use the same :doc:`keyboard shortcuts </advanced/keyboard-shortcuts>` to "
-"insert formatted text, bullet lists, and more. You can even add file "
+"insert formatted text, bullet lists and more. You can even add file "
 "attachments and links!"
 msgstr ""
 "Bilgi tabanı düzenleyicisi, Zammad bilet oluşturucusunda bulunan aynı "
@@ -6420,14 +6427,14 @@ msgstr ""
 "kullanabileceğiniz anlamına gelir. Hatta dosya ekleri ve bağlantılar "
 "ekleyebilirsiniz!"
 
-#: ../extras/knowledge-base.rst:196
+#: ../extras/knowledge-base.rst:213
 msgid "Different link types"
 msgstr ""
 
 #: ../extras/knowledge-base.rst:184
 #, fuzzy
 #| msgid "🔗 **Weblink**"
-msgid "**Web link**"
+msgid "Web link"
 msgstr "🔗 **Web bağlantısı**"
 
 #: ../extras/knowledge-base.rst:184
@@ -6437,7 +6444,7 @@ msgstr "URL'ler diğer web sitelerini gösteriyor."
 #: ../extras/knowledge-base.rst:188
 #, fuzzy
 #| msgid "💡 **Link Answer**"
-msgid "**Link Answer**"
+msgid "Link Answer"
 msgstr "💡 **Bağlantılı Cevap**"
 
 #: ../extras/knowledge-base.rst:187
@@ -6448,36 +6455,63 @@ msgid ""
 msgstr "Diğer bilgi tabanı cevaplarından iç referanslar."
 
 #: ../extras/knowledge-base.rst:192
-#, fuzzy
-#| msgid "📋 **Linked Tickets**"
-msgid "**Linked Tickets**"
-msgstr "📋 **Bağlı Biletler**"
+msgid "Image"
+msgstr ""
 
 #: ../extras/knowledge-base.rst:191
+msgid ""
+"Include an image from your computer in the answer. Unlike file attachments, "
+"these images are embedded directly in the answer."
+msgstr ""
+
+#: ../extras/knowledge-base.rst:199
+msgid "Video"
+msgstr ""
+
+#: ../extras/knowledge-base.rst:195
+msgid ""
+"Include a video to embed in the answer. By default, you can embed videos "
+"from Vimeo and YouTube. Depending on your Zammad settings, MediaCMS and "
+"PeerTube instances can be enabled by your admin as well. A list of supported "
+"video services is displayed in the video dialog below the URL field."
+msgstr ""
+
+#: ../extras/knowledge-base.rst:203
+#, fuzzy
+#| msgid "Linking Tickets"
+msgid "Linked Tickets"
+msgstr "Bağlantılı Biletler"
+
+#: ../extras/knowledge-base.rst:202
 #, fuzzy
 msgid ""
 "Internal references to Zammad tickets (visible only in preview and edit "
 "mode)."
 msgstr "Zammad biletlerinden iç referanslar."
 
-#: ../extras/knowledge-base.rst:196
-#, fuzzy
-#| msgid "Tags"
-msgid "**Tags**"
-msgstr "Etiketler"
+#: ../extras/knowledge-base.rst:208
+msgid "Attachments"
+msgstr ""
 
-#: ../extras/knowledge-base.rst:195
+#: ../extras/knowledge-base.rst:206
+msgid ""
+"Add any file as an attachment to your answer. Such an attachment isn't "
+"embedded in the body of the answer. Readers can download it by clicking on "
+"it in the attachment section."
+msgstr ""
+
+#: ../extras/knowledge-base.rst:211
 msgid ""
 "Can help to categorize or label answers for better search results. Please "
-"note that tags are visible publicly and can be the same like those in your "
+"note that tags are visible publicly and can be the same as those in your "
 "tickets."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:221
+#: ../extras/knowledge-base.rst:238
 msgid "Visibility"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:199
+#: ../extras/knowledge-base.rst:216
 #, fuzzy
 msgid ""
 "Set the visibility of an answer to control who can see an article, or "
@@ -6488,31 +6522,31 @@ msgstr ""
 "tarihte yayınlanmasını planlamak için yanıtın **görünürlüğünü** ayarlayın. "
 "Makaleler, görünürlüklerine göre **renk kodu** alır:"
 
-#: ../extras/knowledge-base.rst:204
+#: ../extras/knowledge-base.rst:221
 msgid "**Public** (visible to everyone)"
 msgstr "**Herkese Açık** (herkes tarafından görülebilir)"
 
-#: ../extras/knowledge-base.rst:206
+#: ../extras/knowledge-base.rst:223
 msgid "|blu|"
 msgstr "|blu|"
 
-#: ../extras/knowledge-base.rst:206
+#: ../extras/knowledge-base.rst:223
 msgid "**Internal** (visible to agents & editors only)"
 msgstr "**Dahili** (sadece aracılar ve editörler görebilir)"
 
-#: ../extras/knowledge-base.rst:208
+#: ../extras/knowledge-base.rst:225
 msgid "|gry|"
 msgstr "|gry|"
 
-#: ../extras/knowledge-base.rst:208
+#: ../extras/knowledge-base.rst:225
 msgid "**Draft/Scheduled/Archived** (visible to editors only)"
 msgstr "**Taslak/Planlanmış/Arşiv** (sadece editörler görebilir)"
 
-#: ../extras/knowledge-base.rst:224
+#: ../extras/knowledge-base.rst:241
 msgid "Using Answers In Ticket Articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:226
+#: ../extras/knowledge-base.rst:243
 msgid ""
 "As soon as the knowledge base contains one or more answers, you can use "
 "these just like text modules. Instead of :kbd:`:`:kbd:`:` just use :kbd:`?"
@@ -7850,7 +7884,7 @@ msgstr ""
 
 #: ../extras/two-factor-authentication/security-keys-setup.rst:24
 msgid ""
-"Next, depending you your browser, you will be presented with different "
+"Next, depending on your browser, you will be presented with different "
 "options. Select one that refers to your chosen security key and follow the "
 "instructions on the screen."
 msgstr ""
@@ -8342,6 +8376,16 @@ msgstr ""
 "Şu anda Zammad kullanıcı belgelerini okumaktasınız. Ayrıca :docs:`system </"
 "index.html>` ve :admin-docs:`administration manuals </index.html>` da "
 "mevcuttur."
+
+#, fuzzy
+#~| msgid "📋 **Linked Tickets**"
+#~ msgid "**Linked Tickets**"
+#~ msgstr "📋 **Bağlı Biletler**"
+
+#, fuzzy
+#~| msgid "Tags"
+#~ msgid "**Tags**"
+#~ msgstr "Etiketler"
 
 #, fuzzy
 #~ msgid ""

--- a/locale/zh_Hans/LC_MESSAGES/user-docs.po
+++ b/locale/zh_Hans/LC_MESSAGES/user-docs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-01 08:43+0200\n"
+"POT-Creation-Date: 2026-07-07 14:22+0200\n"
 "PO-Revision-Date: 2026-06-17 10:15+0000\n"
 "Last-Translator: chen <chenchen@4chian.com>\n"
 "Language-Team: Chinese (Simplified Han script) <https://"
@@ -1441,7 +1441,7 @@ msgstr ""
 msgid "**Paused, no action needed right now** (e.g. pending)"
 msgstr ""
 
-#: ../snippets/ticket-state-type-circles.rst:8 ../extras/knowledge-base.rst:204
+#: ../snippets/ticket-state-type-circles.rst:8 ../extras/knowledge-base.rst:221
 msgid "|grn|"
 msgstr ""
 
@@ -2526,6 +2526,7 @@ msgid ""
 msgstr ""
 
 #: ../basics/ticket-basics.rst:117 ../basics/zammad-glossary.rst:706
+#: ../extras/knowledge-base.rst:213
 msgid "Tags"
 msgstr ""
 
@@ -5819,8 +5820,9 @@ msgid ""
 msgstr ""
 
 #: ../extras/knowledge-base.rst:0
-msgid "Screenshot showing the modal for of the RSS button"
-msgstr ""
+#, fuzzy
+msgid "Screenshot shows the modal for of the RSS button"
+msgstr "演示如何在工单视图中运行宏的屏幕录像。"
 
 #: ../extras/knowledge-base.rst:107
 msgid ""
@@ -5831,7 +5833,7 @@ msgstr ""
 #: ../extras/knowledge-base.rst:110
 msgid ""
 "If you want to revoke the access and renew your token, you can do so in the "
-"RSS modal."
+"RSS dialog."
 msgstr ""
 
 #: ../extras/knowledge-base.rst:0
@@ -5889,9 +5891,7 @@ msgid ""
 msgstr ""
 
 #: ../extras/knowledge-base.rst:None
-msgid ""
-"Screencast showing the visibility option for categories for granular access "
-"permissions"
+msgid "Screenshot shows the granular category permissions for knowledge base"
 msgstr ""
 
 #: ../extras/knowledge-base.rst:153
@@ -5932,16 +5932,16 @@ msgid ""
 "The knowledge base editor comes equipped with the same **rich text editing "
 "capabilities** available in the Zammad ticket composer. That means you can "
 "use the same :doc:`keyboard shortcuts </advanced/keyboard-shortcuts>` to "
-"insert formatted text, bullet lists, and more. You can even add file "
+"insert formatted text, bullet lists and more. You can even add file "
 "attachments and links!"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:196
+#: ../extras/knowledge-base.rst:213
 msgid "Different link types"
 msgstr ""
 
 #: ../extras/knowledge-base.rst:184
-msgid "**Web link**"
+msgid "Web link"
 msgstr ""
 
 #: ../extras/knowledge-base.rst:184
@@ -5949,7 +5949,7 @@ msgid "URLs pointing to other websites."
 msgstr ""
 
 #: ../extras/knowledge-base.rst:188
-msgid "**Link Answer**"
+msgid "Link Answer"
 msgstr ""
 
 #: ../extras/knowledge-base.rst:187
@@ -5959,63 +5959,92 @@ msgid ""
 msgstr ""
 
 #: ../extras/knowledge-base.rst:192
-#, fuzzy
-msgid "**Linked Tickets**"
-msgstr "宏"
+msgid "Image"
+msgstr ""
 
 #: ../extras/knowledge-base.rst:191
+msgid ""
+"Include an image from your computer in the answer. Unlike file attachments, "
+"these images are embedded directly in the answer."
+msgstr ""
+
+#: ../extras/knowledge-base.rst:199
+msgid "Video"
+msgstr ""
+
+#: ../extras/knowledge-base.rst:195
+msgid ""
+"Include a video to embed in the answer. By default, you can embed videos "
+"from Vimeo and YouTube. Depending on your Zammad settings, MediaCMS and "
+"PeerTube instances can be enabled by your admin as well. A list of supported "
+"video services is displayed in the video dialog below the URL field."
+msgstr ""
+
+#: ../extras/knowledge-base.rst:203
+#, fuzzy
+msgid "Linked Tickets"
+msgstr "宏"
+
+#: ../extras/knowledge-base.rst:202
 msgid ""
 "Internal references to Zammad tickets (visible only in preview and edit "
 "mode)."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:196
-msgid "**Tags**"
+#: ../extras/knowledge-base.rst:208
+msgid "Attachments"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:195
+#: ../extras/knowledge-base.rst:206
+msgid ""
+"Add any file as an attachment to your answer. Such an attachment isn't "
+"embedded in the body of the answer. Readers can download it by clicking on "
+"it in the attachment section."
+msgstr ""
+
+#: ../extras/knowledge-base.rst:211
 msgid ""
 "Can help to categorize or label answers for better search results. Please "
-"note that tags are visible publicly and can be the same like those in your "
+"note that tags are visible publicly and can be the same as those in your "
 "tickets."
 msgstr ""
 
-#: ../extras/knowledge-base.rst:221
+#: ../extras/knowledge-base.rst:238
 msgid "Visibility"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:199
+#: ../extras/knowledge-base.rst:216
 msgid ""
 "Set the visibility of an answer to control who can see an article, or "
 "schedule it to be published at a later date. Articles are color-coded "
 "according to their visibility:"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:204
+#: ../extras/knowledge-base.rst:221
 msgid "**Public** (visible to everyone)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:206
+#: ../extras/knowledge-base.rst:223
 msgid "|blu|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:206
+#: ../extras/knowledge-base.rst:223
 msgid "**Internal** (visible to agents & editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:208
+#: ../extras/knowledge-base.rst:225
 msgid "|gry|"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:208
+#: ../extras/knowledge-base.rst:225
 msgid "**Draft/Scheduled/Archived** (visible to editors only)"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:224
+#: ../extras/knowledge-base.rst:241
 msgid "Using Answers In Ticket Articles"
 msgstr ""
 
-#: ../extras/knowledge-base.rst:226
+#: ../extras/knowledge-base.rst:243
 msgid ""
 "As soon as the knowledge base contains one or more answers, you can use "
 "these just like text modules. Instead of :kbd:`:`:kbd:`:` just use :kbd:`?"
@@ -7230,7 +7259,7 @@ msgstr ""
 
 #: ../extras/two-factor-authentication/security-keys-setup.rst:24
 msgid ""
-"Next, depending you your browser, you will be presented with different "
+"Next, depending on your browser, you will be presented with different "
 "options. Select one that refers to your chosen security key and follow the "
 "instructions on the screen."
 msgstr ""
@@ -7650,6 +7679,10 @@ msgid ""
 "also :docs:`system </index.html>` and :admin-docs:`administration manuals </"
 "index.html>` available."
 msgstr ""
+
+#, fuzzy
+#~ msgid "**Linked Tickets**"
+#~ msgstr "宏"
 
 #, fuzzy
 #~ msgid "Split ticket button"


### PR DESCRIPTION
Translations update from [Zammad-Translations](https://translations.zammad.org) for [Documentation/User Documentation (pre-release)](https://translations.zammad.org/projects/documentations/user-documentation-pre-release/).



Current translation status:

![Weblate translation status](https://translations.zammad.org/widget/documentations/user-documentation-pre-release/horizontal-auto.svg)