### PR TITLE
Maintenance: Document how long read notifications are kept

### DIFF
--- a/extras/user-menu-profile-settings.rst
+++ b/extras/user-menu-profile-settings.rst
@@ -114,6 +114,17 @@ account.
          Use the first four columns to choose when to receive **internal
          notifications**. The right column enables email notification as well.
 
+      .. note::
+         Notifications you have already read are removed from the list
+         automatically. Ones you marked as read yourself disappear after about
+         ten minutes. Ones Zammad marked as read for you - which happens when
+         someone else changes the state of the ticket the notification belongs
+         to - remain for about eight hours. Independently of this, no
+         notification is kept for longer than nine months.
+
+         The clean-up runs every two hours, so a notification can stay visible
+         somewhat longer than the times given above.
+
    Limit Groups
       .. figure:: /images/extras/user-menu-profile-settings/profile-and-settings-notifications-limit-groups.png
          :align: center

--- a/locale/user-docs.pot
+++ b/locale/user-docs.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Zammad User Documentation pre-release\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-11 08:23+0200\n"
+"POT-Creation-Date: 2026-08-17 14:57+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -2933,7 +2933,7 @@ msgstr ""
 #: ../basics/zammad-glossary.rst:489
 #: ../extras/mobile-view.rst:85
 #: ../extras/user-menu-profile-settings.rst:0
-#: ../extras/user-menu-profile-settings.rst:115
+#: ../extras/user-menu-profile-settings.rst:126
 msgid "Notifications"
 msgstr ""
 
@@ -5814,23 +5814,31 @@ msgstr ""
 msgid "Use the first four columns to choose when to receive **internal notifications**. The right column enables email notification as well."
 msgstr ""
 
-#: ../extras/user-menu-profile-settings.rst:134
+#: ../extras/user-menu-profile-settings.rst:118
+msgid "Notifications you have already read are removed from the list automatically. Ones you marked as read yourself disappear after about ten minutes. Ones Zammad marked as read for you - which happens when someone else changes the state of the ticket the notification belongs to - remain for about eight hours. Independently of this, no notification is kept for longer than nine months."
+msgstr ""
+
+#: ../extras/user-menu-profile-settings.rst:125
+msgid "The clean-up runs every two hours, so a notification can stay visible somewhat longer than the times given above."
+msgstr ""
+
+#: ../extras/user-menu-profile-settings.rst:145
 msgid "Limit Groups"
 msgstr ""
 
-#: ../extras/user-menu-profile-settings.rst:121
+#: ../extras/user-menu-profile-settings.rst:132
 msgid "By default, you will receive notifications for all tickets in every group you belong to - even for tickets that are assigned to other agents. Use the **Limit Groups** switch and settings below it to disable such notifications on a per-group basis. You will continue to receive notifications for your own tickets."
 msgstr ""
 
-#: ../extras/user-menu-profile-settings.rst:127
+#: ../extras/user-menu-profile-settings.rst:138
 msgid "If you turn on **Limit Groups** feature, but disable the notifications from all groups, you may receive the following warning."
 msgstr ""
 
-#: ../extras/user-menu-profile-settings.rst:133
+#: ../extras/user-menu-profile-settings.rst:144
 msgid "In this case, saving your settings will implicitly turn off **Limit Groups** feature, since no limits will be left in effect."
 msgstr ""
 
-#: ../extras/user-menu-profile-settings.rst:136
+#: ../extras/user-menu-profile-settings.rst:147
 msgid "The contents of these email notifications can be customized on self-hosted installations. Administrators can learn more in the :admin-docs:`system notification configuration </misc/system-notifications.html>`."
 msgstr ""
 
@@ -5838,27 +5846,27 @@ msgstr ""
 msgid "Out of Office"
 msgstr ""
 
-#: ../extras/user-menu-profile-settings.rst:143
+#: ../extras/user-menu-profile-settings.rst:154
 msgid "Schedule absence periods in advance, and designate a substitute to handle your tickets while you're gone."
 msgstr ""
 
-#: ../extras/user-menu-profile-settings.rst:146
+#: ../extras/user-menu-profile-settings.rst:157
 msgid "Your substitute will receive all your ticket notifications during your absence, and have a custom :ref:`overview <overviews>` created to help keep track of your tickets. You will receive notifications while you are absent."
 msgstr ""
 
-#: ../extras/user-menu-profile-settings.rst:151
+#: ../extras/user-menu-profile-settings.rst:162
 msgid "Tired of the overview order your admin decided on? This section allows you to choose an overview order that fits you the best."
 msgstr ""
 
