### PR TITLE
Translations update from Zammad-Translations

### DIFF
--- a/locale/de/LC_MESSAGES/user-docs.po
+++ b/locale/de/LC_MESSAGES/user-docs.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Zammad (for Agents)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2026-07-10 15:28+0200\n"
-"PO-Revision-Date: 2026-07-11 05:07+0000\n"
+"PO-Revision-Date: 2026-07-14 10:10+0000\n"
 "Last-Translator: Ralf Schmid <rsc@zammad.com>\n"
 "Language-Team: German <https://translations.zammad.org/projects/"
 "documentations/user-documentation-pre-release/de/>\n"
@@ -7548,8 +7548,6 @@ msgid "Different link types"
 msgstr "Verschiedene Link-Typen"
 
 #: ../extras/knowledge-base.rst:184
-#, fuzzy
-#| msgid "Web link"
 msgid "Weblink"
 msgstr "Link"
 
@@ -7599,10 +7597,8 @@ msgstr ""
 "Videodienste wird im Videodialogfeld unterhalb des URL-Feldes angezeigt."
 
 #: ../extras/knowledge-base.rst:203
-#, fuzzy
-#| msgid "Create Tickets"
 msgid "Related Tickets"
-msgstr "Tickets erstellen"
+msgstr "Verwandte Tickets"
 
 #: ../extras/knowledge-base.rst:202
 msgid ""


### PR DESCRIPTION
Translations update from [Zammad-Translations](https://translations.zammad.org) for [Documentation/User Documentation (pre-release)](https://translations.zammad.org/projects/documentations/user-documentation-pre-release/).



Current translation status:

![Weblate translation status](https://translations.zammad.org/widget/documentations/user-documentation-pre-release/horizontal-auto.svg)