-#: ../extras/user-menu-profile-settings.rst:154
+#: ../extras/user-menu-profile-settings.rst:165
 msgid "You can revert to the default instance ordering at any time by using the upper right button ``Reset overview order``."
 msgstr ""
 
-#: ../extras/user-menu-profile-settings.rst:159
+#: ../extras/user-menu-profile-settings.rst:170
 msgid "This option is only visible to agents by default. It can be completely deactivated by your admin."
 msgstr ""
 
-#: ../extras/user-menu-profile-settings.rst:162
+#: ../extras/user-menu-profile-settings.rst:173
 msgid "If it is activated, the order does not change, even if your admin renames or reorders the overviews. The overview order is stored in your profile and thus applies to any device you use with your account."
 msgstr ""
 
@@ -5870,7 +5878,7 @@ msgstr ""
 msgid "Calendar"
 msgstr ""
 
-#: ../extras/user-menu-profile-settings.rst:172
+#: ../extras/user-menu-profile-settings.rst:183
 msgid "Add your ticket deadlines to your own favorite calendar app with the iCal link listed on this page."
 msgstr ""
 
@@ -5878,7 +5886,7 @@ msgstr ""
 msgid "Devices"
 msgstr ""
 
-#: ../extras/user-menu-profile-settings.rst:177
+#: ../extras/user-menu-profile-settings.rst:188
 msgid "See a list of all devices logged into your Zammad account (and revoke access, if necessary)."
 msgstr ""
 
@@ -5886,11 +5894,11 @@ msgstr ""
 msgid "Token Access"
 msgstr ""
 
-#: ../extras/user-menu-profile-settings.rst:182
+#: ../extras/user-menu-profile-settings.rst:193
 msgid "Generate personal access tokens for third party applications to use the Zammad API."
 msgstr ""
 
-#: ../extras/user-menu-profile-settings.rst:186
+#: ../extras/user-menu-profile-settings.rst:197
 msgid "Always generate a new token for each application you connect to Zammad! This makes it possible to revoke access for individual applications if a token is ever compromised."
 msgstr ""
 
@@ -5898,7 +5906,7 @@ msgstr ""
 msgid "Linked Accounts"
 msgstr ""
 
-#: ../extras/user-menu-profile-settings.rst:192
+#: ../extras/user-menu-profile-settings.rst:203
 msgid "See a list of third party services (e.g. Facebook or Google) linked to your Zammad account."
 msgstr ""
 


### PR DESCRIPTION
Zammad removes read online notifications from the notification list on its own,
but this is not documented anywhere — neither in the user documentation, nor in
Privacy & Data Retention, nor on the scheduler page. Agents therefore see
notifications disappear without an explanation, and there is nothing to point
them to.

This adds a short note to the *Notifications* section of *User Menu & Profile
Settings*.

**What the note says, and where the numbers come from:**

| Behaviour | Source |
|---|---|
| Read by the agent themselves: ~10 minutes | `max_own_seen = 10.minutes.ago` |
| Marked read by Zammad: ~8 hours | `max_auto_seen = 8.hours.ago` |
| Anything older: 9 months | `max_age = 9.months.ago` |
| Clean-up interval: 2 hours | scheduler seed, `period: 2.hours` |

* `app/models/online_notification.rb` — `OnlineNotification.cleanup`, including
  the condition that separates the two periods:
  `(user_id = updated_by_id AND updated_at < :max_own_seen) OR (user_id != updated_by_id AND updated_at < :max_auto_seen)`
* `db/seeds/schedulers.rb` — *Delete old online notification entries.*
* `app/models/ticket/sets_online_notification_seen.rb` and
  `app/jobs/ticket_online_notification_seen_job.rb` — the automatic path, which
  applies when another user changes the ticket's state.

The wording deliberately says "about ten minutes" and "about eight hours"
because the clean-up job runs every two hours, so the exact moment a
notification vanishes varies.

**Notes for review**

* The values are identical in 7.1 and in the current development branch.
* Behaviour was verified against a running 7.2 instance, not only read from the
  source: notifications aged 11 minutes (own) and 9 hours (automatic) were
  removed by `OnlineNotification.cleanup`, while 5 minutes, 11 minutes
  (automatic) and 7 hours survived.
* `make gettext` was run; `locale/user-docs.pot` is updated accordingly.
* No translation files are touched — those come from Weblate.
* `rstcheck` reports the same five pre-existing role warnings before and after
  this change and nothing new; `make html` builds without warnings for this
  page.